### PR TITLE
feat(#54): Add Favorite Attribute and Key Skill cap per Division

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -68,7 +68,7 @@ Distribute *14 points* across your four core attributes. Each attribute has a mi
 | *Empathy* | 2–5 | Charisma, social intuition, and resistance to psychological horror.
 |===
 
-> *Division Priority:* Your Division's Key Attributes are where your character naturally excels. It is strongly recommended to place your highest scores there. There is no hard rule preventing you from assigning points elsewhere, but a Recovery agent with Strength 2 will break quickly.
+> *Division Favorite Attribute:* Each Division has one *Favorite Attribute* — the stat at the core of your agent's identity. Plan to assign 4 or 5 points there. *Wayfinder:* Wits | *Recovery:* Agility | *The Keep:* Empathy | *Stack:* Wits. Investing there is strongly recommended but not mechanically enforced.
 
 > *Attributes as Health:* Your attributes also serve as your health pools. Strength absorbs physical damage; Agility absorbs exhaustion; Wits absorbs mental horror; Empathy absorbs emotional trauma. A score of 0 in any attribute means your character is *Broken*.
 
@@ -98,7 +98,17 @@ Distribute *10 points* across the twelve core skills. No single skill may exceed
 
 > *Unranked skills:* A skill at rating 0 means you have no formal training. You may still attempt rolls using only your Attribute Dice — there are no "untrained" restrictions.
 
-> *Division Key Skills:* Strongly invest at least 2 of your 10 points in each of your Division's Key Skills. These are the rolls you will make most often under pressure.
+> *Division Key Skill — Starting Cap Exception:* Each Division has one designated Key Skill that may start at rating *4* instead of the normal maximum of 3. This represents professional specialization before Covenant service. You may spend up to 4 of your starting points on that skill.
+
+[%header,cols="1,1"]
+|===
+| Division | Key Skill (Starting Cap: 4)
+
+| Wayfinder | Lore
+| Recovery | Firearms
+| The Keep | Command
+| Stack | Tech
+|===
 
 ---
 

--- a/docs/chapters/05-attributes-skills.adoc
+++ b/docs/chapters/05-attributes-skills.adoc
@@ -41,6 +41,8 @@ The twelve core skills are mapped to these four attributes, tailored to support 
 | Psychoanalyze | Reading psychological states, detecting deception through behavior, stabilizing traumatized witnesses.
 |===
 
+> *Division Key Skill:* During character creation, each Division designates one Key Skill with a starting cap of *4* instead of the standard maximum of 3. See the Character Creation chapter for details.
+
 ---
 
 == Skill Stunts

--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -15,7 +15,9 @@ The Wayfinder Division serves as the primary investigative arm of the Covenant. 
 [cols="1,2"]
 |===
 | *Key Attributes* | Wits, Empathy
+| *Favorite Attribute* | Wits
 | *Key Skills* | Investigate, Lore, Tech, Psychoanalyze
+| *Key Skill (Cap 4 at creation)* | Lore
 | *Starting Clearance Level* | 3
 |===
 
@@ -92,7 +94,9 @@ Unlike other Divisions, the Recovery Division has *no internal departments or sp
 [cols="1,2"]
 |===
 | *Key Attributes* | Strength, Agility
+| *Favorite Attribute* | Agility
 | *Key Skills* | Force, Brawl, Firearms, Sneak
+| *Key Skill (Cap 4 at creation)* | Firearms
 | *Starting Clearance Level* | 2
 |===
 
@@ -146,7 +150,9 @@ Members of the Keep are entrusted with the stewardship of the Covenant's most se
 [cols="1,2"]
 |===
 | *Key Attributes* | Empathy, Wits
+| *Favorite Attribute* | Empathy
 | *Key Skills* | Lore, Command, Endure, Heal
+| *Key Skill (Cap 4 at creation)* | Command
 | *Starting Clearance Level* | 3
 |===
 
@@ -219,7 +225,9 @@ Stack agents design, modify, and distribute the tools used by Covenant agents â€
 [cols="1,2"]
 |===
 | *Key Attributes* | Wits, Agility
+| *Favorite Attribute* | Wits
 | *Key Skills* | Tech, Sleight of Hand, Investigate, Craft _(specialized sub-skill for building/repairing gear)_
+| *Key Skill (Cap 4 at creation)* | Tech
 | *Starting Clearance Level* | 4
 |===
 


### PR DESCRIPTION
Closes #54

## Changes

### Character Creation (01-introduction.adoc)
- **Step 3:** Replace generic 'Division Priority' callout with explicit Favorite Attribute per Division (Wayfinder: Wits | Recovery: Agility | The Keep: Empathy | Stack: Wits)
- **Step 4:** Replace generic key-skill investment note with the cap exception rule (one Key Skill per Division may start at 4) + mini lookup table

### Division Reference (09-divisions.adoc)
- Add **Favorite Attribute** and **Key Skill (Cap 4 at creation)** rows to all four Division Key Stats tables

### Skills Reference (05-attributes-skills.adoc)
- Brief callout note after the main skills table pointing to the creation cap exception