### PR TITLE
[Issue #25] Covenant Standing — Reputation and Meta-Progression System

### DIFF
--- a/docs/chapters/14-headquarters.adoc
+++ b/docs/chapters/14-headquarters.adoc
@@ -208,3 +208,157 @@ If the compromise event results in a direct assault (rolls 5–6), run it as a s
 * If the team retreats: roll on the Compromise Event table again (once) to determine collateral damage.
 
 > *Optional — Named Threats:* If the Threat Meter has recently been driven up by a specific rival faction, the GM may assign a Named Threat as the assault leader. This escalates the scene but awards +2 DP if the Named Threat is captured or killed.
+
+---
+
+[[covenant-standing]]
+== Covenant Standing (Reputation System)
+
+**Covenant Standing** is a per-cell meta-progression score that measures how the
+Verdant Covenant perceives your cell's effectiveness, discretion, and reliability.
+It is not glamour — it does not mean fame. A cell with high Standing is one that
+has been trusted with increasingly sensitive operations because they *do not leave
+messes*.
+
+Standing is tracked as a single score from **0 to 20**, shared by the entire cell.
+It never applies to individual agents — the Covenant evaluates teams, not heroes.
+
+---
+
+=== Standing Ranks
+
+[%header,cols="1,1,4"]
+|===
+| Score | Rank | What It Means
+
+| 0–4   | *Unknown*           | The cell is new or unproven. Covenant resources are minimal; access is limited to Tier 1 upgrades and standard CL 1–2 requisitions.
+| 5–9   | *Acknowledged*      | The cell has delivered results. Wayfinder and Keep division contacts treat the cell as credible. CL 3 requisitions become available.
+| 10–14 | *Trusted*           | The cell handles significant cases. The Covenant routes priority case files through them. CL 4 access opens. Keep reinforcements available.
+| 15–19 | *Honored*           | The cell has operated at the highest levels. Named contacts within Covenant leadership. Access to Classified Archive and Covenant assets.
+| 20    | *Covenant Elite*    | Fewer than a dozen cells in history have reached this. The Covenant treats the cell as irreplaceable. No resource limits. Legacy recorded.
+|===
+
+---
+
+=== Gaining Standing
+
+Standing increases at the end of a case when specific outcomes are achieved.
+All gains are cumulative — multiple criteria can apply in a single case.
+
+[%header,cols="3,1,3"]
+|===
+| Trigger | Standing Gain | Notes
+
+| Successful containment of primary artifact           | +2 | Artifact recovered and secure in transport or HQ
+| Zero civilian exposure (no witnesses, no media)      | +1 | Bonus on top of other gains; lost if any civilian knowledge confirmed
+| Rival faction neutralized (operative captured/fled)  | +2 | Does not apply if rival escaped with artifact
+| Tier 3 artifact recovered intact                     | +3 | Replaces standard containment +2 for Tier 3 cases
+| Cold case resolved (artifact dormant 10+ years)      | +1 | Bonus; applies when case origins predate the cell
+| Covenant agent rescued from hostile custody          | +2 | Applies once per arc, not per session
+| Case resolved without casualties (any side)          | +1 | Bonus; Covenant prefers clean operations
+| Named Threat operative captured (not just fled)      | +3 | Rare; named threat must be confirmed Covenant-file target
+|===
+
+> The maximum Standing gain in a single case is **+6** (containment + zero exposure +
+> clean resolution, for example). Avoid banking on Tier 3 cases to push the track —
+> those cases are designed to hurt.
+
+---
+
+=== Losing Standing
+
+Standing losses are immediate and cannot be avoided by narrative justification. The
+Covenant knows. It always knows.
+
+[%header,cols="3,1,3"]
+|===
+| Trigger | Standing Loss | Notes
+
+| Confirmed civilian casualties                       | −2 per casualty | Witnesses who survive and go public count as −3 instead
+| Resonance event reported in media                   | −3 | Any press coverage of supernatural phenomena linked to a case
+| Artifact lost to rival faction or enemy             | −3 | Lost in the field, stolen post-recovery, or destroyed improperly
+| Agent compromised, turned, or gone rogue            | −4 | Applies whether the agent is caught or simply disappears
+| Case abandoned mid-operation                        | −2 | Cell withdrew without artifact containment or Covenant approval
+| HQ location exposed to non-Covenant entities        | −4 | Does not require an attack; exposure alone is the failure
+| Cover story collapsed (public incident attributed to cell) | −3 | Any incident where the cell is publicly connected to supernatural events
+|===
+
+> Standing cannot go below 0. The Covenant does not formally execute cells with low
+> Standing — it simply stops routing cases to them and begins reassigning their
+> contacts. Effective retirement.
+
+---
+
+=== Standing Rewards
+
+Standing unlocks access to resources, upgrades, and Covenant infrastructure that
+cannot be purchased with Development Points alone.
+
+[%header,cols="2,1,4"]
+|===
+| Reward | Min. Standing | Effect
+
+| *Tier 2 HQ Upgrades Unlocked*       | 5  | Cell may begin purchasing Tier 2 facilities (see <<hq-upgrade-tree>>). DP cost unchanged.
+| *CL 3 Requisition Access*           | 5  | Standard CL 3 gear is available without special authorization.
+| *Keep Reinforcements*               | 10 | Once per arc, request a second Covenant cell for 1 session of operational support. They arrive equipped; they do not share Standing.
+| *Tier 3 HQ Upgrades Unlocked*       | 10 | Cell may begin purchasing Tier 3 facilities. DP cost unchanged.
+| *CL 4 Requisition Access*           | 10 | High-tier equipment (specialized surveillance, artifact containment casings, prototype weapons) available via formal request.
+| *Classified Archive Access*         | 15 | Wayfinder Division shares files on cold cases and artifact history normally restricted to senior analysts. +2 dice on Lore and Investigate rolls during Phase 2 (Research).
+| *Covenant Asset Call-In*            | 15 | Once per campaign arc, the Covenant deploys a named asset — insider at a government agency, black-market arms contact, demolitions specialist — to assist directly.
+| *Legacy Standing Bonus*             | 20 | When a cell member retires or dies, their Keeper (xp replacement PC) begins play with 3 Standing already gained toward the cell total.
+| *Unrestricted HQ Upgrade*           | 20 | Once per arc, build any single HQ upgrade for 0 DP. The Covenant funds it directly.
+|===
+
+---
+
+=== Standing and HQ Upgrade Gates
+
+Some HQ facilities already require specific prerequisites (DP investment and prior
+facilities). **Standing gates** apply on top of those prerequisites for the most
+sensitive upgrades. These upgrades cannot be built regardless of DP until the
+Standing threshold is met.
+
+[%header,cols="3,1,1"]
+|===
+| Facility | DP Cost | Min. Standing
+
+| *Microfiche Archive* (Tier 2)          | 3 DP | 5
+| *Occult Laboratory* (Tier 2)           | 4 DP | 5
+| *Faraday Cage* (Tier 2)               | 3 DP | 5
+| *Field Intel Network* (Tier 3)         | 5 DP | 10
+| *Resonance Dampening Vault* (Tier 3)   | 6 DP | 10
+| *Safe House Network* (Tier 3)          | 4 DP | 15
+| *Covenant Armorer* (Tier 3)            | 5 DP | 10
+|===
+
+> **Design Note:** Standing gates exist because Tier 2 and 3 facilities represent
+> the Covenant extending significant trust to a cell. An unproven cell does not get
+> access to the Occult Laboratory or the Resonance Dampening Vault. They have to
+> earn it.
+
+---
+
+=== Rival Cells (Optional Rule)
+
+At campaign start, the GM may establish a rival Covenant cell operating in the
+same region. Rival cells compete for case priority, Covenant resources, and Standing.
+
+Roll on this table during the first session:
+
+[%header,cols="1,4"]
+|===
+| d6 | Rival Cell Relationship
+
+| 1 | *Allied.* The rival cell is cooperative. Shared cases award both cells +1 Standing if resolved successfully. Loss is shared too.
+| 2 | *Indifferent.* The rival cell operates on different case types. They will not interfere — unless cases overlap.
+| 3 | *Competitive.* The rival cell is racing the player cell on at least one case per arc. First to contain gains +1 Standing; second gains nothing.
+| 4 | *Hostile (Institutional).* The rival cell has filed a formal complaint against the player cell with Covenant leadership. The PC cell's next Standing gain is reduced by 1.
+| 5 | *Compromised.* The rival cell has a mole. They do not know. The player cell may — do they report it and lose a potential ally, or use it?
+| 6 | *Shadow.* The rival cell does not officially exist. Their operations leave no records. When their cases intersect with the player cell, nothing is as it seems.
+|===
+
+**Rival Cell Standing:** Track the rival cell's Standing separately. If a rival
+cell reaches a Standing tier higher than the player cell's, the Covenant begins
+routing priority cases to the rival — the next case the player cell receives is
+a leftover (roll Complication twice, keep both results).
+


### PR DESCRIPTION
Closes #25

Adds Covenant Standing system to `docs/chapters/14-headquarters.adoc`:

- Standing score (0–20, per-cell) with 5 named ranks: Unknown / Acknowledged / Trusted / Honored / Covenant Elite
- 8-entry gain trigger table (+1 to +3 per trigger, max +6 per case)
- 7-entry loss trigger table (−2 to −4; floor at 0)
- 9-entry Standing Rewards table (CL access, Tier 2/3 unlock gates, reinforcements, Archive access, Covenant asset call-in, legacy bonus)
- Standing gate table for HQ upgrades (cross-references Issue #15 facility tree)
- Optional Rival Cell rules: d6 relationship table, rival Standing tracking, priority case routing consequences
- Design note on why tier gates exist (trust-based access)