### PR TITLE
feat(#71): define explicit damage types — Physical, Mental, and Corruption

### DIFF
--- a/docs/chapters/06-health-damage-armor.adoc
+++ b/docs/chapters/06-health-damage-armor.adoc
@@ -2,17 +2,34 @@
 
 In the Year Zero Engine, characters do not possess a traditional, escalating pool of "Hit Points." Instead, your *four core Attributes directly serve as your health pools*.
 
-== Taking Damage
+== Damage Types
 
-[%header,cols="1,1,3"]
-|===
-| Damage Type | Target Attribute | Common Sources
+Every source of damage specifies its type and target attribute. The attack defines the damage, not the defender.
 
-| Physical | *Strength* | Attacks, falls, hazardous environments, toxins
-| Exhaustion | *Agility* | Sleep deprivation, prolonged exertion
-| Mental | *Wits* | Supernatural terror, psychic assault
-| Emotional | *Empathy* | Psychological manipulation, witnessing horror
+[%header,cols="2,2,4"]
 |===
+| Damage Type | Target | Sources
+
+| *Physical* | *Strength* (violence, toxins, falls) or *Agility* (exhaustion, prolonged exertion) | Weapons, environmental hazards, physical traps, mundane combat
+| *Mental* | *Wits* (terror, confusion, psychic assault) or *Empathy* (grief, guilt, emotional manipulation) | Failed Fear checks (Wits only), supernatural abilities, psychological attacks, social betrayal
+| *Corruption* | *Corruption track* directly | Pushing rolls, activating Division Talents, occult exposure, artifact activation/feedback, specific creature attacks
+|===
+
+=== Damage Type Rules
+
+. *The source specifies the damage type and target attribute.* The defender does not choose.
+. *Combination attacks* are possible: a supernatural creature might deal Physical (STR) + Corruption damage in the same attack. Both are applied.
+. *Weapon stat blocks* list: Damage value, Damage Type, Target Attribute. Example: _Knife — Damage 2, Physical (STR)_.
+. *Creature stat blocks* list damage per attack. Example: _Shadow Tendril — Damage 2, Mental (WIT) + 1 Corruption_.
+. *Broken state* triggers when any attribute reaches 0, as before. Physical Broken (STR/AGI = 0) → Physical Critical Injury table. Mental Broken (WIT/EMP = 0) → Mental Critical Injury table.
+
+=== What Determines STR vs AGI / WIT vs EMP
+
+* *Physical attacks* default to *STR* unless the source is specifically about exhaustion, fatigue, or overexertion (then AGI).
+* *Mental attacks* default to *WIT* unless the source is specifically emotional, social, or empathic (then EMP).
+* The GM does not adjudicate this per-attack. The weapon, creature, or event definition states the target.
+
+---
 
 == The Broken State
 

--- a/docs/chapters/11-equipment.adoc
+++ b/docs/chapters/11-equipment.adoc
@@ -34,19 +34,19 @@ To reflect the covert nature of the Covenant, characters do not use personal cas
 
 == 1980s Weaponry
 
-Weapons provide a Gear Bonus (added to Firearms or Brawl) and a flat Damage rating.
+Weapons provide a Gear Bonus (added to Firearms or Brawl) and a flat Damage rating. All mundane weapons deal *Physical (STR)* damage unless noted otherwise.
 
-[%header,cols="2,^1,^1,1,3,^1"]
+[%header,cols="2,^1,^1,1,1,3,^1"]
 |===
-| Weapon | Gear Bonus | Damage | Range | Special Traits | CL
+| Weapon | Gear Bonus | Damage | Type | Range | Special Traits | CL
 
-| *Brass Knuckles* | +1 | 1 | Engaged | Concealable. | 1
-| *Switchblade* | +1 | 2 | Engaged | Concealable; puncture criticals. | 1
-| *Stun Gun / Taser* | +2 | Stun | Engaged | Target loses their next Slow Action (stunned). | 2
-| *.38 Snub-nose Revolver* | +2 | 2 | Short | Reliable — ignore first 1 when pushing. | 2
-| *9mm Semi-Auto Pistol* | +2 | 2 | Short | High capacity; split successes to hit multiple targets. | 3
-| *Pump-Action Shotgun* | +3 | 3 | Short | +1 Damage at Engaged range. Loud and bulky. | 3
-| *M16 Assault Rifle* | +2 | 3 | Long | Full auto — can push twice, consumes extra ammo. | 4
+| *Brass Knuckles* | +1 | 1 | Physical (STR) | Engaged | Concealable. | 1
+| *Switchblade* | +1 | 2 | Physical (STR) | Engaged | Concealable; puncture criticals. | 1
+| *Stun Gun / Taser* | +2 | Stun | Physical (STR) | Engaged | Target loses their next Slow Action (stunned). | 2
+| *.38 Snub-nose Revolver* | +2 | 2 | Physical (STR) | Short | Reliable — ignore first 1 when pushing. | 2
+| *9mm Semi-Auto Pistol* | +2 | 2 | Physical (STR) | Short | High capacity; split successes to hit multiple targets. | 3
+| *Pump-Action Shotgun* | +3 | 3 | Physical (STR) | Short | +1 Damage at Engaged range. Loud and bulky. | 3
+| *M16 Assault Rifle* | +2 | 3 | Physical (STR) | Long | Full auto — can push twice, consumes extra ammo. | 4
 |===
 
 == Armor

--- a/docs/chapters/17-bestiary.adoc
+++ b/docs/chapters/17-bestiary.adoc
@@ -41,6 +41,7 @@ Motivation: One sentence describing what this adversary wants in this scene.
 * *Armor Rating* functions identically to PC armor — Gear dice rolled against incoming damage.
 * *Fear Rating* applies to supernatural entities and rare humans. 0 = no Fear check triggered. See `docs/chapters/07-resonance-corruption.adoc`.
 * *Broken State* defines what happens when the adversary's Strength hits 0.
+* *Damage types* in special abilities should specify their type and target: Physical (STR or AGI), Mental (WIT or EMP), or Corruption. See `docs/chapters/06-health-damage-armor.adoc`.
 
 === Simplified Humanoid Format
 


### PR DESCRIPTION
Closes #71

## Summary
Adds a clear, authoritative Damage Types section defining the three damage categories.

### New Section in ch06
- Three damage types: Physical (STR/AGI), Mental (WIT/EMP), Corruption (track)
- Five rules: source specifies type, combination attacks allowed, weapon/creature stat block format, Broken state mapping
- STR vs AGI / WIT vs EMP determination guidelines

### Weapon Table Updated (ch11)
- Added Type column to weapon table
- All mundane weapons tagged as Physical (STR)
- Introductory line notes all mundane weapons default to Physical (STR)

### Bestiary Updated (ch17)
- Added damage type note to stat block format notes
- Cross-reference to ch06 for the full damage type taxonomy