### PR TITLE
feat(#59): Add Lifepath system as Step 7 (Experience Track)

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -12,11 +12,11 @@ The resulting framework is a fast, decisive, and player-centric engine designed 
 
 = Creating Your Agent
 
-Every player in Neon Relic portrays a sworn agent of *The Verdant Covenant* — a specialist with a particular expertise, a history that brought them to this work, and a threshold for the horrors they are about to witness. Character creation follows these twelve steps in order.
+Every player in Neon Relic portrays a sworn agent of *The Verdant Covenant* — a specialist with a particular expertise, a history that brought them to this work, and a threshold for the horrors they are about to witness. Character creation follows these thirteen steps in order.
 
 [NOTE]
 ====
-*Design Note:* Steps 10 and 11 (Dark Secrets and Relationships) are cross-referenced but not yet fully developed. See Issue #2 and Issue #17 for those mechanics. For now, note a placeholder and continue.
+*Design Note:* Steps 11 and 12 (Dark Secrets and Relationships) are cross-referenced but not yet fully developed. See Issue #2 and Issue #17 for those mechanics. For now, note a placeholder and continue.
 ====
 
 ---
@@ -144,7 +144,28 @@ Once attributes are set, note the following:
 
 ---
 
-== Step 7: Claim Your Division Item
+== Step 7: Choose Your Experience Track
+
+Every agent brings a personal history into their first operation. Your *Experience Track* represents your seniority before this mission begins — it determines your age, any modification to your Clearance Level, and grants you one additional General Talent beyond the one selected in Step 5.
+
+[%header,cols="1,1,1,3,2"]
+|===
+| Track | Age | CL Modifier | Additional Benefit | Cost
+
+| *Rookie* | 22–28 | — | One additional General Talent | —
+| *Field Veteran* | 29–38 | +1 _(max 4)_ | One additional General Talent | —
+| *Senior Operative* | 39–52 | +1 _(max 4)_ | One additional General Talent | Begin play with *+1 Resonance*
+|===
+
+> *CL Cap:* No agent may begin play above Clearance Level *4*, regardless of Division or Experience Track.
+
+> *General Talent (Lifepath):* This talent is separate from the General Talent selected in Step 5. All agents begin play with *two General Talents* — one chosen in Step 5, one reflecting their operative history.
+
+If your Experience Track grants a CL bonus, update your Clearance Level now.
+
+---
+
+== Step 8: Claim Your Division Item
 
 Every agent receives their Division's *signature item* at induction. This item requires no CL check and no requisition roll — record it automatically.
 
@@ -160,7 +181,7 @@ Every agent receives their Division's *signature item* at induction. This item r
 
 ---
 
-== Step 8: Select Starting Gear
+== Step 9: Select Starting Gear
 
 Each agent begins with a Division-appropriate kit. Gear beyond this standard kit requires a *Clearance Level roll* during the mission's Equipping Phase.
 
@@ -196,7 +217,7 @@ Each agent begins with a Division-appropriate kit. Gear beyond this standard kit
 
 ---
 
-== Step 9: Choose Your Anchor
+== Step 10: Choose Your Anchor
 
 Every agent carries an *Anchor* — a tangible, physical object tied to a core humanizing memory from before the Covenant. It connects you to the ordinary world you are fighting to protect, and it is your most reliable tool for clearing Resonance and healing Corruption.
 
@@ -211,7 +232,7 @@ Record your Anchor's name and the memory it represents on your character sheet.
 
 ---
 
-== Step 10: Choose Your Dark Secret _(Placeholder)_
+== Step 11: Choose Your Dark Secret _(Placeholder)_
 
 Every Covenant agent harbors a *Dark Secret* — something from their past that the Covenant knows, or should know, about them. Dark Secrets create narrative hooks and can affect how NPCs and factions react to your character.
 
@@ -219,7 +240,7 @@ Every Covenant agent harbors a *Dark Secret* — something from their past that 
 
 ---
 
-== Step 11: Define Your Relationships
+== Step 12: Define Your Relationships
 
 Every agent enters play with three *Relationship Slots*. These define the personal stakes that make missions matter and connect the character to the world beyond the Covenant.
 
@@ -252,7 +273,7 @@ When a Relationship NPC is *killed, captured, corrupted, or otherwise removed fr
 
 ---
 
-== Step 12: Name and Biography
+== Step 13: Name and Biography
 
 Choose a name appropriate for the 1980s United States setting. Write 2–3 sentences of biography: who were you before the Covenant? What incident drew their attention? What can you not bring yourself to talk about?
 
@@ -269,11 +290,13 @@ After completing all steps, your sheet should record:
 | Field | Notes
 
 | *Name / Division / Department* | Identity and role
-| *Clearance Level* | 2–4 depending on Division
+| *Clearance Level* | Division default + Experience Track modifier (max 4)
+| *Age* | Set by Experience Track (22–52)
 | *Attributes (STR / AGI / WIT / EMP)* | 14 points distributed, 2–5 each
 | *Skills (12)* | 10 points distributed, 0–3 each
 | *Division Talent* | One chosen from Division list
-| *General Talent* | One chosen from General Talents list (Advancement chapter)
+| *General Talent* | One chosen from General Talents list (Step 5)
+| *General Talent (Lifepath)* | One chosen from General Talents list (Step 7)
 | *Division Item* | Automatic (or Stack bonus)
 | *Starting Gear* | Division kit ± optional items
 | *Resonance* | Starts at 0
@@ -335,21 +358,25 @@ _Remaining 6 skills are at 0._
 |===
 | Statistic | Value
 
-| Clearance Level | 2
+| Clearance Level | 2 _(initial; updated in Step 7)_
 | Resonance | 0
 | Corruption | 0
 | Max Corruption Threshold | 13
 |===
 
-=== Step 7–8: Division Item and Gear
+=== Step 7: Experience Track
 
-Petra records the *Verdant Satchel* automatically. From the Recovery Kit she takes: .38 Special revolver (12 rounds), D-cell flashlight, field kit (rope, zip ties, chalk, crowbar), and field jacket. For her additional CL 2 item she selects a police scanner.
+Petra's six years in DEA field operations make her a *Field Veteran* (age 34). Her CL increases from 2 to *3*. She selects *Paranormal Intuition* as her Lifepath General Talent — entering a room and knowing whether something supernatural has been there suits someone who learned too late to trust her instincts.
 
-=== Step 9: Anchor
+=== Steps 8–9: Division Item and Gear
+
+Petra records the *Verdant Satchel* automatically. From the Recovery Kit she takes: .38 Special revolver (12 rounds), D-cell flashlight, field kit (rope, zip ties, chalk, crowbar), and field jacket. For her additional CL 3 item she selects a police scanner.
+
+=== Step 10: Anchor
 
 > *Anchor:* A cassette tape — Los Lobos, _By the Light of the Moon_, 1987. Her brother Marco made it for her birthday. She keeps it in the inside pocket of her field jacket and hasn't listened to it since the Tucson raid.
 
-=== Steps 10–11: Dark Secret and Relationships
+=== Steps 11–12: Dark Secret and Relationships
 
 > *Dark Secret:* Petra's former DEA supervisor is now working for *The Vantablack Compact*. She has not reported this.
 
@@ -357,6 +384,6 @@ Petra records the *Verdant Satchel* automatically. From the Recovery Kit she tak
 > *Personal Tie:* Her younger brother Marco, a cop in Phoenix who doesn't know she quit the DEA.
 > *Rival/Enemy:* Agent Harlan Voss — a Keep operative who questioned her competence during the Tucson debrief. She hasn't forgotten.
 
-=== Step 12: Biography
+=== Step 13: Biography
 
 _"Petra Vasquez, former DEA Special Agent, six years in field operations before the Tucson Incident. The Covenant found her two days after the raid. She's never asked them how they knew."_


### PR DESCRIPTION
Closes #59

## Changes

### New Step 7: Choose Your Experience Track
- **Rookie** (age 22–28): No CL modifier, one additional General Talent
- **Field Veteran** (age 29–38): +1 CL (max 4), one additional General Talent
- **Senior Operative** (age 39–52): +1 CL (max 4), one additional General Talent, begin play with +1 Resonance (the cost of experience)
- CL hard cap of 4 regardless of Division or track
- Lifepath General Talent is separate from the creation General Talent from Step 5

### Renumbering
- Old Steps 7–12 become Steps 8–13 throughout the document

### Character Sheet Summary
- CL note updated to reference Experience Track modifier
- Age row added
- General Talent (Lifepath) row added

### Petra Vasquez Worked Example
- Field Veteran (age 34), CL rises from 2 to 3
- Paranormal Intuition as Lifepath General Talent
- All step references corrected to new numbering