### PR TITLE
feat(#5): opposed rolls, helping, and group roll mechanics

### DIFF
--- a/docs/chapters/04-core-mechanics.adoc
+++ b/docs/chapters/04-core-mechanics.adoc
@@ -35,3 +35,153 @@ However, pushing represents the character exerting maximum physical, mental, or 
 * *You cannot push a roll if you already have a −1 penalty to the associated Attribute.* This prevents players from continuously "farming" resources on safe rolls.
 
 The analog nature of 1980s technology perfectly complements this mechanical attrition. Pushing a gear-assisted roll might degrade the item — short-circuiting alkaline batteries or jamming mechanisms — effectively reducing its inherent bonus until it can be repaired during downtime.
+
+---
+
+== Opposed Rolls
+
+When two characters are directly working against each other — a guard watching for intruders while an agent tries to slip past, a witness resisting an interrogation, two agents in a grapple — a *standard roll is not sufficient*. Both sides have active stakes in the outcome. Use an *Opposed Roll*.
+
+=== Procedure
+
+. Both characters construct their dice pools normally (Attribute + Skill + Gear).
+. Both roll simultaneously.
+. Count the number of *6s* each side rolled — these are their *successes*.
+. The side with more successes wins.
+
+=== Tie-Breaking
+
+> **Design Decision:** In Neon Relic, ties are resolved *in favor of the active party* — the character initiating the action. +
+> +
+> **Rationale:** Neon Relic is an action-and-investigation game. Agents are protagonists taking risks. A tie should reward decisive action rather than passive defense. The threat of failure is already baked into the Resonance cost of pushing — we don't need the additional drag of defender-wins ties slowing down forward momentum. This differs from _Vaesen_ (defender wins) and aligns more closely with the feel of _Alien RPG_.
+
+If both sides roll zero successes, the outcome is *no change* — the situation remains unresolved, and the GM should advance the fiction in a direction that applies pressure (the confrontation escalates, time runs out, a third party notices, etc.). The acting character does *not* gain Resonance from a zero-zero tie.
+
+=== Common Opposed Pairings
+
+The following pairings arise most frequently in play. Either side may push their roll as normal, gaining 1 Resonance.
+
+[%header,cols="2,2,3"]
+|===
+| Active Roll | Opposing Roll | Situation
+
+| Sneak (AGI) | Investigate (WIT) | Agent moves silently past a watchful guard or suspicious bystander
+| Manipulate (EMP) | Psychoanalyze (EMP) | Convincing a witness — the target is actively trying to spot the lie
+| Command (EMP) | Manipulate (EMP) | Asserting authority vs. someone talking their way out from under it
+| Force (STR) | Endure (STR) | Trying to physically overpower or restrain another character
+| Brawl (STR) | Brawl (STR) | Contested grapple, disarm, or shove
+| Sleight of Hand (AGI) | Investigate (WIT) | Planting or pocketing an item without being noticed
+| Sneak (AGI) | Investigate (WIT) | Tailing a target without being made
+| Tech (WIT) | Tech (WIT) | Counter-hacking: both parties on the same BBS or mainframe simultaneously
+|===
+
+> *Mismatched skills are allowed.* If a situation calls for it, the GM may permit any logical pairing. The table above is guidance, not a hard constraint.
+
+=== Pushed Opposed Rolls
+
+Either or both sides may push their roll (gaining 1 Resonance each). Pushes are declared *before* comparing results. If both sides push and the result is still a tie, the active party wins as normal.
+
+*You may not push an opposed roll if you already have a −1 penalty to the relevant Attribute.*
+
+---
+
+== Helping
+
+Agents operating as a team can be more effective than any individual. When one agent attempts a roll and an ally is present and capable, that ally may *help*.
+
+=== Who May Help
+
+An ally may help if **both** of the following are true:
+
+* They are present in the scene (Engaged or Close range — same room, same vehicle, actively coordinating).
+* They have a *rating of at least 1* in the relevant skill, **or** they can provide a plausible narrative justification for how their own skill set contributes (GM approval).
+
+=== The Helping Bonus
+
+* Each helper adds *+1 die* to the active character's dice pool.
+* A maximum of *2 helpers* may assist on any single roll.
+* The helping dice are *Skill Dice* (green) — they can produce successes but are not pushed separately.
+
+> **Maximum pool size:** With 2 helpers, a character's pool can be up to +2 dice above their normal maximum. This represents peak team coordination — beyond this, too many cooks.
+
+=== Helping and Resonance
+
+* If the active character *pushes* the roll, helpers are *not* penalized — they lent their dice to the initial roll, not the push.
+* If a helper's contributed die shows a *1 on the initial (pre-push) roll*, the active character still gains those dice for the push (1s on initial rolls only matter for gear degradation, not helpers).
+* Helpers do *not* gain Resonance when the active character pushes.
+
+=== Helping in Combat
+
+Helping during combat requires a *slow action* from the helper. A helper who assists a slow action during a combat round cannot take any other slow action that round.
+
+---
+
+== Group Rolls
+
+Some situations call for the *entire team to attempt the same action simultaneously* — crossing a dark chasm, navigating a treacherous building undetected before the guards change, deciphering a large number of documents before the contact leaves.
+
+=== Procedure
+
+. Each character rolls their individual dice pool for the relevant skill.
+. Count how many characters *succeed* (rolled at least one 6).
+. Compare against the *Group Success Threshold* set by the GM:
+
+[%header,cols="1,3"]
+|===
+| Threshold | When to Use
+
+| *All succeed* | The action requires total team performance — a single failure has consequences (e.g., stealth approach; one noise ruins it for everyone)
+| *Majority succeed* | Most of the team needs to make it (e.g., climbing a fence before a gate locks)
+| *At least one succeeds* | The team needs one person to pull it off; others can assist if needed
+|===
+
+=== Group Roll Failure
+
+If the group fails to meet the threshold:
+
+* The GM applies consequences to *all who failed*, not as individual failures but as a shared narrative setback.
+* Individual characters who succeeded are not penalized — they did their part.
+* Characters who failed *may push* as normal (gaining 1 Resonance each), independently.
+
+> **Group rolls and Resonance:** Each character manages their own Resonance on a group roll independently. A group roll gone wrong — four agents all pushing, all gaining 1 Resonance — creates the kind of compounding pressure that makes the Corruption system matter.
+
+---
+
+== Worked Examples
+
+=== Opposed Roll: The Tail Job
+
+*Situation:* Agent Petra Vasquez (Recovery) is tailing a suspected Compact operative through a crowded airport. The operative gets a feeling he's being watched and starts scanning the crowd.
+
+* **Petra rolls:** Sneak (AGI 4 + Sneak 3) = 7 dice. Rolls: 6, 5, 3, 3, 2, 1, 1 → *1 success*.
+* **Operative rolls:** Investigate (WIT 3 + Investigate 2) = 5 dice. Rolls: 4, 4, 3, 2, 1 → *0 successes*.
+* **Result:** Petra wins — she stays undetected and follows him to his contact.
+
+If Petra had rolled 0 successes and the operative also rolled 0, the tail continues but something shifts — maybe Petra loses him in the crowd, or the operative ducks into a bathroom and the GM advances the clock.
+
+=== Opposed Roll with Push: The Interrogation
+
+*Situation:* Wayfinder Agent Reyes is interrogating a frightened historian who knows where the artifact is. The historian desperately doesn't want to cooperate.
+
+* **Reyes rolls:** Manipulate (EMP 4 + Manipulate 2) = 6 dice. Rolls: 5, 4, 4, 3, 2, 1 → *0 successes*.
+* Reyes decides to *push* (gains 1 Resonance, now at 2). Re-rolls all 5 non-6 dice: 6, 6, 3, 2, 1 → *2 successes*.
+* **Historian rolls:** Psychoanalyze (EMP 3 + Psychoanalyze 1) = 4 dice. Rolls: 6, 4, 3, 2 → *1 success*.
+* **Result:** Reyes wins (2 vs 1). The historian cracks. The extra success can be spent on a stunt — perhaps he volunteers more than just the location.
+
+=== Helping: Cracking a Locked File Cabinet
+
+*Situation:* Stack agent Kowalski is picking a government-grade lock. Sleight of Hand 2 (AGI 3 + skill 2 = 5 dice). Keep agent Osei has Sleight of Hand 1 and offers to hold the flashlight steady and narrate the tumblers. GM approves.
+
+* Osei adds +1 die. Kowalski rolls *6 dice* total instead of 5.
+* Result: 6, 6, 5, 3, 2, 1 → 2 successes. The lock opens, and the extra success means it opens fast — no time lost.
+
+=== Group Roll: The Silent Entry
+
+*Situation:* Four agents must all enter a research facility quietly before a guard completes his patrol. GM sets threshold: *all succeed* (failure means the guard hears movement).
+
+* Petra (Sneak 3, AGI 4): 7 dice → 6, 4, 3, 2, 1, 1, 1 → *1 success* ✓
+* Reyes (Sneak 1, AGI 2): 3 dice → 5, 4, 2 → *0 successes* ✗
+* Osei (Sneak 0, EMP 3): 3 attribute dice → 6, 3, 1 → *1 success* ✓
+* Kowalski (Sneak 2, AGI 4): 6 dice → 6, 6, 3, 2, 1, 1 → *2 successes* ✓
+
+Reyes failed. Threshold not met. The GM rules the guard hears something from Reyes' direction and starts to turn. *Reyes pushes* (gains 1 Resonance): re-rolls 3 dice → 6, 4, 2 → *1 success*. The group just barely makes it — but Reyes is now at 1 Resonance and the tension meter has ticked up.


### PR DESCRIPTION
Closes #5

Adds three new sections to \docs/chapters/04-core-mechanics.adoc\:

## Opposed Rolls
- Full procedure: both sides roll, most 6s wins
- **Tie-breaking decision: active party wins** (rationale documented inline — rewards protagonism over passive defense, aligns with Alien RPG feel rather than Vaesen)
- Zero-zero tie: no change, GM advances fiction with pressure
- Common NR opposed pairings table (8 examples covering investigation, social, physical)
- Pushed opposed rolls: each side manages independently

## Helping
- +1 die per helper, max 2 helpers
- Requires skill >= 1 or GM-approved narrative justification
- Helpers don't gain Resonance when active character pushes
- In combat: helping costs a slow action from the helper

## Group Rolls
- Three threshold types: all succeed / majority / at least one
- Failure applies shared narrative consequence; individuals push independently
- Note on Resonance compounding across the group

## Worked Examples
Four fully narrated examples: tail job (opposed), interrogation with push (opposed+push), file cabinet (helping), silent building entry (group roll with push)