### PR TITLE
feat(#17): add Relationship slots and Drive mechanic

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -191,11 +191,57 @@ Every Covenant agent harbors a *Dark Secret* — something from their past that 
 
 ---
 
-== Step 10: Define Your Relationships _(Placeholder)_
+== Step 10: Define Your Relationships and Drive
 
-Agents are connected to the world around them — a Covenant superior who mentored them, a civilian they protect, a rival from a former life. These ties create stakes and can mechanically affect Corruption checks.
+Every agent enters play with three *Relationship Slots* and one *Drive*. These mechanics create personal stakes and grant mechanical benefits when those stakes are threatened or honored.
 
-> *This mechanic is not yet fully designed.* See Issue #17 for the full Relationships and Motivations system. For now, note one *Covenant Contact* (an NPC within the organization) and one *Personal Tie* (someone outside it).
+=== Relationship Slots
+
+Each slot defines a named NPC and your character's connection to them: who they are, why they matter, and what you would do to protect or reach them.
+
+[%header,cols="1,2,4"]
+|===
+| Slot | Type | What to Define
+
+| *Slot 1* | *Covenant Contact* | A superior, peer, or mentor within the organization. Someone who vouched for you, trained you, or relies on your results. Choose from: your Division handler, a fellow regional agent team lead, or the archivist who briefed you on your first Case File.
+| *Slot 2* | *Personal Tie* | A civilian outside the Covenant — someone who doesn't know what you do. A family member, a childhood friend, a former partner. They are completely unaware of the supernatural. They represent the life you're risking everything to protect.
+| *Slot 3* | *Rival or Enemy* | Someone who opposes you within your world — a faction contact who burned you, a former colleague who left the Covenant badly, or a Named Threat who already knows your face. This slot creates tension and recurring story hooks. The rival/enemy does not need to be an active threat right now — they are a *loaded element* for the GM to use.
+|===
+
+*Recording a Relationship:* Write the NPC's name, their connection to your character, and one thing your character believes about them (this belief may be wrong). The GM will use this to make the relationship meaningful in play.
+
+=== Drive
+
+Your *Drive* is a single-sentence statement of what your character fundamentally wants, fears, or believes. It is your character's engine.
+
+*Examples:*
+* "I will prove the Covenant's work is worth the cost." (Wayfinder idealist)
+* "I will find out what happened to my brother." (Recovery agent w/ personal mystery)
+* "I will survive long enough to get out." (Keep warden who wants to walk away)
+* "I will fix what I broke." (Stack specialist living down a past failure)
+
+*Mechanical effect — Invoking Your Drive:*
+
+Once per scene, when you take an action *directly in service of your Drive* (attack to protect your Personal Tie, push through to uncover the truth your Drive demands, sacrifice personal safety for a Drive-motivated goal), you may:
+
+. Declare the Drive aloud or describe how the action serves it.
+. Gain *+2 dice* on a single roll related to that action.
+
+This is a one-use bonus per scene. It refreshes at the start of each new scene.
+
+> *Drive vs. Dark Secret:* Your Drive is what you want. Your Dark Secret is something you're hiding. They often intersect — the secret may explain the drive. Discuss both with your GM during Session Zero.
+
+=== Relationship Loss and Consequence
+
+When a Relationship NPC is *killed, captured, corrupted, or otherwise removed from the story*:
+
+* *Covenant Contact lost:* Gain *+2 Resonance* (organizational shock) and lose Slot 1's active bonus until a new Contact is established (requires a scene in downtime to rebuild the tie).
+* *Personal Tie harmed or threatened:* Immediate *Corruption Check* (Difficulty 2) triggered by the emotional impact. If the tie is killed: automatic Corruption Check (no roll to avoid) with +1 Resonance added.
+* *Rival/Enemy eliminated:* The slot opens. The character may define a new one (a new rival may emerge naturally) or leave it empty (no mechanical penalty — the story just loses one of its loaded elements).
+
+*The Death of a Personal Tie:* This is one of the most psychologically catastrophic events in the game. Agents who lose their Personal Tie without the Corruption Check failing are changed — the GM should reflect this. Their Drive may need to be revised. The slot does not refill easily.
+
+> *Design note (Anchors):* Personal Ties function mechanically as *Anchors* — a connection to the non-supernatural world that slows Corruption's advance. The term "Anchor" may appear in other chapter references (e.g., the Faraday Cage description, Psychoanalyze skill). Both terms refer to the same mechanic.
 
 ---
 


### PR DESCRIPTION
Closes #17. Replaces Step 10 placeholder with full relationships system: 3 slots (Covenant Contact, Personal Tie, Rival/Enemy), Drive trait with +2 dice invoke mechanic, relationship loss consequences (Resonance/Corruption), and Anchor cross-reference note.