### PR TITLE
feat(#6): Fear and Terror mechanics

### DIFF
--- a/docs/chapters/07-resonance-corruption.adoc
+++ b/docs/chapters/07-resonance-corruption.adoc
@@ -45,3 +45,127 @@ This creates a terrifying escalation. If a character pushes multiple rolls and h
 | *13–14* | Fugue States | A nearby entity or latent force begins seizing control of the character's motor functions. Lost time and memory gaps.
 | *Exceeds Threshold* | *Catatonic Revelation* | The character's mind completely breaks upon perceiving the underlying, terrifying geometry of the universe. Permanent catatonic state. *Immediately removed from the campaign.*
 |===
+
+---
+
+== Fear Mechanics
+
+The Corruption track governs the long arc of psychological decay. *Fear* governs the acute, in-the-moment terror of direct supernatural confrontation — the thing that happens to your body and your mind in the next thirty seconds when the entity looks at you.
+
+Fear and Corruption are linked: failed Fear checks generate Resonance, and Resonance amplifies Corruption checks. A single terrifying encounter can compress weeks of accumulated pressure into one scene.
+
+=== What Triggers a Fear Check
+
+The GM calls for a Fear check when a character directly confronts a source of genuine supernatural horror. Not everything unusual triggers one — strange sounds, unusual smells, or reading an old text do not. A Fear check requires *direct sensory confrontation* with something that violates the natural order.
+
+[%header,cols="2,4"]
+|===
+| Trigger | Examples
+
+| *Encountering a supernatural entity* | Seeing a bound entity, a possessed human, or a manifestation for the first time this scene
+| *Artifact activation failure* | An artifact the character is handling detonates, tears reality, or emits a vision that cannot be explained
+| *Witnessing violent supernatural death* | An ally or bystander is killed or consumed by occult means in front of the character
+| *Occult revelation* | Irrefutable proof of something the human mind cannot accommodate — a genuine miracle, a impossible geometry, a speaking dead
+| *Sustained entity presence* | For each *additional round* a character remains within Engaged range of an active, hostile entity (after the initial check)
+|===
+
+> *One check per trigger:* If the same entity is already known to the character from a prior session and has been observed before, no new Fear check is required merely for seeing it again — only for new escalations (it doing something new, getting closer, attacking).
+
+=== The Fear Check Procedure
+
+. *The GM states the entity's Fear Rating* (a number from 1 to 5) or notes that the event is a flat Fear 2 or Fear 3 trigger (see Fear Rating table below).
+. *The character rolls Wits dice* equal to their current *Wits attribute* (no skill modifier — Fear is instinctual, not trained).
+. *Count failures:* For every die that shows a *1*, the character takes *1 point of Wits damage* AND gains *1 Resonance point*.
+. *Count the Fear Rating as a threshold:* If the total number of non-6 dice equals or exceeds the Fear Rating, the character is *Shaken* (see below) even if they took no Wits damage.
+
+> *Why Wits?* Fear strikes the rational, pattern-recognizing mind first. The brain tries to *explain* what the eyes are seeing — and fails. Empathy governs emotional horror (grief, bargaining, despair); that comes later, through the Corruption track.
+
+> *Why 1s specifically?* In the YZE framework, 1s on Attribute dice represent self-harm — the cost of pushing your own limits. On a Fear check, 1s represent the moment the mind cracks trying to process the unprocessable. This is cognitively consistent with the push mechanic.
+
+=== Fear Ratings
+
+[%header,cols="1,1,4"]
+|===
+| Rating | Threat Level | Examples
+
+| *1* | Unsettling | A shadow that moves wrong. A sound that shouldn't exist. A photograph with an extra figure.
+| *2* | Disturbing | A possessed civilian. A minor entity (shadow-form, bound spirit). A fresh, inexplicably ritualistic death scene.
+| *3* | Horrifying | A mid-tier entity fully manifested. An artifact consuming a living person. A Covenant vault breach in progress.
+| *4* | Shattering | A major entity (ancient, named, deliberate). An artifact performing an impossible act of scale (restructuring a room, erasing a person).
+| *5* | Annihilating | A Class-5 entity. A tear in physical space. Direct contact with whatever the artifacts are *for*.
+|===
+
+Fear Ratings are a property of supernatural *entities* and *events*, not of individual characters. Add the Fear Rating stat to entity stat blocks in the Bestiary (`docs/chapters/17-bestiary.adoc`).
+
+=== Shaken
+
+A character who rolls a Fear check and has *more non-6 results than successes* (i.e., the roll mostly failed) is *Shaken* for the remainder of the scene, even if they took no Wits damage.
+
+*Shaken effects:*
+
+* *−1 die* on all Wits and Empathy rolls for the rest of the scene.
+* Cannot voluntarily move toward the source of Fear (they can hold position or retreat).
+* Can be *snapped out of it* by an ally spending a slow action and succeeding on a Psychoanalyze roll (difficulty: Fear Rating of the trigger).
+
+Shaken is not a condition that persists between scenes — it represents immediate shock, not lasting damage. Lasting damage is Wits loss and Resonance gain.
+
+=== Resonance Generation from Fear
+
+Each point of Wits damage taken from a Fear check generates *1 Resonance point*. This is cumulative with any Resonance gained from pushing rolls in the same scene.
+
+> *Design Note:* This is the Resonance-Fear link that makes supernatural encounters mechanically distinct from physical combat. A fistfight reduces Strength. A Fear check reduces Wits *and* raises Resonance — which raises the Corruption check multiplier — which narrows your Corruption threshold. The more frightened you are, the closer to the edge you slide. This is the intended spiral.
+
+=== Pushing a Fear Check
+
+A character *may not push a Fear check.* Fear is involuntary. There is no "trying harder" against the absolute horror of the unnatural. The only mitigation available is mechanical resistance (see below).
+
+=== Resisting and Reducing Fear
+
+Several mechanics interact with Fear:
+
+[%header,cols="2,3"]
+|===
+| Mechanic | Effect on Fear
+
+| *Academic Grounding* (Wayfinder Talent) | After 1 hour of research on a specific entity type, reduce its effective Fear Rating by 1 (min 1) for the rest of the session for the Wayfinder only.
+| *The Confessor* (Keep Talent) | After using this talent to clear Resonance, the next Fear check this session is made with *+2 bonus dice*.
+| *Anchor (Memento)* | Using an Anchor during downtime has no direct Fear resistance — but clearing Resonance before an encounter lowers the Corruption cascade from a failed check.
+| *Empathy attribute* | Empathy does not reduce Fear checks directly, but it sets the Max Corruption Threshold — a high-Empathy character can sustain more Resonance before the cascade becomes lethal.
+| *Familiarity* | If a character has *previously survived a Fear check* against the same entity type without breaking, future checks against the same type are made with *+1 bonus die*. Familiarity is per entity type, not per individual entity.
+|===
+
+=== The Panic Table (Wits Broken)
+
+If a Fear check reduces a character's Wits to *0*, they are *Broken* — and the mind's last-resort survival responses take over. Roll *1d6* on the following table. The GM describes what the character does for the remainder of the current round. The player regains narrative control at the start of the next round, but the character is Shaken and cannot act on their first available action.
+
+[%header,cols="^1,2,4"]
+|===
+| Roll | Response | What Happens
+
+| *1* | *Fight* | The character attacks the nearest living creature — ally or enemy, whichever is closest — with their bare hands. They cannot use weapons or gear this round.
+| *2* | *Flight* | The character runs at full speed in the direction *away from the source of Fear* until they are out of sight of it or hit an obstacle. They drop whatever they are holding.
+| *3* | *Freeze* | The character is utterly paralyzed. They cannot move, speak, or take any action. They may be moved by allies (costs a slow action). Hostile entities may act against them freely.
+| *4* | *Denial* | The character's mind refuses to process the supernatural event. They treat it as mundane for the rest of the scene — narrating it in completely ordinary terms to other characters ("That's obviously just a guy in a costume. The blood is stage blood."). They cannot take any action that acknowledges the entity as real.
+| *5* | *Compulsion* | The character becomes locked in a repetitive behavior — counting ceiling tiles, repeating a phrase, sorting objects, reloading a weapon over and over. They can move (slowly) but cannot take any meaningful action until an ally snaps them out with a Psychoanalyze roll (Difficulty 2).
+| *6* | *Fugue* | The player hands the GM their character sheet. The GM narrates what the character does for the rest of the scene. This may include wandering, speaking to things that aren't there, or following the entity. The player regains control at the *start of the next scene*, not the next round.
+|===
+
+> *Recovering from Broken (Wits 0):* After the scene ends, the character's Wits return to 1 automatically — they are no longer Broken but they are severely shaken. Full Wits recovery follows normal healing rules. A character Broken by Fear also triggers a *Corruption Check* immediately when the scene ends (not during — there's no moment for reflection mid-crisis).
+
+=== Fear vs. Standard Wits Damage
+
+A direct psychic assault from an entity, an artifact feedback, or a targeted supernatural ability may also reduce Wits — but that is *not a Fear check*. The distinction matters:
+
+[%header,cols="2,2,2"]
+|===
+| | *Fear Check* | *Direct Wits Damage*
+
+| *Trigger* | Sensory confrontation with supernatural horror | Targeted attack or artifact effect
+| *Mechanism* | Roll Wits dice; 1s deal damage + Resonance | Damage is applied directly (no roll, or attacker rolls)
+| *Resonance generated?* | *Yes* — 1 per Wits damage | *No* — unless the character chooses to push a resistance roll
+| *Shaken?* | Possibly (roll-dependent) | No (unless effect says so)
+| *Pushable?* | *No* | Yes (standard push rules)
+| *Panic table?* | Yes, if Wits reaches 0 | Yes, if Wits reaches 0 (same table)
+|===
+
+> The key difference is *Resonance generation*. A possessed agent using a mental attack is doing tactical damage. Standing in the presence of something that should not exist and having your mind try to process it is existentially corrosive in a way combat is not.


### PR DESCRIPTION
Closes #6

Adds a full Fear Mechanics section to \docs/chapters/07-resonance-corruption.adoc\.

## What's included
- **Fear check triggers** — 5 trigger categories with examples (entity encounter, artifact failure, supernatural death, occult revelation, sustained proximity)
- **Fear check procedure** — roll Wits dice; 1s deal Wits damage AND generate 1 Resonance each
- **Fear Ratings 1–5** — stat for supernatural entities (Unsettling → Annihilating); integrated into Bestiary stat blocks (#16)
- **Shaken condition** — −1 die on Wits/Empathy for the scene; snapped out by ally Psychoanalyze roll
- **Resonance spiral** — the Fear→Resonance→Corruption cascade is the core design, documented with rationale
- **Fear checks cannot be pushed** — design decision with rationale
- **Fear resistance** — Academic Grounding (Wayfinder), The Confessor (Keep), Familiarity (+1 bonus die)
- **d6 Panic table** — Fight / Flight / Freeze / Denial / Compulsion / Fugue; tone-appropriate for 1980s occult horror
- **Fear vs. direct Wits damage** — comparison table clarifying the mechanical distinction (Resonance generation is the key)