### PR TITLE
feat(#67): collapse Resonance and Corruption into unified Corruption track

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -4,7 +4,7 @@ The synthesis of 1980s cultural tropes, analog technology, and occult horror pre
 
 By utilizing the *Year Zero Engine (YZE)*, a framework celebrated for its modularity and narrative-driven mechanics, Project Neon Relic constructs a game environment that mirrors the investigative, base-building structure of _Vaesen_ while injecting the high-stakes psychological tension found in the _Alien RPG_ and the moral ambiguity of the _Blade Runner RPG_.
 
-The game casts players as agents of *The Verdant Covenant*, a secretive society operating within the neon-drenched, synthesizer-scored landscape of the late 1980s. The design mandates a complete thematic reskin of the YZE mechanics, including specialized class divisions, analog items, supernatural abilities, and faction-based settings. Furthermore, it integrates a uniquely engineered *"Resonance and Corruption"* mechanic — a proprietary addition that conceptually bridges the volatile "Stress and Panic" system of _Alien_ with the resource-management aspects of "Willpower" in _Forbidden Lands_, and the humanity attrition of _Blade Runner_.
+The game casts players as agents of *The Verdant Covenant*, a secretive society operating within the neon-drenched, synthesizer-scored landscape of the late 1980s. The design mandates a complete thematic reskin of the YZE mechanics, including specialized class divisions, analog items, supernatural abilities, and faction-based settings. Furthermore, it integrates a uniquely engineered *Corruption* mechanic — a proprietary addition that conceptually bridges the volatile "Stress and Panic" system of _Alien_ with the resource-management aspects of "Willpower" in _Forbidden Lands_, and the humanity attrition of _Blade Runner_.
 
 The resulting framework is a fast, decisive, and player-centric engine designed to deliver episodic, "monster-of-the-week" mysteries that are ultimately anchored by strategic headquarters management and a deep exploration of the "Artifact of Doom" narrative trope.
 
@@ -119,7 +119,7 @@ At creation, every agent selects *two* talents:
 * *One Division Talent* chosen from your Division's talent list (see the Divisions chapter). You may only choose from your own Division's list at creation.
 * *One General Talent* chosen from the General Talents list (see the Advancement chapter). These are available to every agent regardless of Division.
 
-Most Division Talents cost *1 Resonance* to activate. One talent per list is a *Healing* talent, usable freely but once per session. General Talents are passive or per-session effects with no Resonance cost unless noted.
+Most Division Talents cost *+1 Corruption* to activate. One talent per list is a *Healing* talent, usable freely but once per session. General Talents are passive or per-session effects with no Corruption cost unless noted.
 
 > *Talent Advancement:* Additional talents can be purchased during play using experience points. See the Advancement chapter.
 
@@ -134,7 +134,6 @@ Once attributes are set, note the following:
 | Statistic | Starting Value
 
 | *Clearance Level (CL)* | Set by Division (see Step 1)
-| *Resonance* | *0* — you begin untouched by the occult
 | *Corruption* | *0* — you begin psychologically intact
 | *Max Corruption Threshold* | `10 + Empathy score`
 | *Broken Thresholds* | Any attribute reaching 0
@@ -154,7 +153,7 @@ Every agent brings a personal history into their first operation. Your *Experien
 
 | *Rookie* | 22–28 | — | One additional General Talent | —
 | *Field Veteran* | 29–38 | +1 _(max 4)_ | One additional General Talent | —
-| *Senior Operative* | 39–52 | +1 _(max 4)_ | One additional General Talent | Begin play with *+1 Resonance*
+| *Senior Operative* | 39–52 | +1 _(max 4)_ | One additional General Talent | Begin play with *+1 Corruption*
 |===
 
 > *CL Cap:* No agent may begin play above Clearance Level *4*, regardless of Division or Experience Track.
@@ -175,7 +174,7 @@ Every agent receives their Division's *signature item* at induction. This item r
 
 | Wayfinder | *Verdant Codex* | Secures memory, decodes language and symbols, maps artifact locations, preserves documents.
 | Recovery | *Verdant Satchel* | Suppresses artifact aura, seals cursed items, warns of instability, produces basic tools on demand.
-| Keep | *Warden's Bracer* | Suppresses artifact magic nearby, warns of containment failure, safe handling of cursed objects, absorbs 1 Resonance/session, +1 Armor Rating.
+| Keep | *Warden's Bracer* | Suppresses artifact magic nearby, warns of containment failure, safe handling of cursed objects, absorbs 1 Corruption/session, +1 Armor Rating.
 | Stack | _(none)_ | Stack agents receive no Division Item, but gain +1 requisition die whenever acquiring _crafting materials_ during the Equipping Phase.
 |===
 
@@ -219,7 +218,7 @@ Each agent begins with a Division-appropriate kit. Gear beyond this standard kit
 
 == Step 10: Choose Your Anchor
 
-Every agent carries an *Anchor* — a tangible, physical object tied to a core humanizing memory from before the Covenant. It connects you to the ordinary world you are fighting to protect, and it is your most reliable tool for clearing Resonance and healing Corruption.
+Every agent carries an *Anchor* — a tangible, physical object tied to a core humanizing memory from before the Covenant. It connects you to the ordinary world you are fighting to protect, and it is your most reliable tool for healing Corruption.
 
 Choose one of the following options:
 
@@ -228,7 +227,7 @@ Choose one of the following options:
 
 Record your Anchor's name and the memory it represents on your character sheet.
 
-> *Mechanic:* Once per session, dedicate a scene to your Anchor — a quiet moment where you handle the object and let the memory surface. Heal *1d4 Corruption* OR clear your entire current *Resonance* pool. Full rules in the Healing chapter.
+> *Mechanic:* Once per session, dedicate a scene to your Anchor — a quiet moment where you handle the object and let the memory surface. Heal *1d4 Corruption*. Full rules in the Healing chapter.
 
 ---
 
@@ -263,11 +262,11 @@ Each slot defines a named NPC and your character's connection to them: who they 
 
 When a Relationship NPC is *killed, captured, corrupted, or otherwise removed from the story*:
 
-* *Covenant Contact lost:* Gain *+2 Resonance* (organizational shock) and lose Slot 1's active bonus until a new Contact is established (requires a scene in downtime to rebuild the tie).
-* *Personal Tie harmed or threatened:* Immediate *Corruption Check* (Difficulty 2) triggered by the emotional impact. If the tie is killed: automatic Corruption Check (no roll to avoid) with +1 Resonance added.
+* *Covenant Contact lost:* Gain *+2 Corruption* (organizational shock) and lose Slot 1’s active bonus until a new Contact is established (requires a scene in downtime to rebuild the tie).
+* *Personal Tie harmed or threatened:* Gain *+1 Corruption* triggered by the emotional impact. If the tie is killed: gain *+3 Corruption* (no roll to avoid).
 * *Rival/Enemy eliminated:* The slot opens. The character may define a new one (a new rival may emerge naturally) or leave it empty (no mechanical penalty — the story just loses one of its loaded elements).
 
-*The Death of a Personal Tie:* This is one of the most psychologically catastrophic events in the game. Agents who lose their Personal Tie without the Corruption Check failing are changed — the GM should reflect this. The slot does not refill easily.
+*The Death of a Personal Tie:* This is one of the most psychologically catastrophic events in the game. Agents who lose their Personal Tie and survive the psychological impact are changed — the GM should reflect this. The slot does not refill easily.
 
 > *Design note (Anchors):* Personal Ties function mechanically as *Anchors* — a connection to the non-supernatural world that slows Corruption's advance. The term "Anchor" may appear in other chapter references (e.g., the Faraday Cage description, Psychoanalyze skill). Both terms refer to the same mechanic.
 
@@ -299,7 +298,6 @@ After completing all steps, your sheet should record:
 | *General Talent (Lifepath)* | One chosen from General Talents list (Step 7)
 | *Division Item* | Automatic (or Stack bonus)
 | *Starting Gear* | Division kit ± optional items
-| *Resonance* | Starts at 0
 | *Corruption* | Starts at 0
 | *Max Corruption Threshold* | 10 + Empathy
 | *Dark Secret* | One sentence placeholder
@@ -349,7 +347,7 @@ _Remaining 6 skills are at 0._
 
 === Step 5: Starting Talents
 
-* *Division Talent:* Petra chooses *Shadow Walker* (1 Resonance): Become entirely imperceptible to mundane guards or cameras for a scene, provided she does not attack. This fits her infiltration background perfectly.
+* *Division Talent:* Petra chooses *Shadow Walker* (+1 Corruption): Become entirely imperceptible to mundane guards or cameras for a scene, provided she does not attack. This fits her infiltration background perfectly.
 * *General Talent:* Petra takes *Flee the Scene* — gain +2 bonus dice to Agility when rolling explicitly to escape a conflict. A field operative who knows when to run lives longer than one who doesn't.
 
 === Step 6: Starting Statistics
@@ -359,7 +357,6 @@ _Remaining 6 skills are at 0._
 | Statistic | Value
 
 | Clearance Level | 2 _(initial; updated in Step 7)_
-| Resonance | 0
 | Corruption | 0
 | Max Corruption Threshold | 13
 |===

--- a/docs/chapters/03b-combat.adoc
+++ b/docs/chapters/03b-combat.adoc
@@ -2,7 +2,7 @@
 
 Combat in Neon Relic is fast, brutal, and consequential. Agents of the Covenant are capable individuals — but they are not soldiers. A prolonged firefight drains attributes that also serve as their sanity and stamina. Every round of violence is a resource you cannot easily recover before the next case.
 
-Combat rules are designed for *investigation-first play*: most situations should be solvable without combat, combat should resolve quickly when it happens, and the aftermath (injury, Resonance, gear degradation) should matter as much as the outcome.
+Combat rules are designed for *investigation-first play*: most situations should be solvable without combat, combat should resolve quickly when it happens, and the aftermath (injury, Corruption, gear degradation) should matter as much as the outcome.
 
 ---
 
@@ -51,7 +51,7 @@ A slow action represents a committed, focused effort requiring your full attenti
 | *Attack (melee or ranged)* | Roll to hit and deal damage. Core offensive action.
 | *First Aid* | Use Heal skill to restore Strength or treat a Critical Injury (requires a First Aid Kit).
 | *Reload* | Reload a firearm that has run dry. No roll required; consumes ammo.
-| *Use an Artifact* | Activate an artifact's properties. Generates Resonance per artifact tier.
+| *Use an Artifact* | Activate an artifact's properties. Generates Corruption per artifact tier.
 | *Activate Division Talent* | Use your Division Talent (if it requires sustained effort).
 | *Manipulate NPC* | Attempt to talk someone down, issue commands, or negotiate during combat.
 | *Help an Ally* | Add +1 die to an ally's next roll this round (must be present, skill >= 1).

--- a/docs/chapters/04-core-mechanics.adoc
+++ b/docs/chapters/04-core-mechanics.adoc
@@ -28,13 +28,11 @@ The elegance of this system lies in its speed; it produces immediate, decisive r
 
 The primary driver of suspense and narrative tension is the *Push* mechanic. If an initial roll yields no sixes (a failure), or if the player desperately needs additional successes for stunts, they may choose to *push* the roll — picking up and re-rolling all dice that do not currently display a 6.
 
-However, pushing represents the character exerting maximum physical, mental, or material effort, and it comes with strict limitations and severe risks:
+However, pushing represents the character exerting maximum physical, mental, or material effort, and it comes with severe risks:
 
-* You immediately gain *1 Resonance point*.
-* You take a *−1 die penalty* on all future rolls utilizing that specific Attribute.
-* *You cannot push a roll if you already have a −1 penalty to the associated Attribute.* This prevents players from continuously "farming" resources on safe rolls.
+* You immediately gain *+1 Corruption*.
 
-> *Design note:* Resonance is the only push cost. There is no separate "Stress" track, no optional complication table. The Resonance system is designed to handle all forms of mental and supernatural pressure through a single unified resource — see `docs/chapters/07-resonance-corruption.adoc` (Design Decision: Resonance vs. Willpower) for the full rationale.
+> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see `docs/chapters/07-resonance-corruption.adoc` for the full rules.
 
 The analog nature of 1980s technology perfectly complements this mechanical attrition. Pushing a gear-assisted roll might degrade the item — short-circuiting alkaline batteries or jamming mechanisms — effectively reducing its inherent bonus until it can be repaired during downtime.
 
@@ -55,13 +53,13 @@ When two characters are directly working against each other — a guard watching
 
 > **Design Decision:** In Neon Relic, ties are resolved *in favor of the active party* — the character initiating the action. +
 > +
-> **Rationale:** Neon Relic is an action-and-investigation game. Agents are protagonists taking risks. A tie should reward decisive action rather than passive defense. The threat of failure is already baked into the Resonance cost of pushing — we don't need the additional drag of defender-wins ties slowing down forward momentum. This differs from _Vaesen_ (defender wins) and aligns more closely with the feel of _Alien RPG_.
+> **Rationale:** Neon Relic is an action-and-investigation game. Agents are protagonists taking risks. A tie should reward decisive action rather than passive defense. The threat of failure is already baked into the Corruption cost of pushing — we don't need the additional drag of defender-wins ties slowing down forward momentum. This differs from _Vaesen_ (defender wins) and aligns more closely with the feel of _Alien RPG_.
 
-If both sides roll zero successes, the outcome is *no change* — the situation remains unresolved, and the GM should advance the fiction in a direction that applies pressure (the confrontation escalates, time runs out, a third party notices, etc.). The acting character does *not* gain Resonance from a zero-zero tie.
+If both sides roll zero successes, the outcome is *no change* — the situation remains unresolved, and the GM should advance the fiction in a direction that applies pressure (the confrontation escalates, time runs out, a third party notices, etc.). The acting character does *not* gain Corruption from a zero-zero tie.
 
 === Common Opposed Pairings
 
-The following pairings arise most frequently in play. Either side may push their roll as normal, gaining 1 Resonance.
+The following pairings arise most frequently in play. Either side may push their roll as normal, gaining +1 Corruption.
 
 [%header,cols="2,2,3"]
 |===
@@ -81,9 +79,7 @@ The following pairings arise most frequently in play. Either side may push their
 
 === Pushed Opposed Rolls
 
-Either or both sides may push their roll (gaining 1 Resonance each). Pushes are declared *before* comparing results. If both sides push and the result is still a tie, the active party wins as normal.
-
-*You may not push an opposed roll if you already have a −1 penalty to the relevant Attribute.*
+Either or both sides may push their roll (gaining +1 Corruption each). Pushes are declared *before* comparing results. If both sides push and the result is still a tie, the active party wins as normal.
 
 ---
 
@@ -106,11 +102,10 @@ An ally may help if **both** of the following are true:
 
 > **Maximum pool size:** With 2 helpers, a character's pool can be up to +2 dice above their normal maximum. This represents peak team coordination — beyond this, too many cooks.
 
-=== Helping and Resonance
+=== Helping and Corruption
 
 * If the active character *pushes* the roll, helpers are *not* penalized — they lent their dice to the initial roll, not the push.
-* If a helper's contributed die shows a *1 on the initial (pre-push) roll*, the active character still gains those dice for the push (1s on initial rolls only matter for gear degradation, not helpers).
-* Helpers do *not* gain Resonance when the active character pushes.
+* Helpers do *not* gain Corruption when the active character pushes.
 
 === Helping in Combat
 
@@ -143,9 +138,9 @@ If the group fails to meet the threshold:
 
 * The GM applies consequences to *all who failed*, not as individual failures but as a shared narrative setback.
 * Individual characters who succeeded are not penalized — they did their part.
-* Characters who failed *may push* as normal (gaining 1 Resonance each), independently.
+* Characters who failed *may push* as normal (gaining +1 Corruption each), independently.
 
-> **Group rolls and Resonance:** Each character manages their own Resonance on a group roll independently. A group roll gone wrong — four agents all pushing, all gaining 1 Resonance — creates the kind of compounding pressure that makes the Corruption system matter.
+> **Group rolls and Corruption:** Each character manages their own Corruption on a group roll independently. A group roll gone wrong — four agents all pushing, all gaining +1 Corruption — creates the kind of compounding pressure that makes the Corruption system matter.
 
 ---
 
@@ -166,7 +161,7 @@ If Petra had rolled 0 successes and the operative also rolled 0, the tail contin
 *Situation:* Wayfinder Agent Reyes is interrogating a frightened historian who knows where the artifact is. The historian desperately doesn't want to cooperate.
 
 * **Reyes rolls:** Manipulate (EMP 4 + Manipulate 2) = 6 dice. Rolls: 5, 4, 4, 3, 2, 1 → *0 successes*.
-* Reyes decides to *push* (gains 1 Resonance, now at 2). Re-rolls all 5 non-6 dice: 6, 6, 3, 2, 1 → *2 successes*.
+* Reyes decides to *push* (gains +1 Corruption, now at 1). Re-rolls all 5 non-6 dice: 6, 6, 3, 2, 1 → *2 successes*.
 * **Historian rolls:** Psychoanalyze (EMP 3 + Psychoanalyze 1) = 4 dice. Rolls: 6, 4, 3, 2 → *1 success*.
 * **Result:** Reyes wins (2 vs 1). The historian cracks. The extra success can be spent on a stunt — perhaps he volunteers more than just the location.
 
@@ -186,4 +181,4 @@ If Petra had rolled 0 successes and the operative also rolled 0, the tail contin
 * Osei (Sneak 0, EMP 3): 3 attribute dice → 6, 3, 1 → *1 success* ✓
 * Kowalski (Sneak 2, AGI 4): 6 dice → 6, 6, 3, 2, 1, 1 → *2 successes* ✓
 
-Reyes failed. Threshold not met. The GM rules the guard hears something from Reyes' direction and starts to turn. *Reyes pushes* (gains 1 Resonance): re-rolls 3 dice → 6, 4, 2 → *1 success*. The group just barely makes it — but Reyes is now at 1 Resonance and the tension meter has ticked up.
+Reyes failed. Threshold not met. The GM rules the guard hears something from Reyes' direction and starts to turn. *Reyes pushes* (gains +1 Corruption): re-rolls 3 dice → 6, 4, 2 → *1 success*. The group just barely makes it — but Reyes is now at 1 Corruption and the tension meter has ticked up.

--- a/docs/chapters/05b-social-conflict.adoc
+++ b/docs/chapters/05b-social-conflict.adoc
@@ -130,7 +130,7 @@ When a social scene ends badly (Disposition reaches 1, or the agents leave havin
 Social encounters with entities, artifacts, or cult members may cross into supernatural territory. When the content of a conversation triggers a Fear check:
 
 * *Direct supernatural revelation during a Manipulate scene* (the NPC says something that cannot be explained naturally): Fear check, Fear Rating 1 or 2.
-* *Psychoanalyze roll on a contaminated NPC* (someone who has long-term artifact exposure): Roll Psychoanalyze as normal. On any failure, the agent picks up a psychic echo — immediate Fear check, Fear Rating 2. On success, the agent gets the information but gains 1 Resonance.
+* *Psychoanalyze roll on a contaminated NPC* (someone who has long-term artifact exposure): Roll Psychoanalyze as normal. On any failure, the agent picks up a psychic echo — immediate Fear check, Fear Rating 2. On success, the agent gets the information but gains +1 Corruption.
 
 See `docs/chapters/07-resonance-corruption.adoc` for full Fear check rules.
 

--- a/docs/chapters/06-health-damage-armor.adoc
+++ b/docs/chapters/06-health-damage-armor.adoc
@@ -164,16 +164,16 @@ Roll when Broken by *Strength or Agility* damage.
 | 63 | *Multiple Wounds* † | Death check. Surviving: roll twice more on this table (ignoring further †). | As per rolled injuries.
 | 64 | *Arterial Strike* † | Bleeding 2 Strength per round. Death check must be made within 2 rounds or automatic death. | Tourniquet (Fast Action, CL 1) buys 1 extra round; Heal (Difficulty 4) fully stabilizes.
 | 65 | *Head Shot* † | Death check. Surviving: permanently remove 1 from Wits AND Empathy. Insight: *+2 dice on Psychoanalyze forever* (near-death clarity). | Cannot be healed. Migraine condition (persistent).
-| 66 | *DOA* † | Automatic death check (no bonus). Surviving: character is clinically dead for 1d6 rounds before CPR-equivalent revives them. All Attributes return to 1. Permanent: Resonance +3, Empathy −1. | See Resonance/Corruption chapter.
+| 66 | *DOA* † | Automatic death check (no bonus). Surviving: character is clinically dead for 1d6 rounds before CPR-equivalent revives them. All Attributes return to 1. Permanent: +3 Corruption, Empathy −1. | See Corruption chapter.
 |===
 
 ---
 
 === Mental & Emotional Critical Injury Table (D66)
 
-Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Resonance — the occult has left its mark.
+Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Corruption — the occult has left its mark.
 
-> *All mental criticals:* Gain *+1 Resonance* upon rolling this table, in addition to any listed in the individual result.
+> *All mental criticals:* Gain *+1 Corruption* upon rolling this table, in addition to any listed in the individual result.
 
 [%header,cols="^1,2,4,3"]
 |===
@@ -195,33 +195,33 @@ Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Reson
 | 32 | *Social Withdrawal* | −2 dice on all Empathy-based rolls. Character refuses social complexity. | Downtime social scene (roleplay) + Psychoanalyze (Difficulty 2).
 | 33 | *Survivor Guilt* | If any ally takes damage within the scene, character suffers 1 Empathy damage (involuntary). | Psychoanalyze (Difficulty 2) + meaningful roleplay scene.
 | 34 | *Paranoid Ideation* | Character believes a specific NPC or faction is surveilling them (GM chooses). Act on it: +1 die on Sneak actions. Suffer it: −1 die on Empathy rolls involving the believed threat. | Psychoanalyze campaign (2 downtime phases).
-| 35 | *Dissociative Identity Trigger* | +1 Resonance (additional). GM introduces an alternate behavioral state — twice per session, at dramatic moments, rolls a d6: 1–2 = alternate state this scene. | Psychoanalyze campaign (3 downtime phases, Difficulty 3).
+| 35 | *Dissociative Identity Trigger* | +1 Corruption (additional). GM introduces an alternate behavioral state — twice per session, at dramatic moments, rolls a d6: 1–2 = alternate state this scene. | Psychoanalyze campaign (3 downtime phases, Difficulty 3).
 | 36 | *Rage Episodes* | When Empathy falls below 2, character must succeed on Wits roll (Difficulty 2) or attack nearest person (ally or foe). | Psychoanalyze campaign (2 downtime phases, Difficulty 3).
-| 41 | *Artifact Resonance (Insight)* | +2 Resonance (additional). Permanent: *+1 die on all artifact interaction rolls* (you opened a channel). Permanent: −1 Empathy. | Cannot be recovered — this is the artifact's mark.
+| 41 | *Artifact Corruption (Insight)* | +2 Corruption (additional). Permanent: *+1 die on all artifact interaction rolls* (you opened a channel). Permanent: −1 Empathy. | Cannot be recovered — this is the artifact's mark.
 | 42 | *Phobia* | New phobia defined (GM and player): when triggered, automatic Fear check at Fear Rating 3. | Psychoanalyze campaign (3 downtime phases, Difficulty 3) reduces to Fear Rating 1.
 | 43 | *Waking Hallucinations* | Wits reduced by 1 permanently. Once per session, character perceives a supernatural intrusion that may or may not be real (GM only knows). | Keep's Empathy specialist can reduce severity; Wits loss is permanent.
 | 44 | *Emotional Bleed* | Permanently −1 Empathy. Character cannot form new meaningful bonds during campaign (no new Relationships — see Issue #17). | Cannot be healed. Existing Relationships remain.
 | 45 | *Fracture Point* | Corruption threshold reduced by 2 (permanently). Max Corruption = `8 + Empathy` instead of `10 + Empathy`. The exposure has cracked something fundamental. | Cannot be reversed.
-| 46 | *Catatonic Episode* † | Death check (mind, not body — failure = permanent catatonia, character retirement). Surviving: Wits and Empathy each reduced by 1. +2 Resonance immediately. | Intensive Psychoanalyze (Difficulty 4, Keep facility) over 2 downtime phases to stabilize.
+| 46 | *Catatonic Episode* † | Death check (mind, not body — failure = permanent catatonia, character retirement). Surviving: Wits and Empathy each reduced by 1. +2 Corruption immediately. | Intensive Psychoanalyze (Difficulty 4, Keep facility) over 2 downtime phases to stabilize.
 | 51 | *Obsessive Documentation* | Character must document everything (Insight: *+2 dice on Investigate* when reviewing notes from current mission). Compulsion: spends all available time writing; −1 die on social rolls (distracted). | Psychoanalyze campaign (3 downtime phases) to reduce compulsion; Insight remains.
 | 52 | *Broken Empathy* | Permanently −2 Empathy. All social skills lose 2 dice. | Cannot be healed — the connection is severed.
-| 53 | *Artifact Imprint* | +3 Resonance (additional). Character begins hearing the artifact that Broke them. GM may use this as a plot hook: the artifact calls them back. | Containment ritual (Issue #15) can suppress the call but not eliminate the imprint.
-| 54 | *Veil Burn* | +2 Resonance. Wits permanently −1. Insight: *+1 die on all artifact Resonance detection rolls* (you can feel them now). | Cannot be healed — the Veil has scorched your perception permanently.
-| 55 | *Shattered Will* † | Death check (mind). Surviving: Wits and Empathy max permanently reduced by 1 each. +2 Resonance. Cannot push rolls for remainder of campaign arc until psychological breakthrough (GM milestone). | Keep Psychoanalyze program (4 downtime phases, Difficulty 4).
-| 56 | *Cosmic Revelation* † | Death check (mind). Surviving: character learns something true and terrible about the Covenant's mission or the nature of artifacts. +3 Resonance, −2 Empathy permanently. Insight: *+2 dice on all Lore-type rolls forever* (Wayfinder skill equivalent). GM defines the revelation — it should reshape how the character sees the world. | Cannot be unlearned. Roleplay is mandatory.
+| 53 | *Artifact Imprint* | +3 Corruption (additional). Character begins hearing the artifact that Broke them. GM may use this as a plot hook: the artifact calls them back. | Containment ritual (Issue #15) can suppress the call but not eliminate the imprint.
+| 54 | *Veil Burn* | +2 Corruption. Wits permanently −1. Insight: *+1 die on all artifact detection rolls* (you can feel them now). | Cannot be healed — the Veil has scorched your perception permanently.
+| 55 | *Shattered Will* † | Death check (mind). Surviving: Wits and Empathy max permanently reduced by 1 each. +2 Corruption. Cannot push rolls for remainder of campaign arc until psychological breakthrough (GM milestone). | Keep Psychoanalyze program (4 downtime phases, Difficulty 4).
+| 56 | *Cosmic Revelation* † | Death check (mind). Surviving: character learns something true and terrible about the Covenant's mission or the nature of artifacts. +3 Corruption, −2 Empathy permanently. Insight: *+2 dice on all Lore-type rolls forever* (Wayfinder skill equivalent). GM defines the revelation — it should reshape how the character sees the world. | Cannot be unlearned. Roleplay is mandatory.
 | 61 | *Memory Dissolution* | Permanently −1 Wits. Character loses one specific skill memory (GM chooses a skill at rank 1–2; it drops to 0). | Cannot recover lost skill without retraining (requires downtime advancement, Issue #2).
 | 62 | *Identity Crisis* | Character's Division Allegiance wavers. For 1 campaign arc, they cannot use their Division Talent. | Major roleplay scene with Covenant superior + Psychoanalyze (Difficulty 3).
-| 63 | *Veil Madness* | +4 Resonance immediately. Corruption check triggered. Roll on this table *again* (ignore result 63 on reroll). | As per second roll result.
-| 64 | *Prophetic Fugue* † | Death check (mind). Surviving: +3 Resonance. Character enters a trance broadcasting the Covenant's location to hostile artifact entities until a Wayfinder performs a Shielding ritual (Issue #15). | Ritual seals the broadcast; Resonance remains.
-| 65 | *Ego Death* † | Death check (mind). Surviving: character personality fundamentally alters. Player rewrites one core Relationship and one Drive. +3 Resonance. Insight: *+2 dice on all Empathy rolls* (dissolution breeds radical compassion — or fearlessness). | Cannot be undone. Roleplay the new self.
-| 66 | *Unraveling* † | Automatic mind death check (no bonus). Surviving: +4 Resonance, −1 to every Attribute permanently, character retires at end of current mission (they cannot continue as an operative). Final scene before retirement should be played. | Retirement is farewell — play it well.
+| 63 | *Veil Madness* | +4 Corruption immediately. Roll on this table *again* (ignore result 63 on reroll). | As per second roll result.
+| 64 | *Prophetic Fugue* † | Death check (mind). Surviving: +3 Corruption. Character enters a trance broadcasting the Covenant's location to hostile artifact entities until a Wayfinder performs a Shielding ritual (Issue #15). | Ritual seals the broadcast; Corruption remains.
+| 65 | *Ego Death* † | Death check (mind). Surviving: character personality fundamentally alters. Player rewrites one core Relationship and one Drive. +3 Corruption. Insight: *+2 dice on all Empathy rolls* (dissolution breeds radical compassion — or fearlessness). | Cannot be undone. Roleplay the new self.
+| 66 | *Unraveling* † | Automatic mind death check (no bonus). Surviving: +4 Corruption, −1 to every Attribute permanently, character retires at end of current mission (they cannot continue as an operative). Final scene before retirement should be played. | Retirement is farewell — play it well.
 |===
 
 ---
 
 === Cross-References
 
-* *Resonance gain* from mental criticals triggers a Corruption Check (see `docs/chapters/07-resonance-corruption.adoc`).
+* *Corruption gain* from mental criticals is applied immediately (see `docs/chapters/07-resonance-corruption.adoc`).
 * *Healing in the field:* First Aid Kit, Heal skill, Psychoanalyze skill — see `docs/chapters/08-skills.adoc` _(Issue #7)_.
 * *Downtime recovery:* Between-mission phases and Keep medical access — see `docs/chapters/09-base-management.adoc` _(Issue #12)_.
 * *Death and dying procedure:* Full death check rules with autopsy and Covenant notification — see _(Issue #13)_.
@@ -276,7 +276,7 @@ Each Condition has: a *name*, the *penalty* it imposes, how it is *applied*, and
 
 | *Deafened*
 | −1 die on Investigate. Cannot hear verbal communication — Manipulate and Command spoken rolls are impossible. May miss reactive cues (ambush, incoming threat).
-| Gunfire in enclosed space (GM discretion after extended firefight), specific artifact resonance pulse, explosive detonation.
+| Gunfire in enclosed space (GM discretion after extended firefight), specific artifact corruption pulse, explosive detonation.
 | Automatic after scene ends, or rest (next scene at full function).
 
 | *Burning*
@@ -305,8 +305,8 @@ Each Condition has: a *name*, the *penalty* it imposes, how it is *applied*, and
 | Anchor scene (roleplay connection with a Relationship NPC; see Issue #17). Rest (one full scene of safety). Successful Psychoanalyze roll by an ally (Difficulty = Fear Rating of the trigger; minimum Difficulty 1).
 
 | *Haunted*
-| Gain 1 Resonance at the start of each scene (before any rolls). Character hears, sees, or senses the source of the Haunting even when alone.
-| Specific supernatural encounters with unresolved resonance. Artifact Imprint (Critical Injury, result 53). Uncontained artifact proximity during sleep (GM discretion).
+| Gain +1 Corruption at the start of each scene (before any rolls). Character hears, sees, or senses the source of the Haunting even when alone.
+| Specific supernatural encounters with unresolved occult energy. Artifact Imprint (Critical Injury, result 53). Uncontained artifact proximity during sleep (GM discretion).
 | Containment Ritual performed by a Wayfinder (Issue #15). Recovery in a Covenant-sanctioned safe house for the full downtime phase. Specific Psychoanalyze campaign (3 downtime phases, Difficulty 3) suppresses but does not eliminate — ritual is required for full removal.
 
 | *Paranoid*
@@ -320,8 +320,8 @@ Each Condition has: a *name*, the *penalty* it imposes, how it is *applied*, and
 | Ally uses Psychoanalyze (Difficulty 1, Slow Action) to restore presence. Otherwise fades at end of scene.
 
 | *Compromised*
-| The character's Corruption threshold is treated as 2 lower than current for this scene only. Corruption checks during this scene are made at +1 die for the GM (more likely to accumulate).
-| Extended artifact contact without containment protocol. Veil Burn (Critical Injury, result 54). Resonance Tap (Shard Construct, Bestiary). Specific rival faction abilities.
+| The character's Corruption threshold is treated as 2 lower than current for this scene only. All Corruption gained during this scene is increased by +1 (each source gives an additional +1 Corruption).
+| Extended artifact contact without containment protocol. Veil Burn (Critical Injury, result 54). Corruption Tap (Shard Construct, Bestiary). Specific rival faction abilities.
 | Scene ends. The threshold reduction resets automatically. The underlying Corruption accumulation remains.
 
 |===

--- a/docs/chapters/07-resonance-corruption.adoc
+++ b/docs/chapters/07-resonance-corruption.adoc
@@ -1,36 +1,28 @@
-= Resonance and Corruption
+= Corruption
 
-Project Neon Relic introduces the unified *Resonance and Corruption* system — the game's signature mechanic. This creates an "inverse hit points" loop where the pursuit of occult power is inherently self-destructive and psychologically corrosive.
+*Corruption* is Neon Relic's signature mechanic — a single ascending number that tracks the cumulative psychic toll of occult exposure, supernatural exertion, and sheer human desperation. It functions as an "inverse hit points" system: every push, every artifact activation, every encounter with the unnatural ratchets the number higher, and there is no coming back from the top.
 
-== The Nature of Resonance
+== The Corruption Track
 
-*Resonance* represents the volatile, metaphysical static accumulating within a character's nervous system. It is a necessary resource to fuel supernatural Talents and activate artifacts, but hoarding it accelerates a character's demise.
-
-Resonance points are acquired through:
-
-[%header,cols="2,1,4"]
-|===
-| Trigger | Resonance Gained | Description
-
-| *Pushing a Roll* | 1 | Exerting your absolute limits directly invites anomalous static.
-| *Occult Exposure* | 1–2 | Witnessing supernatural entities, reading forbidden tomes, or being targeted by anomalous phenomena.
-| *Activating Artifacts* | 1–3 | Utilizing the supernatural properties of a Resonant Artifact. Cost varies by artifact tier.
-|===
-
-== The Corruption Track (The Doom Clock)
-
-Instead of rolling on a randomized trauma table, *Corruption is tracked cumulatively*, functioning like inverse hit points that slowly build toward a catastrophic break.
+Corruption starts at *0* and increases from there. There is no separate "Resonance pool," no volatile buffer, and no cascade check — Corruption is gained directly from its sources and healed by its methods.
 
 *Maximum Corruption Threshold* = `10 + Empathy score`
 
-When a character witnesses something truly mind-breaking or utilizes a cursed artifact, the GM calls for a *Corruption Check*. This is _not_ a dice roll — the character's lingering Resonance cascades into permanent psychological decay:
+When a character's Corruption *exceeds* their threshold, their mind permanently fractures. The character enters a catatonic state and is *immediately removed from the campaign*.
 
-[quote]
-____
-*New Corruption Level* = Current Corruption + Current Resonance
-____
+== Sources of Corruption
 
-This creates a terrifying escalation. If a character pushes multiple rolls and hoards 4 Resonance points, their first Corruption Check jumps their score by 4. If they don't clear their Resonance, the next check jumps it by another 4. As Resonance grows, the speed at which the character hurtles toward their threshold *multiplies*.
+[%header,cols="2,1,4"]
+|===
+| Trigger | Corruption Gained | Description
+
+| *Pushing a Roll* | +1 | Exerting your absolute limits invites psychic static.
+| *Activating a Division Talent* | +1 | Talents that tap the supernatural exact a cost.
+| *Occult Exposure* | +1 to +3 | Witnessing entities, reading forbidden tomes, or being targeted by anomalous phenomena. GM sets severity.
+| *Artifact Activation* | +1 to +3 | Utilizing an artifact's supernatural properties. Cost varies by artifact tier.
+| *Fear Check (any 1s rolled)* | +1 | The mind cracks trying to process the unprocessable. See Fear rules below.
+| *Failed Fear Check* | +1 | On top of any 1s penalty. See Fear rules below.
+|===
 
 == Corruption Effects
 
@@ -46,13 +38,26 @@ This creates a terrifying escalation. If a character pushes multiple rolls and h
 | *Exceeds Threshold* | *Catatonic Revelation* | The character's mind completely breaks upon perceiving the underlying, terrifying geometry of the universe. Permanent catatonic state. *Immediately removed from the campaign.*
 |===
 
+== Healing Corruption
+
+[%header,cols="2,3,3"]
+|===
+| Method | Effect | Requirements
+
+| *Anchor Scene* | Heal *1d4 Corruption* | Once per session. Dedicate a scene to interacting with your Anchor.
+| *Full Rest (24 hours)* | Heal Corruption equal to *Empathy score* | Full 24-hour cycle resting in a secure, non-anomalous location (e.g., Covenant HQ).
+| *Healing Talents* | Varies by talent | See Division Talents and General Talents marked with _(Healing)_.
+|===
+
+> *Design note:* Corruption healing is intentionally slow. An agent with Empathy 3 heals 3 Corruption per full day of rest — but gaining 3+ Corruption in a single scene is easy. The economy is deliberately asymmetric: you gain faster than you heal, and the only way to stay safe is to make fewer desperate choices.
+
 ---
 
 == Fear Mechanics
 
 The Corruption track governs the long arc of psychological decay. *Fear* governs the acute, in-the-moment terror of direct supernatural confrontation — the thing that happens to your body and your mind in the next thirty seconds when the entity looks at you.
 
-Fear and Corruption are linked: failed Fear checks generate Resonance, and Resonance amplifies Corruption checks. A single terrifying encounter can compress weeks of accumulated pressure into one scene.
+Fear and Corruption are directly linked: Fear checks that produce 1s on the dice generate Corruption, and failed Fear checks generate additional Corruption plus a panic response. A single terrifying encounter can spike Corruption in a way that takes days of rest to undo.
 
 === What Triggers a Fear Check
 
@@ -75,12 +80,12 @@ The GM calls for a Fear check when a character directly confronts a source of ge
 
 . *The GM states the entity's Fear Rating* (a number from 1 to 5) or notes that the event is a flat Fear 2 or Fear 3 trigger (see Fear Rating table below).
 . *The character rolls Wits dice* equal to their current *Wits attribute* (no skill modifier — Fear is instinctual, not trained).
-. *Count failures:* For every die that shows a *1*, the character takes *1 point of Wits damage* AND gains *1 Resonance point*.
+. *Count 1s:* For every die that shows a *1*, the character takes *1 point of Wits damage*. If *any* 1s were rolled, the character also gains *+1 Corruption* (only one, regardless of how many 1s appeared).
 . *Count the Fear Rating as a threshold:* If the total number of non-6 dice equals or exceeds the Fear Rating, the character is *Shaken* (see below) even if they took no Wits damage.
 
 > *Why Wits?* Fear strikes the rational, pattern-recognizing mind first. The brain tries to *explain* what the eyes are seeing — and fails. Empathy governs emotional horror (grief, bargaining, despair); that comes later, through the Corruption track.
 
-> *Why 1s specifically?* In the YZE framework, 1s on Attribute dice represent self-harm — the cost of pushing your own limits. On a Fear check, 1s represent the moment the mind cracks trying to process the unprocessable. This is cognitively consistent with the push mechanic.
+> *Why 1s?* In the YZE framework, 1s on Attribute dice represent self-harm — the cost of pushing your own limits. On a Fear check, 1s represent the moment the mind cracks trying to process the unprocessable.
 
 === Fear Ratings
 
@@ -107,13 +112,13 @@ A character who rolls a Fear check and has *more non-6 results than successes* (
 * Cannot voluntarily move toward the source of Fear (they can hold position or retreat).
 * Can be *snapped out of it* by an ally spending a slow action and succeeding on a Psychoanalyze roll (difficulty: Fear Rating of the trigger).
 
-Shaken is not a condition that persists between scenes — it represents immediate shock, not lasting damage. Lasting damage is Wits loss and Resonance gain.
+Shaken is not a condition that persists between scenes — it represents immediate shock, not lasting damage. Lasting damage is Wits loss and Corruption gain.
 
-=== Resonance Generation from Fear
+=== Corruption Generation from Fear
 
-Each point of Wits damage taken from a Fear check generates *1 Resonance point*. This is cumulative with any Resonance gained from pushing rolls in the same scene.
+Each Fear check that includes *any dice showing 1* generates *+1 Corruption* for the character. This is in addition to Wits damage from those same 1s, and in addition to any Corruption gained from pushing rolls in the same scene.
 
-> *Design Note:* This is the Resonance-Fear link that makes supernatural encounters mechanically distinct from physical combat. A fistfight reduces Strength. A Fear check reduces Wits *and* raises Resonance — which raises the Corruption check multiplier — which narrows your Corruption threshold. The more frightened you are, the closer to the edge you slide. This is the intended spiral.
+> *Design Note:* This is the Corruption-Fear link that makes supernatural encounters mechanically distinct from physical combat. A fistfight reduces Strength. A Fear check reduces Wits *and* raises Corruption — which narrows the gap to the Corruption threshold. The more frightened you are, the closer to the edge you slide. This is the intended spiral.
 
 === Pushing a Fear Check
 
@@ -128,9 +133,9 @@ Several mechanics interact with Fear:
 | Mechanic | Effect on Fear
 
 | *Academic Grounding* (Wayfinder Talent) | After 1 hour of research on a specific entity type, reduce its effective Fear Rating by 1 (min 1) for the rest of the session for the Wayfinder only.
-| *The Confessor* (Keep Talent) | After using this talent to clear Resonance, the next Fear check this session is made with *+2 bonus dice*.
-| *Anchor (Memento)* | Using an Anchor during downtime has no direct Fear resistance — but clearing Resonance before an encounter lowers the Corruption cascade from a failed check.
-| *Empathy attribute* | Empathy does not reduce Fear checks directly, but it sets the Max Corruption Threshold — a high-Empathy character can sustain more Resonance before the cascade becomes lethal.
+| *The Confessor* (Keep Talent) | After using this talent to heal Corruption, the next Fear check this session is made with *+2 bonus dice*.
+| *Anchor (Memento)* | Using an Anchor during downtime heals Corruption directly — lowering your total before the next encounter.
+| *Empathy attribute* | Empathy sets the Max Corruption Threshold — a high-Empathy character can sustain more Corruption before the threshold is reached.
 | *Familiarity* | If a character has *previously survived a Fear check* against the same entity type without breaking, future checks against the same type are made with *+1 bonus die*. Familiarity is per entity type, not per individual entity.
 |===
 
@@ -150,7 +155,7 @@ If a Fear check reduces a character's Wits to *0*, they are *Broken* — and the
 | *6* | *Fugue* | The player hands the GM their character sheet. The GM narrates what the character does for the rest of the scene. This may include wandering, speaking to things that aren't there, or following the entity. The player regains control at the *start of the next scene*, not the next round.
 |===
 
-> *Recovering from Broken (Wits 0):* After the scene ends, the character's Wits return to 1 automatically — they are no longer Broken but they are severely shaken. Full Wits recovery follows normal healing rules. A character Broken by Fear also triggers a *Corruption Check* immediately when the scene ends (not during — there's no moment for reflection mid-crisis).
+> *Recovering from Broken (Wits 0):* After the scene ends, the character's Wits return to 1 automatically — they are no longer Broken but they are severely shaken. Full Wits recovery follows normal healing rules. A character Broken by Fear also gains *+1 Corruption* immediately when the scene ends.
 
 === Fear vs. Standard Wits Damage
 
@@ -161,57 +166,13 @@ A direct psychic assault from an entity, an artifact feedback, or a targeted sup
 | | *Fear Check* | *Direct Wits Damage*
 
 | *Trigger* | Sensory confrontation with supernatural horror | Targeted attack or artifact effect
-| *Mechanism* | Roll Wits dice; 1s deal damage + Resonance | Damage is applied directly (no roll, or attacker rolls)
-| *Resonance generated?* | *Yes* — 1 per Wits damage | *No* — unless the character chooses to push a resistance roll
+| *Mechanism* | Roll Wits dice; 1s deal damage + Corruption | Damage is applied directly (no roll, or attacker rolls)
+| *Corruption generated?* | *Yes* — +1 if any 1s are rolled | *No* — unless the character chooses to push a resistance roll
 | *Shaken?* | Possibly (roll-dependent) | No (unless effect says so)
 | *Pushable?* | *No* | Yes (standard push rules)
 | *Panic table?* | Yes, if Wits reaches 0 | Yes, if Wits reaches 0 (same table)
 |===
 
-> The key difference is *Resonance generation*. A possessed agent using a mental attack is doing tactical damage. Standing in the presence of something that should not exist and having your mind try to process it is existentially corrosive in a way combat is not.
+> The key difference is *Corruption generation*. A possessed agent using a mental attack is doing tactical damage. Standing in the presence of something that should not exist and having your mind try to process it is existentially corrosive in a way combat is not.
 
----
 
-== Design Decision: Resonance vs. Willpower
-
-=== The Question
-
-Three structural options were evaluated for how to handle mental stress and supernatural pressure:
-
-*Option A — Resonance as a standalone volatile resource (current design)*
-
-Resonance is a separate track, not attached to any Attribute. It accumulates from pushing rolls, occult exposure, and artifact use, and cascades into Corruption on a Corruption Check.
-
-*Option B — Fold Resonance into a Willpower Attribute*
-
-Add a fifth Attribute (Willpower) that serves as both the mental stress pool and the Resonance equivalent. Resonance would be Willpower damage.
-
-*Option C — Two-layer system: Stress + Resonance*
-
-Mundane mental pressure (fear of death, loss) tracked as Stress; supernatural exposure tracked as Resonance. Corruption Check only triggers from Resonance.
-
-=== The Decision: Option A (with clarifications)
-
-*Resonance is kept as a standalone volatile resource.* It is the game's signature mechanic and unique selling point.
-
-The concerns about redundancy (Option B) and complexity (Option C) are resolved by clarifying what Resonance *already does*:
-
-. *Resonance is already the mental stress track.* It is generated by pushing rolls (exertion/desperation), fear checks (psychological trauma), and occult exposure (supernatural horror). It does not need a parallel Stress track because those three triggers cover the full range of in-fiction pressure.
-
-. *Resonance is not Willpower damage because it is not an Attribute.* It can exceed any natural cap. The volatility of Resonance — it can spike suddenly, it can be cleared, it compounds exponentially on Corruption Checks — is intentional. An Attribute damage model would flatten this dynamic.
-
-. *Decoupling from stats is thematically correct.* Resonance is not a measure of your character's resilience (that's Wits and Empathy). It is a measure of what the universe has left on them. Two characters with identical Wits can have wildly different Resonance levels based on the choices they made, the artifacts they used, and when they last had time to clear. That asymmetry is the design goal.
-
-=== Implications for Push Roll Consequences
-
-This decision has one implication that must be stated clearly in chapter 04 (Core Mechanics) and enforced at the table:
-
-*Pushing a roll always costs 1 Resonance.* There is no push consequence table, no gear-or-stress choice, no optional complication. The cost is Resonance. Always. This keeps the system elegant and keeps every push decision meaningful in the same currency.
-
-The exception: *gear degradation* on pushed gear rolls is a separate consequence (the item may break) but it does not replace the Resonance cost — it is additional.
-
-=== Why Not Option C?
-
-Option C (Stress + Resonance) was rejected because it would require GMs and players to constantly classify sources of pressure as 'mundane' or 'supernatural' — and in an occult investigation game, that boundary is almost never clean. The first time a player argues about whether watching their colleague die on a non-supernatural mission generates Stress or Resonance, the table loses 10 minutes to a rules discussion that should have been a scene.
-
-Resonance handles both. Its lack of supernatural specificity is a feature: *the universe does not care about intent*.

--- a/docs/chapters/08-healing.adoc
+++ b/docs/chapters/08-healing.adoc
@@ -1,6 +1,6 @@
 = Healing: Anchors, Talents, and Rest
 
-Because Corruption and Resonance naturally build to lethal levels, characters must actively seek to heal their psychological wounds.
+Because Corruption naturally builds toward lethal levels, characters must actively seek to heal their psychological wounds.
 
 == Methods of Recovery
 
@@ -8,8 +8,8 @@ Because Corruption and Resonance naturally build to lethal levels, characters mu
 |===
 | Method | Effect | Requirements
 
-| *All-Day Rest* | Clears Resonance pool to 0. Heals 1 Corruption. | Full 24-hour cycle resting in a secure, non-anomalous location (e.g., Covenant HQ).
-| *Anchor (Memento)* | Heals 1d4 Corruption _or_ clears entire Resonance pool. | Once per session. Dedicate a scene to interacting with your Anchor.
+| *Full Rest (24 hours)* | Heals Corruption equal to *Empathy score*. | Full 24-hour cycle resting in a secure, non-anomalous location (e.g., Covenant HQ).
+| *Anchor (Memento)* | Heals *1d4 Corruption*. | Once per session. Dedicate a scene to interacting with your Anchor.
 | *Healing Talents* | Varies by Talent. | See Division Talents and General Talents marked with _(Healing)_.
 |===
 

--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -2,7 +2,7 @@
 
 In Project Neon Relic, players are sworn members of *The Verdant Covenant*. Because no single person possesses the brains, brawn, network, and magical guardianship required to hunt dangerous artifacts, players choose a *Division* (their core class) which dictates their starting attributes, skills, and Clearance Level (CL).
 
-Within that Division, players select a *Department* background. During creation, they may select one of the 5 unique *Division Talents*. These Talents operate similarly to magic systems — they guarantee a supernatural or highly specialized effect but require the expenditure of Resonance to activate, feeding directly into the game's risk-reward loop.
+Within that Division, players select a *Department* background. During creation, they may select one of the 5 unique *Division Talents*. These Talents operate similarly to magic systems — they guarantee a supernatural or highly specialized effect but cost +1 Corruption to activate, feeding directly into the game’s risk-reward loop.
 
 == Division 1: The Wayfinder
 
@@ -67,11 +67,11 @@ Through the vigilance of the Department of Counterintelligence, the Covenant ens
 |===
 | Talent | Cost | Effect
 
-| *The Antiquarian's Eye* | 1 Resonance | Instantly identify an artifact's primary activation trigger and base effect without a Lore roll.
-| *Ghost in the Machine* | 1 Resonance | Use Tech to directly interface with electronic devices jammed or possessed by anomalous entities.
-| *The Hunch* | 1 Resonance | Ask the GM one yes/no question about a crime scene or NPC's motive. The GM must answer truthfully.
+| *The Antiquarian's Eye* | +1 Corruption | Instantly identify an artifact's primary activation trigger and base effect without a Lore roll.
+| *Ghost in the Machine* | +1 Corruption | Use Tech to directly interface with electronic devices jammed or possessed by anomalous entities.
+| *The Hunch* | +1 Corruption | Ask the GM one yes/no question about a crime scene or NPC's motive. The GM must answer truthfully.
 | *Academic Grounding* _(Healing)_ | — | Spend an hour researching an entity and framing it in academic terms. Heal 1 Corruption for yourself or one ally.
-| *Eldritch Empathy* | 1 Resonance | Sense the immediate emotional state, hunger, or primary intent of an invisible or disguised supernatural entity.
+| *Eldritch Empathy* | +1 Corruption | Sense the immediate emotional state, hunger, or primary intent of an invisible or disguised supernatural entity.
 |===
 
 == Division 2: The Recovery
@@ -130,9 +130,9 @@ Choose one background that defines your agent's prior experience:
 |===
 | Talent | Cost | Effect
 
-| *Conditioned Mind* | — | Once per session, entirely ignore the Resonance point generated from pushing a roll.
-| *Unstoppable Force* | 1 Resonance | Your next successful melee or unarmed attack inflicts +2 damage.
-| *Shadow Walker* | 1 Resonance | Become entirely imperceptible to mundane guards or cameras for a scene, provided you do not attack.
+| *Conditioned Mind* | — | Once per session, entirely ignore the Corruption point generated from pushing a roll.
+| *Unstoppable Force* | +1 Corruption | Your next successful melee or unarmed attack inflicts +2 damage.
+| *Shadow Walker* | +1 Corruption | Become entirely imperceptible to mundane guards or cameras for a scene, provided you do not attack.
 | *Adrenaline Junkie* | — | When you have a −1 penalty to Strength, gain +2 bonus dice to all Agility rolls.
 | *Gallows Humor* _(Healing)_ | — | Once per session, after surviving a combat encounter, crack a dark joke. You and all allies who hear you heal 1d4 Corruption.
 |===
@@ -163,7 +163,7 @@ All Keepers wear the *Warden's Bracer*, marking them as guardians of the Covenan
 * Suppresses artifact magic in close proximity
 * Warns the wearer if containment fails
 * Allows safe handling of cursed objects
-* Absorbs Resonance (soaks 1 Resonance per session)
+* Absorbs Corruption (soaks 1 Corruption per session)
 * Grants *+1 to Armor Rating*
 
 === Keep Departments
@@ -199,11 +199,11 @@ Working in coordination with the Wayfinder Division's Department of Counterintel
 |===
 | Talent | Cost | Effect
 
-| *Containment Protocol* | 1 Resonance | Quickly improvise a ward using mundane materials (salt, copper wire). Any supernatural entity must make a Hard (−2) roll to cross it.
-| *Shield of the Covenant* | 1 Resonance | When an ally within Engaged range is attacked, automatically step in front of the blow. Take the damage but halve its severity.
-| *The Inquisitor's Gaze* | 1 Resonance | While conversing with someone, instantly know their current Corruption score and whether they are possessed.
+| *Containment Protocol* | +1 Corruption | Quickly improvise a ward using mundane materials (salt, copper wire). Any supernatural entity must make a Hard (−2) roll to cross it.
+| *Shield of the Covenant* | +1 Corruption | When an ally within Engaged range is attacked, automatically step in front of the blow. Take the damage but halve its severity.
+| *The Inquisitor's Gaze* | +1 Corruption | While conversing with someone, instantly know their current Corruption score and whether they are possessed.
 | *Sanctuary Master* | — | When inside Covenant HQ, automatically succeed on any Wits (Lore) roll regarding the history of a contained artifact.
-| *The Confessor* _(Healing)_ | — | Spend a quiet moment listening to an ally confess their Dark Secret. Both you and the ally clear your Resonance pools entirely.
+| *The Confessor* _(Healing)_ | — | Spend a quiet moment listening to an ally confess their Dark Secret. Both you and the ally heal *1d4 Corruption*.
 |===
 
 [[division-4-stack]]
@@ -248,9 +248,9 @@ Stack agents design, modify, and distribute the tools used by Covenant agents �
 |===
 | Talent | Cost | Effect
 
-| *Requisition Expert* | 1 Resonance | During the Equipping Phase, automatically acquire any one non-artifact item, bypassing the CL roll entirely.
-| *Jury-Rig* | 1 Resonance | Immediately restore a broken or degraded piece of gear to maximum bonus during combat or a high-tension scene.
-| *Prototyper* | 1 Resonance | Grant a piece of mundane gear an Artifact Die (d8) for a single skill roll. The item is permanently destroyed immediately after.
+| *Requisition Expert* | +1 Corruption | During the Equipping Phase, automatically acquire any one non-artifact item, bypassing the CL roll entirely.
+| *Jury-Rig* | +1 Corruption | Immediately restore a broken or degraded piece of gear to maximum bonus during combat or a high-tension scene.
+| *Prototyper* | +1 Corruption | Grant a piece of mundane gear an Artifact Die (d8) for a single skill roll. The item is permanently destroyed immediately after.
 | *Duct Tape & WD-40* _(Healing)_ | — | Spend a Shift at base tinkering. Automatically repair all degraded gear for the entire party without a roll, and heal 1 Corruption.
-| *Experimental Shielding* | 1 Resonance | Once per session, completely ignore the degradation penalty of rolling a 1 on a Gear Die.
+| *Experimental Shielding* | +1 Corruption | Once per session, completely ignore the degradation penalty of rolling a 1 on a Gear Die.
 |===

--- a/docs/chapters/10-advancement.adoc
+++ b/docs/chapters/10-advancement.adoc
@@ -85,7 +85,7 @@ Experience Points (XP) are awarded at the end of each Case File through a struct
 | 1 | Did you participate in the session? _(Automatic +1 XP)_
 | 2 | Did you risk your life for a fellow Covenant member or an innocent civilian?
 | 3 | Did your Dark Secret complicate the mission, or did you heavily interact with your Anchor?
-| 4 | Did the team successfully secure or contain a Resonant Artifact?
+| 4 | Did the team successfully secure or contain an Occult Artifact?
 | 5 | Did you learn something new and significant about the supernatural threat or rival factions?
 |===
 
@@ -114,7 +114,7 @@ General Talents are specialized perks available to *any character*, providing me
 | *Heavy Packer* | Carry items equal to twice your Strength without becoming encumbered.
 | *Skeptic's Shield* | Once per session, outright ignore a minor supernatural effect by rigidly refusing to acknowledge the impossible.
 | *Night Owl* | Ignore all penalties from sleep deprivation. Operate perfectly in the dark.
-| *Chain Smoker* _(Healing)_ | Consume a scarce resource (cigarette, specific 80s junk food) during stress. Clear 1 Resonance.
+| *Chain Smoker* _(Healing)_ | Consume a scarce resource (cigarette, specific 80s junk food) during stress. Heal 1 Corruption.
 | *Analog Junkie* | Gain +2 Gear dice when using period-accurate 1980s technology (ham radios, acoustic couplers, microfiche).
 | *Grit Your Teeth* | Once per session, ignore a −1 Attribute penalty for a single critical roll.
 | *Desensitized* | Gain +1 bonus die to all Empathy rolls when dealing with horrific or gruesome crime scenes.

--- a/docs/chapters/11-equipment.adoc
+++ b/docs/chapters/11-equipment.adoc
@@ -280,7 +280,7 @@ Both sides roll simultaneously. The side with more successes moves the Contact T
 * Each speed tier below the opponent's: −1 die on the chase roll.
 * Handling bonus/penalty applies directly to the roll.
 
-*Pushing a chase roll:* +1 Resonance as normal. The vehicle also takes 1 Wear immediately (the driver is wringing everything out of it).
+*Pushing a chase roll:* +1 Corruption as normal. The vehicle also takes 1 Wear immediately (the driver is wringing everything out of it).
 
 ==== Vehicle Maneuvers
 
@@ -346,7 +346,7 @@ a **1**. Gear degrades one step down the die chain (d12 → d10 → d8 → d6 �
 Broken). A **Broken** item cannot be used until repaired.
 
 > Stack Division Talent *Jury-Rig* can restore a broken item mid-scene at the cost
-> of 1 Resonance. Formal repair rules below handle everything else.
+> of +1 Corruption. Formal repair rules below handle everything else.
 
 ---
 

--- a/docs/chapters/12-artifacts.adoc
+++ b/docs/chapters/12-artifacts.adoc
@@ -2,19 +2,19 @@
 
 In an occult thriller setting, artifacts are fundamentally dangerous — objects of immense, unknowable power that exact a heavy toll on the human mind and physical reality. Project Neon Relic leans heavily into the *"Artifact of Doom"* narrative trope, ensuring that utilizing magic is always a terrifying gamble.
 
-== The Mechanics of Resonant Artifacts
+== The Mechanics of Occult Artifacts
 
-Within the YZE system, mystical objects are classified as *Resonant Artifacts*. They often appear entirely mundane — a vintage Polaroid camera, a rusted World War I trench lighter, a tarnished silver coin — but are imbued with intense paranatural energy.
+Within the YZE system, mystical objects are classified as *Occult Artifacts*. They often appear entirely mundane — a vintage Polaroid camera, a rusted World War I trench lighter, a tarnished silver coin — but are imbued with intense paranatural energy.
 
 To utilize an artifact, a character must trigger its specific *activation condition* (e.g., speaking a phrase in a dead language, feeding it a drop of blood, or playing a specific frequency). Artifacts function in two interdependent ways:
 
 . *Overwhelming Power* — The artifact allows an action far outside normal human capability: viewing past events, turning invisible, commanding the undead, or dealing massive unblockable damage to supernatural entities.
 
-. *The Psychological Toll* — Every activation immediately generates *1–3 Resonance* (by artifact tier), pushing the user closer to a Corruption Check.
+. *The Psychological Toll* — Every activation immediately generates *+1 to +3 Corruption* (by artifact tier), pushing the user closer to the Corruption threshold.
 
 Furthermore, when invoked, the player rolls a specific *Artifact Die* (d8, d10, or d12). If the roll results in a *1*, the artifact's internal metaphysical structure fractures — it may break, go dormant, or trigger a horrific localized side-effect.
 
-== Catalog of 1980s Resonant Artifacts
+== Catalog of 1980s Occult Artifacts
 
 [%header,cols="2,2,3,3"]
 |===
@@ -23,46 +23,46 @@ Furthermore, when invoked, the player rolls a specific *Artifact Die* (d8, d10, 
 | *The Betamax of St. Jude*
 | Degraded Betamax tape in unmarked black sleeve.
 | Displays the immediate 10-minute future when played on a VCR. Auto-success on any opposed Wits or Agility roll in the current scene.
-| *2 Resonance.* VCR combusts; user temporarily blinded by visions of their own death.
+| *2 Corruption.* VCR combusts; user temporarily blinded by visions of their own death.
 
 | *The Obsidian Walkman*
 | Heavy, modified Sony cassette player with stone-like casing.
 | Hear the ambient frequencies of the dead. Communicate with spirits to discover hidden clues or bypass Investigation rolls.
-| *1 Resonance.* User deafened by psychic static; gains permanent phobia of silence.
+| *1 Corruption.* User deafened by psychic static; gains permanent phobia of silence.
 
 | *The Oppenheimer Lens*
 | Aviator sunglasses with fused desert-glass lenses.
 | See the true monstrous forms of entities hiding in human guises. Pierce all supernatural illusions.
-| *1 Resonance.* Lenses shatter; shards cause 1 permanent Agility damage.
+| *1 Corruption.* Lenses shatter; shards cause 1 permanent Agility damage.
 
 | *The Judas Coin*
 | Heavy silver denarius, unnaturally warm.
 | Target overwhelmed by greed or guilt during social interaction. Auto-success on Empathy (Manipulate).
-| *2 Resonance.* Coin burns through user's flesh (1 physical damage); target becomes violently hostile.
+| *2 Corruption.* Coin burns through user's flesh (1 physical damage); target becomes violently hostile.
 
 | *The Chronos Polaroid*
 | Polaroid SX-70 camera smelling of ozone.
 | Photographs a location as it appeared 24 hours prior. Bypasses tracking or forensic analysis.
-| *1 Resonance.* Flash acts as beacon, alerting nearest supernatural entity to party's exact location.
+| *1 Corruption.* Flash acts as beacon, alerting nearest supernatural entity to party's exact location.
 |===
 
 ---
 
-== Artifact Carry Weight and Resonance Pressure
+== Artifact Carry Weight and Corruption Pressure
 
 Artifacts are not merely heavy objects — they exert *metaphysical pressure* on the agent carrying them. This interacts with the Encumbrance system in two ways:
 
 === Physical Weight
 
-Each artifact has a baseline Encumbrance value equal to its *Resonance cost tier*:
+Each artifact has a baseline Encumbrance value equal to its *Corruption cost tier*:
 
 [%header,cols="^1,^1,3"]
 |===
 | Artifact Tier | Enc. | Notes
 
-| Low (1 Resonance) | 1 | Small objects: a coin, a cassette tape, an old photograph.
-| Medium (2 Resonance) | 2 | Larger objects: cameras, walkmen, instruments.
-| High (3 Resonance) | 3 | Bulky or imposing objects: weapons, mirrors, bound volumes.
+| Low (1 Corruption) | 1 | Small objects: a coin, a cassette tape, an old photograph.
+| Medium (2 Corruption) | 2 | Larger objects: cameras, walkmen, instruments.
+| High (3 Corruption) | 3 | Bulky or imposing objects: weapons, mirrors, bound volumes.
 |===
 
 === Active Artifact Pressure
@@ -70,16 +70,16 @@ Each artifact has a baseline Encumbrance value equal to its *Resonance cost tier
 Carrying an artifact that has been *activated at least once this Case File* imposes *+1 Enc.* above its base value for the remainder of the session. The artifact's metaphysical structure is disturbed — it pushes back.
 
 * This additional Enc. is invisible to standard detectors — only characters with the *Lore* skill or Wayfinder training can sense something is off.
-* If an active artifact's pressure pushes the carrier into the *Encumbered* Condition, they also roll *+1 Resonance* at the start of each scene while carrying it (the resonance leaks passively).
+* If an active artifact's pressure pushes the carrier into the *Encumbered* Condition, they also gain *+1 Corruption* at the start of each scene while carrying it (the corruption leaks passively).
 
 === Stacking Artifacts
 
 Carrying more than one artifact simultaneously is permitted but discouraged:
 
 * *Two artifacts:* Both active pressure rules apply independently.
-* *Three or more artifacts:* The GM rolls a Resonance Cascade — all carried artifacts leak resonance into the carrier simultaneously. Each artifact applies its Resonance cost at the end of the scene, even if none were used.
+* *Three or more artifacts:* The GM triggers a Corruption Cascade — all carried artifacts leak corruption into the carrier simultaneously. Each artifact applies its Corruption cost at the end of the scene, even if none were used.
 
-> *Lore check (Difficulty 2):* An agent who succeeds on a Lore roll after picking up an artifact can sense its tier and whether a previous carrier activated it. Failure means the agent is unaware of the added pressure until they notice the Encumbered Condition or start gaining unplanned Resonance.
+> *Lore check (Difficulty 2):* An agent who succeeds on a Lore roll after picking up an artifact can sense its tier and whether a previous carrier activated it. Failure means the agent is unaware of the added pressure until they notice the Encumbered Condition or start gaining unplanned Corruption.
 
 ---
 
@@ -91,7 +91,7 @@ specific, dangerous object with a history, a hunger, and consequences that rippl
 through the case file. The catalog above provides examples, but GMs need a
 structured framework for designing originals.
 
-The rules below use a **Resonance Budget** system: the power of an artifact's
+The rules below use a **Corruption Budget** system: the power of an artifact's
 effect is always proportional to the psychological and physical cost of using it.
 No free rides. No safe artifacts.
 
@@ -118,9 +118,9 @@ introducing the artifact to players.
 | What does activating it do?
 | State the mechanical benefit clearly: what roll it replaces, what it grants, what threat it neutralizes.
 
-| *Resonance Cost & Tier*
-| How much Resonance does activation generate?
-| 1 Resonance = Tier 1. 2 Resonance = Tier 2. 3 Resonance = Tier 3. See budget guidelines below.
+| *Corruption Cost & Tier*
+| How much Corruption does activation generate?
+| 1 Corruption = Tier 1. 2 Corruption = Tier 2. 3 Corruption = Tier 3. See budget guidelines below.
 
 | *Fracture Condition*
 | What happens when the Artifact Die rolls 1?
@@ -133,28 +133,28 @@ introducing the artifact to players.
 
 ---
 
-[[resonance-budget]]
-=== Resonance Budget System
+[[corruption-budget]]
+=== Corruption Budget System
 
-An artifact's Resonance cost is not arbitrary — it flows directly from the power
-of the effect. Use this framework to set Resonance cost and choose the Artifact Die.
+An artifact's Corruption cost is not arbitrary — it flows directly from the power
+of the effect. Use this framework to set Corruption cost and choose the Artifact Die.
 
 [%header,cols="1,1,2,4"]
 |===
-| Tier | Resonance Cost | Artifact Die | Effect Power Level
+| Tier | Corruption Cost | Artifact Die | Effect Power Level
 
 | *1 — Uncanny*
-| 1 Resonance
+| 1 Corruption
 | d8
 | Grants an automatic success on a single skill roll, or reveals information that would require a Diff 2 roll. No direct combat effect. Minor sensory or perceptual ability.
 
 | *2 — Threatening*
-| 2 Resonance
+| 2 Corruption
 | d10
 | Replaces a full skill roll with guaranteed success, or grants a significant combat advantage (extra dice, forced complication on enemy). Affects one target in zone.
 
 | *3 — Catastrophic*
-| 3 Resonance
+| 3 Corruption
 | d12
 | Transcends normal human action entirely — massive unblockable damage, reality alteration, mass psychic attack, temporal displacement of a scene. Cannot be replicated by any mundane skill roll.
 |===
@@ -166,7 +166,7 @@ These rules prevent artifacts from becoming "I win" buttons:
 . **One effect only.** Artifacts do one thing. They do it perfectly. They do not do anything else.
 . **No healing.** Artifacts cannot restore Stress, Corruption, or physical Damage.
    _(They can transfer damage — a Tier 2 artifact might push one agent's wounds to another — but cannot eliminate harm from the fiction.)_
-. **Always costs something.** Even on a "successful" fracture-free roll, the Resonance cost is paid. The artifact does not become safer with use.
+. **Always costs something.** Even on a "successful" fracture-free roll, the Corruption cost is paid. The artifact does not become safer with use.
 . **Fracture scales with Tier.** Tier 1 fractures are painful and personal. Tier 2 fractures affect the party or scene. Tier 3 fractures threaten the location or the case.
 
 ---
@@ -207,7 +207,7 @@ kept inert during transport and what triggers it inadvertently.
 |===
 
 > **Stack Division Note:** The <<facility-covenant-armorer,Covenant Armorer>> HQ
-> facility and the Keep's Resonance Dampening Vault provide structural support for
+> facility and the Keep's Corruption Dampening Vault provide structural support for
 > containment. Without them, field containment relies on improvised measures and
 > Wayfinder knowledge.
 
@@ -249,7 +249,7 @@ it when:
 | Decay Score | Artifact Die | Status
 
 | 0 | Full die (d8/d10/d12) | Active and fully dangerous
-| 1–2 | Step down one die | Effect weakened; Resonance cost reduced by 1 (min 1)
+| 1–2 | Step down one die | Effect weakened; Corruption cost reduced by 1 (min 1)
 | 3–4 | Step down two dice | Barely active; only works on activation rolls of 5–6
 | 5 | — | Inert. Artifact is neutralized and safe for permanent containment. Case closed.
 |===
@@ -266,7 +266,7 @@ it when:
 To illustrate the framework in practice:
 
 **Origin:** In 1943, Dr. Eli Morrow performed an experimental surgery in a
-research hospital outside Chicago. During the procedure, a resonance event —
+research hospital outside Chicago. During the procedure, a corruption event —
 origin unknown — caused Morrow to hear the deaths of everyone in the building
 simultaneously. He died at the operating table. His stethoscope absorbed the
 event.
@@ -279,10 +279,10 @@ hears not the target's heartbeat but their greatest fear — precise, immersive,
 and exploitable. Grants automatic success on any Empathy (Manipulate) or
 Investigate (interrogation) roll against that target for the rest of the scene.
 
-**Resonance Cost:** 2 Resonance.
+**Corruption Cost:** 2 Corruption.
 
 **Fracture Condition (on 1):** The user hears their *own* death — vivid,
-detailed, inevitable. They gain 2 Resonance immediately and cannot take Slow
+detailed, inevitable. They gain +2 Corruption immediately and cannot take Slow
 Actions until end of scene (paralyzed by the vision).
 
 **Containment Profile:** Physical Isolation — wrapped in surgical gauze treated

--- a/docs/chapters/13-case-file.adoc
+++ b/docs/chapters/13-case-file.adoc
@@ -53,7 +53,7 @@ Survivors return to base. During this phase:
 
 * All requisitioned gear is returned to Stack
 * Players undergo debriefing and answer XP questions
-* Characters attempt to clear accumulated Resonance
+* Characters attempt to heal accumulated Corruption
 * Check if temporary psychological traumas become permanent conditions
 * Initiate new Headquarters upgrades
 
@@ -76,7 +76,7 @@ Every Countdown has *5 stages*, named by their escalation level. Not every case 
 | 1 | *Dormant* | The threat is latent. The artifact is present but not yet destabilizing. | Investigation can proceed without urgency. NPCs may be anxious but not in immediate danger.
 | 2 | *Stirring* | The artifact is beginning to resonate. Minor anomalies are visible to those who know what to look for. | Environmental strangeness. One NPC has been affected. The rival faction has been alerted.
 | 3 | *Active* | The artifact is unstable. An entity manifests or the situation escalates visibly. | Direct danger begins. Civilian NPCs may be harmed. The rival faction is moving.
-| 4 | *Escalating* | The threat is pursuing the agents or actively threatening HQ assets. Containment window is closing. | Enemy reinforcements arrive. Key locations become inaccessible. Agents gain 1 Resonance (environmental saturation — this is not optional).
+| 4 | *Escalating* | The threat is pursuing the agents or actively threatening HQ assets. Containment window is closing. | Enemy reinforcements arrive. Key locations become inaccessible. Agents gain +1 Corruption (environmental saturation — this is not optional).
 | 5 | *Crisis* | No more investigation time. The threat forces confrontation now. | Forced confrontation scene. If the agents do not act, see *Clock Expiry* below.
 |===
 
@@ -104,7 +104,7 @@ The clock can be *slowed* (the next tick is delayed) or *held* (one stage does n
 | Action | Effect
 
 | *Successful Lore roll (Difficulty 3)* — agents identify the specific activation condition and prevent it from occurring | Clock held for one trigger cycle (one "free" trigger before it advances).
-| *Secure a secondary resonance source* — removing a contributing artifact, sealing a ritual circle, or disrupting the rival faction's preparations | Clock advance delayed by one full phase (in-game).
+| *Secure a secondary occult source* — removing a contributing artifact, sealing a ritual circle, or disrupting the rival faction's preparations | Clock advance delayed by one full phase (in-game).
 | *Full containment of the artifact* | Clock stops advancing. The immediate threat is on hold until the artifact is removed from containment.
 |===
 
@@ -112,7 +112,7 @@ The clock can be *slowed* (the next tick is delayed) or *held* (one stage does n
 
 The clock *cannot typically be reversed* — once a stage is reached, its effects persist. However:
 
-* A successful *Wayfinder Division ritual* can reduce Stage 4 back to Stage 3 (the escalating resonance field is pushed back).
+* A successful *Wayfinder Division ritual* can reduce Stage 4 back to Stage 3 (the escalating corruption is pushed back).
 * Eliminating the rival faction's active presence at a location may reduce Stage 3 back to Stage 2 for that location only (the faction was accelerating the threat independently).
 
 These require significant resources, time, and usually a Lore roll at Difficulty 3 or 4. They are not guaranteed.
@@ -150,7 +150,7 @@ Faster clocks create urgency but reduce investigation time. Slower clocks allow 
 
 | 1 | Dormant | Session open; clocks begins ticking | The journalist is alive and unaware. The Compact team is 2 hours out. The Mirror is in the penthouse.
 | 2 | Stirring | Team spends more than 1 hour investigating without reaching the penthouse, OR fires a weapon anywhere in the hotel | The Mirror activates. An Echoing Remnant manifests in the corridor between the team and the penthouse. The journalist has seen it and is hiding. The Compact team is now 30 minutes out.
-| 3 | Crisis | Team has not secured the Mirror and Remnant is still active when the Compact team arrives | The Compact team enters the building. The journalist's camera captures the Remnant — the team must now deal with both the Compact operatives AND the Remnant AND contain the journalist. The Mirror's resonance is saturating the top two floors. All agents in the top two floors gain 1 Resonance per scene.
+| 3 | Crisis | Team has not secured the Mirror and Remnant is still active when the Compact team arrives | The Compact team enters the building. The journalist's camera captures the Remnant — the team must now deal with both the Compact operatives AND the Remnant AND contain the journalist. The Mirror's corruption field is saturating the top two floors. All agents in the top two floors gain +1 Corruption per scene.
 |===
 
 ---
@@ -158,7 +158,7 @@ Faster clocks create urgency but reduce investigation time. Slower clocks allow 
 == Cross-References
 
 * GM guidance for building and calibrating Countdown clocks: `docs/chapters/18-gm-guidance.adoc`
-* Resonance gain mechanics: `docs/chapters/07-resonance-corruption.adoc`
+* Corruption gain mechanics: `docs/chapters/07-resonance-corruption.adoc`
 * Wayfinder Division rituals: `docs/chapters/15-rival-factions.adoc` (and Issue #15)
 
 ---
@@ -194,8 +194,8 @@ Roll two d6s: the first die is the tens digit, the second is the units digit.
 | 24 | Compass                     | Points toward the nearest supernatural entity regardless of direction
 | 25 | Mirror (compact or full)    | Shows true form of all entities reflected; cannot be looked away from
 | 26 | Surgical instrument         | Wounds inflicted by it cannot be healed by normal medicine
-| 31 | Film reel                   | Footage shows crimes not yet committed; watching triggers Corruption Check
-| 32 | Blueprint or schematics     | Construction following these plans creates a resonant space; builders don't survive
+| 31 | Film reel                   | Footage shows crimes not yet committed; watching causes +1 Corruption
+| 32 | Blueprint or schematics     | Construction following these plans creates a corrupted space; builders don't survive
 | 33 | Coin (antique)              | Payment seals bargains metaphysically; collection agent is always a monster
 | 34 | Key (iron or bone)          | Opens any locked door; what waits behind is never what was expected
 | 35 | Hand tool (hammer, wrench)  | Objects struck retain kinetic energy indefinitely; environment becomes hostile
@@ -215,7 +215,7 @@ Roll two d6s: the first die is the tens digit, the second is the units digit.
 | 61 | Wristwatch                  | Vibrates when the wearer is about to make a fatal mistake
 | 62 | Handcuffs or restraints     | Anyone bound cannot lie; binding marks disappear but effects persist
 | 63 | Tape recorder               | Previous owner's last words loop at danger peaks; cannot be erased
-| 64 | Newspaper (dated ahead)     | Next day's events described accurately; handling causes 1 Resonance per reading
+| 64 | Newspaper (dated ahead)     | Next day's events described accurately; handling causes +1 Corruption per reading
 | 65 | Wallet or purse             | Holds exactly what is needed in any situation; contents are never explained
 | 66 | Mundane item (GM choice)    | Appears entirely ordinary; effect is not discovered until a Fracture
 |===
@@ -230,11 +230,11 @@ How does the cell first become aware of the case?
 |===
 | d6 | Inciting Incident
 
-| 1 | *Missing Person Report* — A Covenant contact is digging into a disappearance that connects to a known resonance signature. They need field backup before the trail goes cold.
+| 1 | *Missing Person Report* — A Covenant contact is digging into a disappearance that connects to a known occult signature. They need field backup before the trail goes cold.
 | 2 | *Anonymous Tip* — An unsigned letter arrives at a cell dead drop, containing specific details only an insider could know. Who sent it — and why now?
 | 3 | *Police Report (Redacted)* — A Keep archivist intercepts a law-enforcement file referencing phenomena that match an active artifact. The police don't understand what they have. The cell does.
 | 4 | *Field Acquisition Gone Wrong* — A previous Recovery team retrieved an artifact but never checked in. Their last known position is on the map. Their radio is silent.
-| 5 | *Covenant Intelligence Briefing* — Wayfinder Division has been tracking a resonance spike for weeks. The spike has stabilized. Something has been activated and is being used.
+| 5 | *Covenant Intelligence Briefing* — Wayfinder Division has been tracking an occult energy spike for weeks. The spike has stabilized. Something has been activated and is being used.
 | 6 | *Civilian Exposure* — A non-Covenant civilian witnessed something they cannot explain. The Covenant's disinformation infrastructure is moving to contain the story — but the artifact is still out there.
 |===
 
@@ -267,10 +267,10 @@ What makes this case harder than it should be?
 | d6 | Complication
 
 | 1 | *Rival Faction Interest* — Another organization (intelligence agency, criminal syndicate, or rogue occultist network) has tracked the same artifact. They are already on-site or arriving within the hour.
-| 2 | *Civilian Entanglement* — Someone innocent — a family member, a local witness, a bystander — has handled the artifact and is already exhibiting resonance symptoms. The clock on their degradation has started.
+| 2 | *Civilian Entanglement* — Someone innocent — a family member, a local witness, a bystander — has handled the artifact and is already exhibiting corruption symptoms. The clock on their degradation has started.
 | 3 | *Media Attention* — A local journalist is following the same trail for completely mundane reasons. Their story goes to press in 48 hours whether the cell intervenes or not.
 | 4 | *Internal Complication* — One of the cell's Covenant contacts has gone quiet. A Wayfinder briefing contains an inconsistency. Something in the chain of command is compromised.
-| 5 | *Containment Failure* — A previous version of this artifact was thought neutralized. It wasn't. Two instances of the same resonance signature are active simultaneously.
+| 5 | *Containment Failure* — A previous version of this artifact was thought neutralized. It wasn't. Two instances of the same occult signature are active simultaneously.
 | 6 | *Escalating Entity* — The artifact has attracted or generated a supernatural entity that has been active in the area for days before the cell arrived. It is not the primary target — but it will interfere.
 |===
 
@@ -325,7 +325,7 @@ Use this procedure to run from nothing to a playable case in one pass:
 ==== Worked Example: "The Holbrook Frequency"
 
 > *Rolled:* d66 = 23 (Radio receiver — parallel timeline transmissions).
-> *Incident:* 5 (Covenant Intelligence Briefing — resonance spike, stabilized).
+> *Incident:* 5 (Covenant Intelligence Briefing — occult energy spike, stabilized).
 > *Location:* 2 (Research laboratory — university).
 > *Complication:* 3 (Media attention — journalist, 48-hour deadline).
 >

--- a/docs/chapters/14-headquarters.adoc
+++ b/docs/chapters/14-headquarters.adoc
@@ -1,6 +1,6 @@
 = Headquarters Management
 
-In YZE games, a persistent base of operations is a fundamental pillar of long-term campaign play. In _Mutant: Year Zero_ it's the Ark; in _Forbidden Lands_, the Stronghold; in _Vaesen_, Castle Gyllencreutz. In Project Neon Relic, the *Headquarters* serves as a mechanical anchor, a psychological safe haven from Resonance, and an economic resource sink giving players ownership over the world.
+In YZE games, a persistent base of operations is a fundamental pillar of long-term campaign play. In _Mutant: Year Zero_ it's the Ark; in _Forbidden Lands_, the Stronghold; in _Vaesen_, Castle Gyllencreutz. In Project Neon Relic, the *Headquarters* serves as a mechanical anchor, a psychological safe haven from Corruption, and an economic resource sink giving players ownership over the world.
 
 == The Covenant Safehouse
 
@@ -89,7 +89,7 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 | 4
 | Secure Communications Room
 | Lead-lined room sealed against electromagnetic and supernatural interference. No phones work inside. No spirits answer. Silence like the inside of a safe.
-| One character per downtime can bleed off up to *4 Resonance* without triggering a Corruption Check. Requires a full day inside — the character is unavailable for other downtime activities that day.
+| One character per downtime can heal up to *4 Corruption*. Requires a full day inside — the character is unavailable for other downtime activities that day.
 |===
 
 === Tier 3 — Advanced Operations
@@ -112,11 +112,11 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 | A former Special Forces armorer gone ghost — works out of the armory back room, asks no questions, and charges only in favors and whiskey.
 | Once per Case File, one item in the team's loadout can be permanently upgraded: *+1 Gear Bonus* to the item's listed value. The item also gains the *Reliable* trait (ignore the first 1 when pushing).
 
-| *Resonance Dampening Vault*
+| *Corruption Dampening Vault*
 | 6
 | Faraday Cage + Occult Laboratory
 | A reinforced sub-chamber within the Faraday Cage, retrofitted with seven-layer lead shielding, hand-drawn containment circles, and rotating salt-line maintenance. Costly to maintain and terrifying to enter alone.
-| Store up to *3 active artifacts* without passive resonance leaking to carriers. Artifacts in the vault do not add Enc. pressure (see `docs/chapters/12-artifacts.adoc`). Vault must be re-consecrated after 3 Case Files (Lore Difficulty 2; failure = 1 random artifact "wakes up").
+| Store up to *3 active artifacts* without passive corruption leaking to carriers. Artifacts in the vault do not add Enc. pressure (see `docs/chapters/12-artifacts.adoc`). Vault must be re-consecrated after 3 Case Files (Lore Difficulty 2; failure = 1 random artifact "wakes up").
 
 | *Safe House Network*
 | 6
@@ -177,11 +177,11 @@ The Threat Meter increases by 1 when:
 
 * The team uses explosives or automatic weapons fire in a populated area
 * A rival faction agent escapes alive with knowledge of the team's base location
-* The team fails to contain a resonance leak (active artifact left unsecured overnight)
+* The team fails to contain a corruption leak (active artifact left unsecured overnight)
 * A deceased agent's civilian identity is linked to the Covenant by law enforcement
 * The team's Countdown Clock expires (any severity) during a Case File
 
-The Threat Meter decreases by 1 at the end of any Case File in which the team was completely covert (no civilian witnesses, no law enforcement contact, no resonance incidents).
+The Threat Meter decreases by 1 at the end of any Case File in which the team was completely covert (no civilian witnesses, no law enforcement contact, no corruption incidents).
 
 === Compromise Event
 
@@ -275,7 +275,7 @@ Covenant knows. It always knows.
 | Trigger | Standing Loss | Notes
 
 | Confirmed civilian casualties                       | −2 per casualty | Witnesses who survive and go public count as −3 instead
-| Resonance event reported in media                   | −3 | Any press coverage of supernatural phenomena linked to a case
+| Supernatural event reported in media                   | −3 | Any press coverage of supernatural phenomena linked to a case
 | Artifact lost to rival faction or enemy             | −3 | Lost in the field, stolen post-recovery, or destroyed improperly
 | Agent compromised, turned, or gone rogue            | −4 | Applies whether the agent is caught or simply disappears
 | Case abandoned mid-operation                        | −2 | Cell withdrew without artifact containment or Covenant approval
@@ -326,14 +326,14 @@ Standing threshold is met.
 | *Occult Laboratory* (Tier 2)           | 4 DP | 5
 | *Faraday Cage* (Tier 2)               | 3 DP | 5
 | *Field Intel Network* (Tier 3)         | 5 DP | 10
-| *Resonance Dampening Vault* (Tier 3)   | 6 DP | 10
+| *Corruption Dampening Vault* (Tier 3)   | 6 DP | 10
 | *Safe House Network* (Tier 3)          | 4 DP | 15
 | *Covenant Armorer* (Tier 3)            | 5 DP | 10
 |===
 
 > **Design Note:** Standing gates exist because Tier 2 and 3 facilities represent
 > the Covenant extending significant trust to a cell. An unproven cell does not get
-> access to the Occult Laboratory or the Resonance Dampening Vault. They have to
+> access to the Occult Laboratory or the Corruption Dampening Vault. They have to
 > earn it.
 
 ---

--- a/docs/chapters/17-bestiary.adoc
+++ b/docs/chapters/17-bestiary.adoc
@@ -78,8 +78,8 @@ Special Abilities:
 
   Improvised Ritual — Once per combat, the cultist may spend their Slow Action
   to attempt a Lore roll (Difficulty 3). On success, they call a fragment of
-  an artifact's resonant effect to their location: all agents within Near range
-  gain 1 Resonance. On failure, the cultist takes 1 Wits damage (backlash).
+  an artifact's corrupting effect to their location: all agents within Near range
+  gain +1 Corruption. On failure, the cultist takes 1 Wits damage (backlash).
 
 Broken State: Zealot's Resolve delays collapse; at STR 1, one more hit Breaks
 them. Broken cultists either enter catatonic prayer or flee. GM's call.
@@ -105,8 +105,8 @@ Skills:
 Special Abilities:
   Burn the Evidence — If the Cell Leader reaches Broken State with a ritual
   site or artifact nearby, they attempt one final Lore roll (Difficulty 2)
-  to trigger a resonance discharge. On success: all within Short range gain
-  2 Resonance. This is not suicidal — they expect to survive. They often don't.
+  to trigger a corruption discharge. On success: all within Short range gain
+  +2 Corruption. This is not suicidal — they expect to survive. They often don't.
 
   Rally the Faithful — While the Cell Leader is active, all Ember Accord
   Cultists in the scene gain +1 die on Brawl rolls. If the Cell Leader falls,
@@ -181,10 +181,8 @@ Special Abilities:
   +2 dice on their next Lore roll. This does not trigger armor. They choose to
   bleed.
 
-  Resonance Tap — On a successful Lore roll (Difficulty 2), the Contractor
-  forces one agent within Near range to roll a Corruption check immediately
-  (regardless of current Resonance level). The GM adds 1 to their Resonance
-  total for this check only.
+  Corruption Tap — On a successful Lore roll (Difficulty 2), the Contractor
+  forces one agent within Near range to gain +2 Corruption immediately.
 
   Bound Sigil — The Contractor carries a ward. The first time they would be
   Broken, the ward absorbs it: they are reduced to STR 1 instead of 0. The
@@ -225,7 +223,7 @@ Special Abilities:
   damage from thrown debris (no attack roll — environmental). An agent who takes
   cover removes themselves from the zone effectively.
 
-  Resonance Bleed — When the Remnant deals damage, the target gains 1 Resonance
+  Corruption Bleed — When the Remnant deals damage, the target gains +1 Corruption
   in addition to the physical effect. The touch carries something of whatever
   this thing was.
 
@@ -251,18 +249,18 @@ strong emotional state.
 
 ----
 Attributes: STR 8 | AGI 3 | WIT 2 | EMP 0
-Armor Rating: 5 (crystallized resonance — the artifact's self-defense)
+Armor Rating: 5 (crystallized occult energy — the artifact's self-defense)
 Fear Rating: 4 (wrongness of form; the geometry of it shouldn't work)
 
 Skills:
   Force 5 | Brawl 4 | Endure 4
 
 Special Abilities:
-  Resonant Shell — Standard firearms deal only 1 Damage per hit against the
+  Occult Shell — Standard firearms deal only 1 Damage per hit against the
   Shard Construct regardless of weapon rating. Artifact-derived weapons, fire,
   or electromagnetic disruption deal full damage.
 
-  Shard Burst (Slow Action) — The Construct fires crystallized resonance shards
+  Shard Burst (Slow Action) — The Construct fires crystallized occult shards
   in a cone. All agents within Near range take 2 Strength damage. Armor applies.
   No attack roll — the GM describes the burst; agents may spend a Fast Action
   to Dodge (opposed AGI roll, Difficulty 2 to avoid) before it lands.
@@ -310,7 +308,7 @@ For quick reference when building encounters:
 * Fear ratings and check triggers: `docs/chapters/07-resonance-corruption.adoc`
 * Faction affiliations and politics: `docs/chapters/15-rival-factions.adoc` _(Issue #14)_
 * Artifacts and what spawns Constructs: `docs/chapters/12-artifacts.adoc` _(Issue #9 origin)_
-* Corruption checks from supernatural sources: `docs/chapters/07-resonance-corruption.adoc`
+* Corruption gain from supernatural sources: `docs/chapters/07-resonance-corruption.adoc`
 
 ---
 
@@ -330,10 +328,10 @@ For quick reference when building encounters:
 | *Skills* | Psychoanalyze 3 (passive pressure), Manipulate 2 (hallucination-induced)
 | *Armor Rating* | Immune to physical damage
 | *Fear Rating* | 3
-| *Resonance Cost* | +1 Resonance per minute spent within it (scene = +3 total)
+| *Corruption Cost* | +1 Corruption per minute spent within it (scene = +3 total)
 |===
 
-*Origin:* A Mire forms when intense psychological trauma fuses with resonant artifact energy over years — a long-term infestation of a place by accumulated suffering. Hospitals, prisons, and sites of mass resonance exposure are most at risk.
+*Origin:* A Mire forms when intense psychological trauma fuses with corrupting artifact energy over years — a long-term infestation of a place by accumulated suffering. Hospitals, prisons, and sites of mass corruption exposure are most at risk.
 
 *Special Abilities:*
 
@@ -350,13 +348,13 @@ gain the Shaken Condition.
 
 Dissolution Trigger — The Mire cannot be destroyed by conventional
 means. It can be dispersed by:
-  (1) Removing the resonant artifact at its core (Investigate Difficulty 3
+  (1) Removing the corrupting artifact at its core (Investigate Difficulty 3
       to locate it inside the zone, Lore Difficulty 2 to identify it
       as the anchor).
   (2) A Containment Ritual (see Wayfinder Division abilities) performed
       by an agent with Lore 3+, taking one full scene.
   (3) Destroying the artifact at its core (Artifact Fracture; triggers
-      a Resonance Cascade — everyone in the zone takes 3 Resonance).
+      a Corruption Cascade — everyone in the zone takes +3 Corruption).
 ----
 
 *Broken State:* Dispersed. The zone returns to normal. Physical damage from the trauma-origin remains (stains, broken furniture, cold spots). The artifact anchor must be contained; leaving it creates a new Mire within 1d6 days.
@@ -379,10 +377,10 @@ means. It can be dispersed by:
 | *Skills* | Force 3, Brawl 2, Endure 3
 | *Armor Rating* | 1 (physical deadness reduces impact)
 | *Fear Rating* | 2
-| *Resonance Cost* | +1 Resonance on first sighting; +1 if recognized as someone known
+| *Corruption Cost* | +1 Corruption on first sighting; +1 if recognized as someone known
 |===
 
-*Origin:* A Hollow is a human corpse reanimated by a resonant artifact using residual psychic impressions of the deceased. The body retains muscle memory and some learned behaviors — but there is nothing behind the eyes.
+*Origin:* A Hollow is a human corpse reanimated by a corrupting artifact using residual psychic impressions of the deceased. The body retains muscle memory and some learned behaviors — but there is nothing behind the eyes.
 
 *Special Abilities:*
 
@@ -401,7 +399,7 @@ the Exhausted Condition. It will pursue until Broken or the artifact is
 removed.
 ----
 
-*Broken State:* Collapse. The body goes completely inert. The artifact that controlled it is not damaged by the Hollow's collapse, but its resonance signature is now readable (Lore Difficulty 1 to identify its history).
+*Broken State:* Collapse. The body goes completely inert. The artifact that controlled it is not damaged by the Hollow's collapse, but its occult signature is now readable (Lore Difficulty 1 to identify its history).
 
 *Motivation:* The Hollow protects the artifact, returned the artifact to its last owner, or simply pursues the last living person it was "tasked" to reach. The GM determines the simple directive at the moment of the Hollow's creation.
 
@@ -421,10 +419,10 @@ removed.
 | *Skills* | Investigate 4, Sneak 5, Manipulate 3
 | *Armor Rating* | Immune to physical damage while intangible
 | *Fear Rating* | 2 (initially); 4 (once its nature is understood)
-| *Resonance Cost* | +2 Resonance when it speaks directly to a character
+| *Corruption Cost* | +2 Corruption when it speaks directly to a character
 |===
 
-*Origin:* Formed from decades of surveillance anxiety — in a city wired by cold-war paranoia, government wiretapping, and Covenant counter-intelligence operations bleeding resonant energy, The Listening coheres as an entity that *only knows how to observe and manipulate*. It does not attack physically; it attacks information.
+*Origin:* Formed from decades of surveillance anxiety — in a city wired by cold-war paranoia, government wiretapping, and Covenant counter-intelligence operations bleeding occult energy, The Listening coheres as an entity that *only knows how to observe and manipulate*. It does not attack physically; it attacks information.
 
 *Special Abilities:*
 
@@ -447,11 +445,11 @@ discretion).
 
 Intangible — The Listening cannot be harmed by physical attacks. It can
 only be targeted by a Containment Ritual or destroyed by removing all
-resonant surveillance equipment from its zone of origin and performing a
+corrupted surveillance equipment from its zone of origin and performing a
 Tech roll (Difficulty 3) to disrupt its signal network.
 ----
 
-*Broken State:* Static. A burst of white noise — every electronic device in Near range emits a single piercing tone and loses 1 Gear Bonus permanently. The Listening disperses. It may reconstitute in 1d6 days if its resonant origin point is not addressed.
+*Broken State:* Static. A burst of white noise — every electronic device in Near range emits a single piercing tone and loses 1 Gear Bonus permanently. The Listening disperses. It may reconstitute in 1d6 days if its occult origin point is not addressed.
 
 *Motivation:* To know everything. To use what it knows. It does not kill — but it will unravel a team from inside if left unchecked.
 
@@ -471,10 +469,10 @@ Tech roll (Difficulty 3) to disrupt its signal network.
 | *Skills* | Psychoanalyze 4, Manipulate 4, Brawl 3 (manifested physical form)
 | *Armor Rating* | 3 (partially intangible)
 | *Fear Rating* | 4 (maximum if the Wraith wears the face of a dead teammate)
-| *Resonance Cost* | +2 Resonance on first contact; +1 each subsequent scene
+| *Corruption Cost* | +2 Corruption on first contact; +1 each subsequent scene
 |===
 
-*Origin:* When a Covenant agent dies during a resonance spike — their Corruption threshold exceeded at the moment of death by artifact activation or entity contact — the psychic echo of that agent does not dissipate cleanly. It *fractures*. The resulting Wraith retains the face, voice, and mannerisms of the deceased, but its core motivation has been replaced entirely by the trauma of its creation.
+*Origin:* When a Covenant agent dies during a corruption spike — their Corruption threshold exceeded at the moment of death by artifact activation or entity contact — the psychic echo of that agent does not dissipate cleanly. It *fractures*. The resulting Wraith retains the face, voice, and mannerisms of the deceased, but its core motivation has been replaced entirely by the trauma of its creation.
 
 *Special Abilities:*
 
@@ -487,26 +485,26 @@ Fear Rating 2.
 
 Guilt Echo — Once per scene, the Wraith can attempt a Psychoanalyze roll
 (opposed by the target's Wits). On success: the target relives a specific
-guilt memory and gains +2 Resonance immediately. The experience is
+guilt memory and gains +2 Corruption immediately. The experience is
 indistinguishable from a genuine flashback.
 
-Resonance Drain — Any character who engages the Wraith in melee gains
-+1 Resonance per round of direct contact, regardless of outcome.
+Corruption Drain — Any character who engages the Wraith in melee gains
++1 Corruption per round of direct contact, regardless of outcome.
 
 Memory of Skill — The Fracture Wraith retains one skill from the deceased
 at their final level. The GM chooses which skill based on the dead agent's
 profile (e.g., a dead Firearms 3 agent becomes a Wraith with Firearms 3).
 ----
 
-*Broken State:* Release. The Wraith dissolves in a cascade of static images — faces, file documents, artifact photographs — before going silent. Characters who witness the dissolution gain +1 XP (the vision is painful but clarifying). The resonance spike that created the Wraith is fully discharged; the location is safe from this specific entity.
+*Broken State:* Release. The Wraith dissolves in a cascade of static images — faces, file documents, artifact photographs — before going silent. Characters who witness the dissolution gain +1 XP (the vision is painful but clarifying). The corruption spike that created the Wraith is fully discharged; the location is safe from this specific entity.
 
-*Motivation:* The Fracture Wraith is not the dead agent. It is the *moment of death* given form. It seeks to replicate the conditions of its creation — drawing living agents toward high-resonance situations, artifact activation, and the threshold of corruption. It doesn't know it's doing this. It believes it's trying to warn them.
+*Motivation:* The Fracture Wraith is not the dead agent. It is the *moment of death* given form. It seeks to replicate the conditions of its creation — drawing living agents toward high-corruption situations, artifact activation, and the threshold of corruption. It doesn't know it's doing this. It believes it's trying to warn them.
 
 ---
 
 == Corrupted NPCs
 
-*Corrupted NPCs* are human characters — factional contacts, civilians, or even Covenant support staff — whose Corruption has crossed into active dysfunction. Unlike Fracture Wraiths or Hollows, they are still alive. They still want things. But *what* they want has been bent by prolonged resonance exposure.
+*Corrupted NPCs* are human characters — factional contacts, civilians, or even Covenant support staff — whose Corruption has crossed into active dysfunction. Unlike Fracture Wraiths or Hollows, they are still alive. They still want things. But *what* they want has been bent by prolonged corruption exposure.
 
 === Corruption Threshold and Behavior
 
@@ -518,7 +516,7 @@ The Corruption thresholds from `docs/chapters/07-resonance-corruption.adoc` appl
 
 | *0* | 0–3 | Normal. No mechanical difference from a baseline NPC.
 | *1* | 4–7 | *Distorted.* The NPC is erratic — inconsistent, prone to misreading motives. −1 die on all social skill rolls targeting them. They believe they are functioning normally.
-| *2* | 8–10 | *Compromised.* The NPC's primary goal has been replaced by the logic of a resonant artifact. They act with genuine conviction in service of something the artifact wants. Fear Rating 1 (their behavior is uncanny and wrong).
+| *2* | 8–10 | *Compromised.* The NPC's primary goal has been replaced by the logic of a corrupting artifact. They act with genuine conviction in service of something the artifact wants. Fear Rating 1 (their behavior is uncanny and wrong).
 | *3* | 11+ | *Broken.* The NPC meets the Fracture Wraith threshold or reaches catatonia. If not Catatonic, treat as equivalent to a Hollow (see above) — still moving, but no longer present.
 |===
 
@@ -527,7 +525,7 @@ The Corruption thresholds from `docs/chapters/07-resonance-corruption.adoc` appl
 Corrupted NPCs are not villains in the traditional sense. They are *victims*. Consider the following when playing them:
 
 * A Stage 1 NPC may give the players subtly wrong information — not because they are lying, but because they have stopped being able to distinguish memory from artifact-induced suggestion.
-* A Stage 2 NPC may have physically altered their behavior to serve the artifact (hoarding it, protecting a building it lives in, feeding it resonance by exposing others to it).
+* A Stage 2 NPC may have physically altered their behavior to serve the artifact (hoarding it, protecting a building it lives in, feeding it corruption by exposing others to it).
 * A Stage 2 NPC who is confronted about their behavior becomes *aggressively defensive* — they are convinced they are fine. A Psychoanalyze roll (Difficulty 3) reveals the fracture.
 * A Stage 2 NPC who is successfully *separated from the artifact* for 48 hours begins to recover. A Psychoanalyze roll (Difficulty 2) can accelerate recovery. Recovery is not complete — they retain the trauma and may have acted against people they care about.
 

--- a/docs/chapters/18-gm-guidance.adoc
+++ b/docs/chapters/18-gm-guidance.adoc
@@ -14,7 +14,7 @@ Before the mechanical tools, three design priorities that should inform every se
 
 . *The Covenant is not infallible.* Headquarters, the Verdant Codex, and the Division protocols exist in tension with the facts in the field. Let them be wrong sometimes. Let the players be right when the institution isn't.
 
-. *The artifacts are not neutral.* Every artifact has a trajectory — a direction it pulls the world. Make sure some of that pull lands on the agents. Resonance and Corruption are not just penalties; they are the story.
+. *The artifacts are not neutral.* Every artifact has a trajectory — a direction it pulls the world. Make sure some of that pull lands on the agents. Corruption is not just a penalty; it is the story.
 
 ---
 
@@ -105,7 +105,7 @@ Every case has at least one *Countdown Clock* — a track that advances as time 
 
 A Countdown Clock has:
 
-* *A name* (what it represents: "Compact Extraction Team Arrives," "Second Civilian Found Dead," "Artifact Resonance Threshold Reached")
+* *A name* (what it represents: "Compact Extraction Team Arrives," "Second Civilian Found Dead," "Artifact Corruption Threshold Reached")
 * *4–6 clock stages*, each with a defined event
 * *Trigger conditions* that advance the clock one step
 
@@ -141,7 +141,7 @@ Every significant NPC needs three things: a *secret*, a *goal*, and a *connectio
 
 | *Secret* | Something the NPC is hiding from the agents. Not necessarily sinister — a witness might be hiding that they trespassed, not that they're a cultist. The secret creates the reason they don't just tell the agents everything at the start.
 | *Goal* | What the NPC is actively trying to accomplish right now. Not a background motivation — a current action. They are doing something during this case.
-| *Artifact connection* | How did this NPC encounter the case's artifact, and what effect has that proximity had on them? Even tangential NPCs should have a small Resonance consequence (nightmares, strange certainty about things they can't know).
+| *Artifact connection* | How did this NPC encounter the case's artifact, and what effect has that proximity had on them? Even tangential NPCs should have a small Corruption consequence (nightmares, strange certainty about things they can't know).
 |===
 
 === The Motivated NPC Test
@@ -207,4 +207,4 @@ Roll when you need an unexpected complication mid-case, when a scene is going to
 * Artifact properties and Tiers: `docs/chapters/12-artifacts.adoc`
 * Rival faction behavior and agendas: `docs/chapters/15-rival-factions.adoc`
 * Entity stat blocks and Fear ratings: `docs/chapters/17-bestiary.adoc`
-* Resonance/Corruption consequences: `docs/chapters/07-resonance-corruption.adoc`
+* Corruption consequences: `docs/chapters/07-resonance-corruption.adoc`

--- a/docs/chapters/19-travel.adoc
+++ b/docs/chapters/19-travel.adoc
@@ -27,7 +27,7 @@ Divide the journey into *legs* — distinct segments separated by a stop, a haza
 * *Short journey* (same city or adjacent area): 1 leg. No encounter roll unless the GM sees an opportunity.
 * *Medium journey* (cross-state, 2–4 hours): 2 legs. Roll on the Road Event table once.
 * *Long journey* (overnight, 4–12 hours): 3–4 legs. Roll on the Road Event table for each leg.
-* *Extended journey* (multi-day cross-country): One leg per major stopping point. Roll for each leg. Each overnight rest (without a secure location) costs 1 Resonance (the exposure accumulates).
+* *Extended journey* (multi-day cross-country): One leg per major stopping point. Roll for each leg. Each overnight rest (without a secure location) costs +1 Corruption (the exposure accumulates).
 
 *Leg structure:*
 
@@ -39,7 +39,7 @@ Each leg, the driver (or lead navigator on foot) makes a skill roll:
 
 *On success:* The leg passes without incident, or the team gains one piece of useful information about the destination.
 *On failure:* Roll on the Road Event table (or the GM applies a prepared complication).
-*On push:* +1 Resonance as normal. The driver is rattled; the vehicle takes wear.
+*On push:* +1 Corruption as normal. The driver is rattled; the vehicle takes wear.
 
 === Phase 3 — Arrival
 
@@ -83,11 +83,11 @@ Roll *d12* when a Road Event is triggered.
 | 3 | *Police Checkpoint.* Roadblock ahead — routine or targeted. The team must choose: reroute (+1 leg to the journey), talk their way through (Manipulate Difficulty 2; failure = detained briefly), or bluff past (Sneak Difficulty 3).
 | 4 | *Road Accident.* A civilian incident is visible ahead — a crash, a stalled car, a figure in the road. Stopping may be medically necessary but adds time and a potential witness.
 | 5 | *Tail Detected.* A vehicle has been maintaining pace behind the team for the last leg (see Rules for Being Followed below).
-| 6 | *Resonance Event.* The drive passes through a zone of residual occult activity. Every character gains *+1 Resonance*. No check required — the exposure just happens. The area smells like copper coins and burnt static.
+| 6 | *Corruption Event.* The drive passes through a zone of residual occult activity. Every character gains *+1 Corruption*. No check required — the exposure just happens. The area smells like copper coins and burnt static.
 | 7 | *CB Radio Intercept.* The team picks up a fragment of conversation relevant to the Case File — a police dispatch, a rival faction contact check, a panicked civilian. Roll Investigate (Difficulty 2) to extract actionable intelligence.
 | 8 | *Trucker's Information.* A rest stop encounter with a long-haul trucker who has been on the road through the destination area. Neutral contact. Investigate (Difficulty 1) reveals one useful local detail (road closures, unusual activity, a landmark). Buy them coffee.
 | 9 | *Wrong Turn.* Navigation error. Add +1 leg to the journey. The new route passes through an area with different terrain (GM chooses: industrial, residential, rural, waterfront — add flavor).
-| 10 | *Mechanical Oddity.* Something in the vehicle is behaving strangely — electronics flickering, compass spinning, tape player recording on its own. Artifact proximity or resonance leak suspected. Lore (Difficulty 2) to assess. No immediate danger — but it should be noted.
+| 10 | *Mechanical Oddity.* Something in the vehicle is behaving strangely — electronics flickering, compass spinning, tape player recording on its own. Artifact proximity or corruption leak suspected. Lore (Difficulty 2) to assess. No immediate danger — but it should be noted.
 | 11 | *Fuel Stop.* The team must stop for gas (or food, or rest). A 15-minute window of vulnerability — public space, potential surveillance. Sneak (Difficulty 1) to transit without being noted by anyone watching.
 | 12 | *Clean Run.* No event this leg. The team arrives at the next waypoint ahead of schedule. They may ask the GM one question about the destination that they would have known if they'd had more time to prepare.
 |===
@@ -115,7 +115,7 @@ Three options, each requiring one skill roll:
 . *Blend In:* AGI (Sneak) or WIT (Investigate, to find a crowd). Difficulty 2. Success = tail loses the vehicle or person in ambient traffic. Requires stopping or drastically altering route.
 . *Double Back / Trap:* WIT (Investigate). Difficulty 3. Success = not only is the tail lost, but the team may identify *who* is following them (a glimpse, a plate, a voice on a radio). This is valuable intelligence.
 
-*On failure:* The tail remains. The team may try again next leg (no Resonance cost for failed attempts — frustration is not supernatural). If the tail stays through an entire journey, they arrive at the destination knowing where the team is going.
+*On failure:* The tail remains. The team may try again next leg (no Corruption cost for failed attempts — frustration is not supernatural). If the tail stays through an entire journey, they arrive at the destination knowing where the team is going.
 
 === The Tail Arrives
 


### PR DESCRIPTION
Closes #67

## Summary
Collapses the two-track Resonance/Corruption system into a single unified Corruption track.

### Key Changes
- **Removed Resonance pool** — no volatile buffer or cascade mechanic
- **Corruption gained directly** from pushing (cost +1), Fear checks (any 1s = +1), artifacts, entities, and environmental exposure
- **Removed Corruption Check** cascade (Resonance → Check → Corruption) — Corruption now increments directly
- **Push simplified** to flat +1 Corruption cost (no -1 die penalty, no usage limits)
- **Renamed** Resonant Artifacts → Occult Artifacts, Resonance Dampening Vault → Corruption Dampening Vault
- **Entity abilities renamed**: Corruption Tap, Corruption Bleed, Corruption Drain, Occult Shell
- **Healing updated**: Anchor heals 1d4 Corruption, Full Rest heals Corruption = Empathy score
- **16 chapter files updated** with comprehensive cross-reference cleanup

### Files Modified
01-introduction, 03b-combat, 04-core-mechanics, 05b-social-conflict, 06-health-damage-armor, 07-resonance-corruption, 08-healing, 09-divisions, 10-advancement, 11-equipment, 12-artifacts, 13-case-file, 14-headquarters, 17-bestiary, 18-gm-guidance, 19-travel