### PR TITLE
feat(#3): add full combat rules chapter

### DIFF
--- a/docs/chapters/03b-combat.adoc
+++ b/docs/chapters/03b-combat.adoc
@@ -1,0 +1,327 @@
+= Combat
+
+Combat in Neon Relic is fast, brutal, and consequential. Agents of the Covenant are capable individuals — but they are not soldiers. A prolonged firefight drains attributes that also serve as their sanity and stamina. Every round of violence is a resource you cannot easily recover before the next case.
+
+Combat rules are designed for *investigation-first play*: most situations should be solvable without combat, combat should resolve quickly when it happens, and the aftermath (injury, Resonance, gear degradation) should matter as much as the outcome.
+
+---
+
+== Initiative
+
+At the start of any hostile confrontation, each participant draws an *Initiative Card* from a standard deck of playing cards (Ace through 10, face cards removed or kept — GM preference). Higher card value acts first. Ties are resolved simultaneously.
+
+=== Initiative Card Draw
+
+* Each participant — PC or NPC — draws one card from a shuffled deck.
+* Participants act in *descending card order* (10 acts before 9, etc.).
+* *Aces are low* (value 1) — drawing an Ace means you act last.
+* Cards are discarded after the round. Reshuffle and redraw at the start of each new round.
+
+> *Why cards?* The card draw creates genuine unpredictability without arithmetic. It also creates a sense of narrative suspense — drawing a 10 is a small victory; drawing an Ace before a firefight is quietly dreadful. In an investigation game where combat is exceptional, this ceremony matters.
+
+=== Initiative Modifiers
+
+* *High Ground / Cover:* +2 to card value (draw, add 2; max 10).
+* *Prone or Recovering:* −2 to card value.
+* *Surprised:* Surprised characters draw *two cards* and keep the lower; they also cannot take a Fast Action on their first turn.
+* *Ambush:* The ambushing side acts a full round before the ambushed side draws any cards. See Surprise below.
+
+=== Surprise and Ambush
+
+A *surprise* occurs when one side is unaware of the other at the moment combat begins.
+
+* To attempt an ambush, the attacking side must succeed on a *Sneak (AGI)* roll opposed by the target's *Investigate (WIT)*. Use group roll rules if multiple ambushers are involved.
+* If the ambush succeeds: the ambushing side takes a *free full round of actions* before initiative cards are drawn for anyone.
+* If the ambush fails: draw initiative normally; no advantage granted.
+
+---
+
+== Action Economy
+
+Each character's turn consists of *one Slow Action* and *one Fast Action*, plus any number of *Free Actions*.
+
+=== Slow Actions
+
+A slow action represents a committed, focused effort requiring your full attention.
+
+[%header,cols="2,4"]
+|===
+| Slow Action | Description
+
+| *Attack (melee or ranged)* | Roll to hit and deal damage. Core offensive action.
+| *First Aid* | Use Heal skill to restore Strength or treat a Critical Injury (requires a First Aid Kit).
+| *Reload* | Reload a firearm that has run dry. No roll required; consumes ammo.
+| *Use an Artifact* | Activate an artifact's properties. Generates Resonance per artifact tier.
+| *Activate Division Talent* | Use your Division Talent (if it requires sustained effort).
+| *Manipulate NPC* | Attempt to talk someone down, issue commands, or negotiate during combat.
+| *Help an Ally* | Add +1 die to an ally's next roll this round (must be present, skill >= 1).
+| *Barricade / Fortify* | Use Force to move heavy objects for cover or block a doorway.
+| *Treat Broken Ally* | Stabilize a Broken ally so they do not die (requires Heal roll).
+|===
+
+=== Fast Actions
+
+A fast action is a quick, reactive, or secondary effort.
+
+[%header,cols="2,4"]
+|===
+| Fast Action | Description
+
+| *Move one zone* | Move from your current zone to an adjacent zone.
+| *Draw or holster a weapon* | Ready a weapon you are carrying. Holstering allows you to pick up something else.
+| *Take cover* | Move into cover within your current zone (+2 Armor Rating bonus, see Cover rules).
+| *Stand up* | Rise from prone or from a knocked-down state.
+| *Grab / pick up an item* | Retrieve a dropped item or item at Engaged range.
+| *Dodge* | Reactive. See Reactive Actions below.
+| *Use a quick item* | Apply a stim, crack a light stick, or use a single-use item.
+|===
+
+=== Free Actions
+
+Free actions can be taken at any point during your turn, in any number.
+
+* Speak briefly (one sentence or a shout)
+* Drop a held item
+* Look around / assess the situation (no roll)
+* Toggle a device that is already in hand (safety off, flashlight switch)
+
+---
+
+== Zones and Range
+
+Combat space is divided into *abstract zones* rather than measured distances. A zone is any coherent area of space — a room, a corridor, an alley, a rooftop section. The GM defines zones when establishing a scene.
+
+=== Zone Size and Movement
+
+Moving *one zone* costs one Fast Action. Moving *two zones* (running) costs both your Fast Action and your Slow Action for the round — you forgo your attack.
+
+[%header,cols="1,3"]
+|===
+| Range Category | Definition
+
+| *Engaged* | Same zone; within arm's reach. Required for melee. Most melee weapons can only be used at Engaged range.
+| *Near* | Same or immediately adjacent zone. Close pistol range; thrown weapons; point-blank shotgun.
+| *Short* | 1–2 zones. Standard pistol and shotgun range; melee not possible.
+| *Long* | 3–4 zones. Rifle range; pistols at −1 die penalty.
+| *Distant* | 5+ zones. Sniper range. Only applies to designated long-range weapons; everything else is out of range.
+|===
+
+=== Zone Features
+
+Every zone has optional *terrain features* the GM can invoke:
+
+[%header,cols="2,4"]
+|===
+| Feature | Mechanical Effect
+
+| *Cramped* (closets, crawlspaces, car interiors) | Long-armed weapons (rifles, shotguns) suffer −2 dice. All movement into/out of zone takes a Slow Action.
+| *Rough* (rubble, debris, slick floor) | Moving into this zone requires a Fast Action *and* an Agility roll (Difficulty 1). On failure, character is prone.
+| *Dark* | All Investigate, Firearms, and ranged attack rolls lose half their dice (round down) unless the character has a light source. Sneak rolls gain +2 dice.
+| *Open* (parking lots, fields) | No cover available in this zone. All ranged attacks against targets here gain +1 die.
+| *Elevated* | Characters here gain +2 to their Initiative card value; ranged attacks against them suffer −1 die.
+|===
+
+---
+
+== Melee Combat
+
+=== Basic Melee Attack
+
+Declare your target (must be at Engaged range). Roll your dice pool:
+
+* *Heavy melee* (knife, crowbar, brawl against an armored target): *Force (STR)* + Weapon Gear Bonus
+* *Fast melee* (unarmed strikes, quick knife work): *Brawl (STR)* + Weapon Gear Bonus
+
+On a hit (at least one 6), deal the weapon's flat *Damage* value directly to the target's Strength. Armor intercepts first.
+
+Extra successes (additional 6s) are *Stunt Points* — see Combat Stunts below.
+
+=== Unarmed Combat
+
+Unarmed attacks use the *Brawl* skill. Bare hands deal *1 Damage* on a hit.
+
+For unarmed grapples, shoves, and disarms, see Special Melee Maneuvers below.
+
+=== Special Melee Maneuvers
+
+All maneuvers require a successful melee attack roll. If the attack misses (no 6s), the maneuver fails entirely.
+
+[%header,cols="2,2,4"]
+|===
+| Maneuver | Skill | Effect
+
+| *Grapple* | Brawl (STR) opposed by Force or Brawl (target's choice) | Target is grappled: they cannot move zones, use two-handed weapons, or take Slow Actions until they break free (costs their Slow Action, opposed Brawl/Force roll).
+| *Shove* | Force (STR) opposed by Endure (STR) | Target is pushed back one zone and is knocked prone. If target is already at a zone edge (stairs, window, rooftop), this may be lethal.
+| *Disarm* | Sleight of Hand (AGI) opposed by Force or Brawl | Target drops their held weapon. It lands at Engaged range on the floor.
+| *Feint* | Brawl (STR) opposed by Wits | No damage this turn. On success: target cannot Dodge your next attack this round. You gain +2 dice on your next melee roll against them.
+|===
+
+---
+
+== Ranged Combat
+
+=== Basic Ranged Attack
+
+Roll *Firearms (AGI)* + Weapon Gear Bonus. On a hit, deal flat Damage to the target's Strength (armor applies).
+
+=== Range Penalties
+
+[%header,cols="1,1,1,1,1,1"]
+|===
+| Weapon Type | Engaged | Near | Short | Long | Distant
+
+| *Pistol (.38, 9mm)* | −1 die | — | — | −1 die | Out of range
+| *Shotgun* | +1 Damage | — | — | −2 dice | Out of range
+| *Assault Rifle* | −2 dice | −1 die | — | — | −1 die
+| *Thrown weapon* | — | — | Out of range | Out of range | Out of range
+|===
+
+> *Engaged penalty for pistols:* At arm's length, controlling a pistol one-handed while someone is grappling you is harder than a clean stance shot. The −1 die reflects that.
+
+=== Cover
+
+A character *in cover* benefits from partial physical shielding.
+
+* **Soft cover** (car door, wooden desk, drywall): +2 Armor Rating against ranged attacks only.
+* **Hard cover** (concrete pillar, stone wall, engine block): +4 Armor Rating against ranged attacks only.
+* Taking cover requires a Fast Action (move into cover within the current zone).
+* A character who fires from cover *loses the cover bonus* for any attacks made against them *that round* — you have to expose yourself to shoot.
+
+=== Ammunition
+
+Ammunition is tracked using a *Resource Die*. When you acquire a weapon or reload, set its ammo die:
+
+[%header,cols="2,1,2"]
+|===
+| Ammo State | Die | Notes
+
+| *Full magazine* | d8 | Fresh load; most pistols and rifles
+| *Half loaded* | d6 | Partially used
+| *Low / scrounged* | d4 | Found ammo, emergency reload
+| *Drum / extended mag* | d10 | Special acquisition (CL 4)
+|===
+
+*When do you roll the ammo die?*
+
+* After *pushing a Firearms roll* (you burned through rounds trying to compensate).
+* After a *full auto burst* (M16 or equivalent — roll twice).
+* At the GM's discretion when dramatically appropriate (long firefight, ambush, running chase).
+
+*Rolling the ammo die:*
+
+* Roll the current die. On a *1 or 2*, step the die down one size (d8→d6→d4→empty).
+* On *empty* (die was d4 and rolled 1–2): weapon is dry. Reload costs a Slow Action.
+
+---
+
+== Reactive Actions
+
+=== Dodge
+
+* *Type:* Fast Action (reactive — used on someone else's turn, not yours)
+* *When:* After a melee or ranged attack is declared against you, before the attacker rolls.
+* *Effect:* Add your *Agility* dice to your "defense pool." The attacker must beat both their own roll and your dodge roll (compare successes; attacker needs more than you).
+* *Cost:* You lose your Fast Action on your *next* turn.
+* *Limitation:* You cannot dodge if you have no Fast Action remaining this round (already spent), if you are prone, if you are Grappled, or if the attack was from ambush (surprise round).
+
+=== Parry
+
+* *Type:* Slow Action (reactive — used on someone else's turn)
+* *When:* After a melee attack is declared against you, before the attacker rolls. Requires a held melee weapon.
+* *Effect:* Roll *Brawl or Force* (your choice). If you match or exceed the attacker's successes, you take no damage. If you beat the attacker's successes, they lose their Slow Action next round (their weapon arm is numbed or they are off-balance).
+* *Cost:* You lose your Slow Action on your *next* turn.
+* *Limitation:* Cannot parry ranged attacks, unarmed shoves, or any attack from a weapon with Damage 4+.
+
+---
+
+== Combat Stunts
+
+Extra successes (6s beyond the first on any attack roll) are *Stunt Points*. Spend them from the table below. One stunt point = one effect unless listed otherwise.
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Knock Prone* | Target is knocked to the ground. They must spend a Fast Action to stand.
+| 1 | *Disarm* | Target drops their held weapon at Engaged range (without a full Disarm maneuver roll).
+| 1 | *Target Limb* | Attack hits a specific limb. GM applies a situational penalty (hobbled, one-armed, etc.) until treated.
+| 1 | *Push Back* | Target is forced one zone away.
+| 1 | *Scare* | Target must immediately make a *Fear check* (Fear Rating 1) even if no supernatural trigger is present. The violence itself breaks them.
+| 2 | *Double Damage* | Deal the weapon's Damage value twice instead of once.
+| 2 | *Suppressive Fire* | Target is pinned — they cannot move zones until the start of your next turn unless they succeed on a Wits roll (Difficulty 2).
+| 2 | *Destroy Cover* | Target's cover is destroyed or invalidated after this attack.
+| 3 | *Critical Hit* | Attack triggers a roll on the Critical Injury table _(Issue #4)_, regardless of whether the target is Broken.
+|===
+
+---
+
+== Chase and Pursuit
+
+When one side is fleeing and the other is pursuing, use the following chase rules.
+
+=== Chase Structure
+
+A chase is divided into *chase rounds*. Each round, both the fleeing and pursuing party roll their relevant attribute + skill:
+
+* *On foot:* Agility + Sneak (for stealth flight) or Agility + Endure (for pure sprint)
+* *By vehicle:* Agility + Tech (operating the vehicle) — full vehicle rules are forthcoming (#21)
+
+=== Chase Outcome Per Round
+
+* Compare successes. The side with more successes *gains distance* (fleeing) or *closes distance* (pursuing).
+* Track relative distance on a simple 5-step track: *Contact → Near → Far → Very Far → Escaped*.
+* Start at Contact. Fleeing party wins a round → move one step toward Escaped. Pursuing party wins → move one step toward Contact.
+
+=== Escape and Recapture
+
+* The fleeing party *escapes* when they reach the Escaped position.
+* During a chase, characters may still attack (at whatever range the current position represents) but do so at *−1 die* (distraction of movement).
+* If the pursuing party reaches Contact: normal combat resumes.
+* *Hiding:* If the fleeing party is at Far or Very Far and succeeds on a Sneak roll (Difficulty 2), they may break the chase entirely without reaching Escaped — they simply vanish into the environment.
+
+---
+
+== Group Combat (Multiple NPCs)
+
+When 3 or more combatants on the NPC side share a common purpose and act together, they may be treated as a *mob*.
+
+=== Mob Rules
+
+* A mob draws *one Initiative card* and acts as a single entity.
+* A mob has a shared Strength pool equal to *3 × mob size* (3 per member, max 15).
+* A mob attacks as one unit: roll dice pool equal to the *highest individual's pool* + bonus dice equal to mob members beyond the first (max +3).
+* *Splitting a mob:* Area effects (full auto, explosive, fire) or AoE-capable stunts can split a mob, with the GM distributing Strength loss across members.
+
+> Mobs represent low-tier hostiles (cultist grunt, security guard, Compact foot soldier). Named or significant NPCs always act individually.
+
+---
+
+== Ending Combat
+
+=== Surrender
+
+An NPC surrenders when their Strength is reduced to 2 or when a *Manipulate (EMP)* roll is made against them while they are below half Strength (Difficulty 1). A surrendered NPC drops their weapon and complies with instructions.
+
+Player characters may *always* choose to surrender — it is never forced mechanically.
+
+=== Retreat and Withdrawal
+
+A character may disengage from combat freely on their turn as long as:
+
+* No enemy is Engaged with them (Engaged = melee), OR
+* They succeed on an Agility roll (Difficulty 1) to break from Engaged contact.
+
+After disengaging, they may move up to two zones in the same turn (spending their Fast Action and Slow Action on movement).
+
+=== Broken in Combat
+
+When an NPC's Strength reaches 0, they are *Broken* (incapacitated). The GM chooses: dead, dying, or surrendering based on context and the nature of the attack.
+
+When a PC's Strength reaches 0, they are *Broken*:
+
+* They collapse and are incapacitated.
+* They must roll on the *Critical Injury table* (see Issue #4 — `docs/chapters/06-health-damage-armor.adoc`).
+* They are out of the fight unless stabilized by an ally (Heal roll, costs a Slow Action, requires a First Aid Kit).
+* An unstabilized Broken PC *dies* at the end of the scene unless treated.
+
+> *Capture over kill:* The Covenant defaults to capturing hostile humans for interrogation. NPCs with relevant information are more valuable alive. GMs should give players narrative opportunities to take prisoners rather than mandating lethality.

--- a/docs/neon-relic.adoc
+++ b/docs/neon-relic.adoc
@@ -23,6 +23,8 @@ include::chapters/02-verdant-covenant.adoc[leveloffset=+1]
 
 include::chapters/03-setting.adoc[leveloffset=+1]
 
+include::chapters/03b-combat.adoc[leveloffset=+1]
+
 include::chapters/04-core-mechanics.adoc[leveloffset=+1]
 
 include::chapters/05-attributes-skills.adoc[leveloffset=+1]


### PR DESCRIPTION
Closes #3

Added docs/chapters/03b-combat.adoc with full combat system:

- Initiative: card draw (Ace=low), initiative modifiers, surprise/ambush rules
- Action economy: Slow / Fast / Free actions with full reference tables
- Zones & range: 5 range categories (Engaged→Distant), zone features (Cramped, Rough, Dark, Open, Elevated)
- Melee: Force/Brawl attacks, unarmed, Grapple/Shove/Disarm/Feint maneuvers
- Ranged: Firearms, range penalty table by weapon type, soft/hard cover (+2/+4 Armor Rating), ammo as Resource Die (d4–d10)
- Reactive actions: Dodge (Fast Action, opposed) and Parry (Slow Action, blocks melee)
- Combat Stunts: 9-entry stunt table for extra successes (1–3 SP cost)
- Chase rules: zone-track pursuit (Contact→Escaped), foot vs skill-based, hiding break
- Group/mob combat: shared initiative, pooled Strength, attack scaling
- Ending combat: surrender, retreat/withdrawal, Broken outcomes (stabilize or die), capture-first design note

Added include::chapters/03b-combat.adoc[leveloffset=+1] to docs/neon-relic.adoc after chapter 03.