### PR TITLE
feat(#7): add skill stunt economy and per-skill stunt tables

### DIFF
--- a/docs/chapters/05-attributes-skills.adoc
+++ b/docs/chapters/05-attributes-skills.adoc
@@ -38,5 +38,182 @@ The twelve core skills are mapped to these four attributes, tailored to support 
 .3+| *Empathy*
 | Manipulate | Bribing informants, deceiving rivals, leveraging secrets.
 | Command | Directing panicked civilians, coordinating team actions under fire.
-| Psychoanalyze | Interrogating suspects, calming allies suffering from supernatural trauma, reading intent.
+---
+
+== Skill Stunts
+
+When you roll more 6s than the *minimum needed to succeed*, each extra 6 is a *Stunt Point*. You may spend Stunt Points to achieve effects beyond simple success.
+
+=== Stunt Economy
+
+* *1 extra 6 = 1 Stunt Point.*
+* You must succeed first (at least one 6 to meet the Difficulty), then extras are stunt points.
+* Stunt Points must be spent immediately — they do not carry between rolls.
+* You may split stunt points across multiple effects if both are available on the same skill.
+* On a *pushed roll*, stunt points still apply from the new result.
+
+> *Cross-reference:* Combat stunts — spending stunt points during an attack roll — are defined in the Combat chapter (`docs/chapters/03b-combat.adoc`). The stunt economy is the same.
+
+=== Generic Stunts (Any Skill)
+
+The following stunts may be purchased on *any* successful skill roll:
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Faster* | Accomplish the action in half the expected time. No narrative explanation needed — you just find the short path.
+| 1 | *Quieter* | Accomplish the action without leaving a detectable trace. The GM cannot use evidence of this action as a future complication.
+| 1 | *Precise* | Your result is exactly as intended — no collateral effects, no ambiguity, no partial outcomes.
+| 1 | *Aid* | Your success automatically assists an ally's next related roll this scene. They gain +1 die on it.
+| 2 | *Extended Effect* | The outcome of your action lasts an additional scene or at least one hour longer than it otherwise would.
+| 2 | *Additional Target* | Your action's results apply to one additional target in the same zone (the GM determines relevance).
+|===
+
+---
+
+=== Strength Skills
+
+==== Force
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Controlled Break* | You force open the door/lock/container without damaging the contents or triggering adjacent mechanisms. Finesse in violence.
+| 1 | *Intimidating Display* | Your feat of strength is visibly dramatic. One NPC present must make a Fear check (Fear Rating 1) or immediately comply with your next simple demand.
+| 2 | *Clear the Room* | A shove, flip, or sweep clears all loose objects from the zone simultaneously (useful for destroying a cultist's ritual setup, or just making a scene).
+|===
+
+==== Brawl
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Stay Down* | Target cannot stand up until the start of your next turn (they must spend a Slow Action to rise but simply cannot).
+| 1 | *Weapon Strike* | You've slapped or struck their weapon arm. Target suffers −1 die on all attack rolls until the end of the round.
+| 2 | *Neck Crank* | Target is Grappled (see Combat chapter) without requiring a separate maneuver roll. Counts as two stunts with one action.
+|===
+
+==== Endure
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Grind Through* | You complete the physical task despite having failed an earlier linked roll this scene (you were already exhausted but push through anyway).
+| 1 | *Inspire* | Your visible physical resilience gives allies heart. One ally in the scene recovers 1 point of Agility.
+| 2 | *Unfazed* | You succeed and take no Agility damage from whatever environmental or physical threat triggered the roll (extreme cold, sleep deprivation, toxic air).
+|===
+
+---
+
+=== Agility Skills
+
+==== Sneak
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Shadow Step* | You can take one additional move action as part of the same turn/scene phase without breaking your stealth. You haven't just crept in — you've repositioned perfectly.
+| 1 | *Identify Exit* | As you infiltrate, you map the fastest withdrawal route. You have +2 dice on any Sneak roll to leave this location later this scene.
+| 2 | *Ghost Pass* | Your passage leaves zero physical trace (no footprints, disturbed dust, or thermal record). Cannot be tracked from this location.
+|===
+
+==== Sleight of Hand
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Undetected* | The target of your pick-pocket, lift, or plant does not notice the action even after the immediate scene ends. They will assume the item was misplaced, not taken.
+| 1 | *Speed Lock* | You open a lock in seconds. No time resource is consumed; the GM cannot use the time you spent as a complication.
+| 2 | *Perfect Plant* | You plant an item on a target in a way that will implicate them credibly. Subsequent investigation will find the planted item and treat it as the target's possession.
+|===
+
+==== Firearms
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Aimed Shot* | The shot hits exactly the intended location (specific limb, lock, cable, tire). GM treats the result as precision even at range.
+| 1 | *Suppression* | Target is pinned behind cover until start of your next turn. They cannot move zones or fire back without losing their cover bonus.
+| 2 | *Warning Shot* | You visibly miss by design, close enough to be terrifying. Target immediately makes a Wits roll (Difficulty 2) or drops to ground and stays there for 1 round. No ammo die roll required.
+|===
+
+---
+
+=== Wits Skills
+
+==== Investigate
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Pattern Lock* | You not only find the evidence — you identify why it matters. The GM must tell you one piece of context about the object's history or origin.
+| 1 | *Clock It* | You determine precisely when an event occurred (within the hour, or narrowed to a 30-minute window). Time is often as revealing as the event.
+| 2 | *Hidden Compartment* | You find something the scene intended to conceal — a room the blueprints don't show, a file folder in a false wall, a trapdoor. GM must reveal one hidden element they had established but not yet disclosed.
+|===
+
+==== Tech
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Trace* | Successfully accessing a system also identifies who else accessed it recently — one account or one physical terminal is revealed.
+| 1 | *Improvised Repair* | The item you're repairing also gets a temporary improvement: a degraded weapon gets +1 Gear die this session; a damaged radio broadcasts on a sealed channel.
+| 2 | *Ghost Session* | Your access to a system leaves no log entry. No one can prove you were there.
+|===
+
+==== Lore
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Deep Context* | Your knowledge is not just what this thing is — you know what it was used for. GM provides one historical or ritual context detail beyond what would normally be available.
+| 1 | *Weakness Identified* | Your lore grants you tactical information: an entity type's vulnerability, an artifact's known failure condition, a ritual's interruption point. +1 die on the next relevant roll.
+| 2 | *Primary Source* | You recall a specific source — a text, a case file, a person — that would contain detailed operational information about this entity or artifact. The GM must confirm the source exists and tell you how to find it.
+|===
+
+---
+
+=== Empathy Skills
+
+==== Manipulate
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Bought Silence* | The target doesn't just comply — they will not mention this conversation to anyone for at least 24 hours. Your leverage persists.
+| 1 | *Read the Room* | Beyond this individual, you gauge how the wider group or faction feels about the situation. The GM tells you one faction-level attitude or intention.
+| 2 | *Turned Asset* | On an already-successful Manipulate, the target now actively wants to help you beyond the scope of your request. They will volunteer additional information or assistance once this session.
+|===
+
+==== Command
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Rally* | One Broken or Shaken ally in the scene immediately acts on their next turn as if they had recovered — they can take their full action once before the condition reasserts.
+| 1 | *Coordinated Action* | Your directive enables two allies to act simultaneously on their initiative cards (they share the same slot this round only).
+| 2 | *Hold the Line* | All allies who can hear you gain +1 die on their next roll this round. The effect of strong leadership under pressure.
+|===
+
+==== Psychoanalyze
+
+[%header,cols="^1,2,4"]
+|===
+| Cost | Stunt | Effect
+
+| 1 | *Pressure Point* | You've identified something this person fears or desperately needs. The GM must reveal one personal vulnerability, driving motivation, or exploitable need.
+| 1 | *Decompress* | The person you're treating recovers 1 additional Wits or Empathy point beyond the normal healing (max to their normal maximum).
+| 2 | *Full Read* | You have comprehensively understood this person's psychological state. For the rest of the scene, you may treat all Psychoanalyze rolls against them as Difficulty 0 — you know them now.
 |===


### PR DESCRIPTION
Closes #7

Added Skill Stunts section to \docs/chapters/05-attributes-skills.adoc\.

- Stunt economy: 1 extra 6 = 1 Stunt Point; spend immediately; can split across multiple effects
- 6 generic stunts (Faster, Quieter, Precise, Aid, Extended Effect, Additional Target) applicable to any roll
- 3 specific stunts per skill, all 12 skills covered: Force, Brawl, Endure, Sneak, Sleight of Hand, Firearms, Investigate, Tech, Lore, Manipulate, Command, Psychoanalyze
- All stunts scoped to 1980s occult investigation fiction
- Cross-reference to combat stunts in 03b-combat.adoc (same economy, not duplicated)