### PR TITLE
feat(#75): remove residual Condition terminology from Critical Injury tables

### DIFF
--- a/docs/chapters/06-health-damage-armor.adoc
+++ b/docs/chapters/06-health-damage-armor.adoc
@@ -180,7 +180,7 @@ Roll when Broken by *Strength or Agility* damage.
 | 62 | *Leg Blown Off* † | Death check. Surviving: movement reduced to 1 zone per Slow Action, permanently. | Cannot regrow. Prosthetic possible (Issue #21, CL 5).
 | 63 | *Multiple Wounds* † | Death check. Surviving: roll twice more on this table (ignoring further †). | As per rolled injuries.
 | 64 | *Arterial Strike* † | Bleeding 2 Strength per round. Death check must be made within 2 rounds or automatic death. | Tourniquet (Fast Action, CL 1) buys 1 extra round; Heal (Difficulty 4) fully stabilizes.
-| 65 | *Head Shot* † | Death check. Surviving: permanently remove 1 from Wits AND Empathy. Insight: *+2 dice on Psychoanalyze forever* (near-death clarity). | Cannot be healed. Migraine condition (persistent).
+| 65 | *Head Shot* † | Death check. Surviving: permanently remove 1 from Wits AND Empathy. Insight: *+2 dice on Psychoanalyze forever* (near-death clarity). | Cannot be healed. Persistent migraines (permanent).
 | 66 | *DOA* † | Automatic death check (no bonus). Surviving: character is clinically dead for 1d6 rounds before CPR-equivalent revives them. All Attributes return to 1. Permanent: +3 Corruption, Empathy −1. | See Corruption chapter.
 |===
 


### PR DESCRIPTION
## Summary

Removes residual "condition" terminology from the Critical Injury tables, completing the cleanup started by #67 (Resonance→Corruption) and #69 (Conditions removal).

### Changes
- **Head Shot (65):** Changed "Migraine condition (persistent)" → "Persistent migraines (permanent)" to eliminate leftover Conditions-system language.

Most of the issue's specified changes were already completed:
- All Resonance→Corruption conversions in mental criticals (done by #67)
- Conditions cross-reference table removal (done by #69)
- Self-contained injury effect descriptions (already in place)

Closes #75