### PR TITLE
feat(#76): continuity review — rename ch07, fix terms, update cross-refs

### DIFF
--- a/docs/chapters/04-core-mechanics.adoc
+++ b/docs/chapters/04-core-mechanics.adoc
@@ -32,7 +32,7 @@ However, pushing represents the character exerting maximum physical, mental, or 
 
 * You immediately gain *+1 Corruption*.
 
-> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see `docs/chapters/07-resonance-corruption.adoc` for the full rules.
+> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see `docs/chapters/07-corruption.adoc` for the full rules.
 
 The analog nature of 1980s technology perfectly complements this mechanical attrition. Pushing a gear-assisted roll might degrade the item — short-circuiting alkaline batteries or jamming mechanisms — effectively reducing its inherent bonus until it can be repaired during downtime.
 

--- a/docs/chapters/05b-social-conflict.adoc
+++ b/docs/chapters/05b-social-conflict.adoc
@@ -132,7 +132,7 @@ Social encounters with entities, artifacts, or cult members may cross into super
 * *Direct supernatural revelation during a Manipulate scene* (the NPC says something that cannot be explained naturally): Fear check, Fear Rating 1 or 2.
 * *Psychoanalyze roll on a contaminated NPC* (someone who has long-term artifact exposure): Roll Psychoanalyze as normal. On any failure, the agent picks up a psychic echo — immediate Fear check, Fear Rating 2. On success, the agent gets the information but gains +1 Corruption.
 
-See `docs/chapters/07-resonance-corruption.adoc` for full Fear check rules.
+See `docs/chapters/07-corruption.adoc` for full Fear check rules.
 
 ---
 
@@ -169,6 +169,6 @@ Another Manipulate roll at Difficulty 2 (they're now at 3). Marcus rolls: 6, 5, 
 == Cross-References
 
 * Skills in context: `docs/chapters/05-attributes-skills.adoc`
-* Fear checks during social scenes: `docs/chapters/07-resonance-corruption.adoc`
+* Fear checks during social scenes: `docs/chapters/07-corruption.adoc`
 * Using Manipulate stunts: `docs/chapters/05-attributes-skills.adoc` (Skill Stunts)
-* NPC Faction relationships: `docs/chapters/14-factions.adoc` _(Issue #14)_
+* NPC Faction relationships: `docs/chapters/15-rival-factions.adoc`

--- a/docs/chapters/06-health-damage-armor.adoc
+++ b/docs/chapters/06-health-damage-armor.adoc
@@ -48,7 +48,7 @@ Being *Broken* is not the same as being dead. Death is a separate, subsequent ev
 
 [%header,cols="1,2,4"]
 |===
-| State | Condition | What It Means
+| State | Status | What It Means
 
 | *Broken / Unconscious* | Any Attribute = 0. Critical Injury rolled. | Character is incapacitated. They can still be saved.
 | *Dying* | Broken with a Death Check Critical Injury (result marked †) — and the Death Check has not yet been resolved, or was survived but the underlying injury is active (Bleeding, Gutted). | The window for stabilization is closing. An untreated Dying character will die.
@@ -81,7 +81,7 @@ To stabilize a Dying ally during the stabilization window:
 * *Action:* Slow Action
 * *Requirements:* A First Aid Kit must be present. Without one, the roll is made at −2 dice.
 * *Difficulty:* 2 (normal), 3 (if Gutted or Arterial Strike), 4 (if DOA attempted mid-round)
-* *On success:* The Dying condition is resolved. The Critical Injury remains. The character is Broken/Unconscious but no longer dying. They need rest and proper medical care, but they will live.
+* *On success:* The Dying state is resolved. The Critical Injury remains. The character is Broken/Unconscious but no longer dying. They need rest and proper medical care, but they will live.
 * *On failure:* Stabilization attempt failed. The character may try again if time permits (same scene). Each failed attempt reduces the character's current Strength by 1 (the effort causes further distress).
 
 === Instant Death
@@ -238,9 +238,9 @@ Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Corru
 
 === Cross-References
 
-* *Corruption gain* from mental criticals is applied immediately (see `docs/chapters/07-resonance-corruption.adoc`).
-* *Healing in the field:* First Aid Kit, Heal skill, Psychoanalyze skill — see `docs/chapters/08-skills.adoc` _(Issue #7)_.
-* *Downtime recovery:* Between-mission phases and Keep medical access — see `docs/chapters/09-base-management.adoc` _(Issue #12)_.
+* *Corruption gain* from mental criticals is applied immediately (see `docs/chapters/07-corruption.adoc`).
+* *Healing in the field:* First Aid Kit, Heal skill, Psychoanalyze skill — see `docs/chapters/08-healing.adoc`.
+* *Downtime recovery:* Between-mission phases and Keep medical access — see `docs/chapters/14-headquarters.adoc`.
 * *Death and dying procedure:* Full death check rules with autopsy and Covenant notification — see _(Issue #13)_.
 * *Artifact Imprint and Veil Burn:* Interaction with artifact containment rituals — see `docs/chapters/12-artifacts.adoc` _(Issue #9)_.
 

--- a/docs/chapters/07-corruption.adoc
+++ b/docs/chapters/07-corruption.adoc
@@ -4,7 +4,7 @@
 
 == The Corruption Track
 
-Corruption starts at *0* and increases from there. There is no separate "Resonance pool," no volatile buffer, and no cascade check — Corruption is gained directly from its sources and healed by its methods.
+Corruption starts at *0* and increases from there. It is gained directly from its sources and reduced (slowly) by its methods — there is no buffer, no cascade, and no shortcut.
 
 *Maximum Corruption Threshold* = `10 + Empathy score`
 

--- a/docs/chapters/10-advancement.adoc
+++ b/docs/chapters/10-advancement.adoc
@@ -101,7 +101,7 @@ Experience Points (XP) are awarded at the end of each Case File through a struct
 
 == General Talents
 
-General Talents are specialized perks available to *any character*, providing mechanical exceptions or situational bonuses:
+General Talents are specialized abilities available to *any character*, providing mechanical exceptions or situational bonuses:
 
 [%header,cols="2,4"]
 |===

--- a/docs/chapters/13-case-file.adoc
+++ b/docs/chapters/13-case-file.adoc
@@ -158,7 +158,7 @@ Faster clocks create urgency but reduce investigation time. Slower clocks allow 
 == Cross-References
 
 * GM guidance for building and calibrating Countdown clocks: `docs/chapters/18-gm-guidance.adoc`
-* Corruption gain mechanics: `docs/chapters/07-resonance-corruption.adoc`
+* Corruption gain mechanics: `docs/chapters/07-corruption.adoc`
 * Wayfinder Division rituals: `docs/chapters/15-rival-factions.adoc` (and Issue #15)
 
 ---
@@ -185,7 +185,7 @@ Roll two d6s: the first die is the tens digit, the second is the units digit.
 | 11 | Cassette tape               | Recordings of events before they happen; playback causes hemorrhaging
 | 12 | Pocket watch                | Stops time in a 5-meter radius for d6 rounds; user ages accelerated
 | 13 | Hospital chart              | Accurate medical diagnosis of anyone named in it; reading causes symptoms
-| 14 | Photograph                  | Shows what the subject fears most; viewing drives Fear roll
+| 14 | Photograph                  | Shows what the subject fears most; viewing drives Fear check
 | 15 | Book (journal/diary)        | Compels reader to continue until finished; knowledge is real and dangerous
 | 16 | Vinyl record                | Music causes compliance in listeners within earshot; player is compelled too
 | 21 | Military dog tags           | Reveals the moment of death of anyone who held the tags

--- a/docs/chapters/17-bestiary.adoc
+++ b/docs/chapters/17-bestiary.adoc
@@ -39,7 +39,7 @@ Motivation: One sentence describing what this adversary wants in this scene.
 * *Attributes* are used exactly as PC attributes — as both dice pool maximums and health pools. When Strength reaches 0, the adversary is Broken.
 * *Skills not listed* default to 0.
 * *Armor Rating* functions identically to PC armor — Gear dice rolled against incoming damage.
-* *Fear Rating* applies to supernatural entities and rare humans. 0 = no Fear check triggered. See `docs/chapters/07-resonance-corruption.adoc`.
+* *Fear Rating* applies to supernatural entities and rare humans. 0 = no Fear check triggered. See `docs/chapters/07-corruption.adoc`.
 * *Broken State* defines what happens when the adversary's Strength hits 0.
 * *Damage types* in special abilities should specify their type and target: Physical (STR or AGI), Mental (WIT or EMP), or Corruption. See `docs/chapters/06-health-damage-armor.adoc`.
 
@@ -306,10 +306,10 @@ For quick reference when building encounters:
 
 == Cross-References
 
-* Fear ratings and check triggers: `docs/chapters/07-resonance-corruption.adoc`
+* Fear ratings and check triggers: `docs/chapters/07-corruption.adoc`
 * Faction affiliations and politics: `docs/chapters/15-rival-factions.adoc` _(Issue #14)_
 * Artifacts and what spawns Constructs: `docs/chapters/12-artifacts.adoc` _(Issue #9 origin)_
-* Corruption gain from supernatural sources: `docs/chapters/07-resonance-corruption.adoc`
+* Corruption gain from supernatural sources: `docs/chapters/07-corruption.adoc`
 
 ---
 
@@ -509,7 +509,7 @@ profile (e.g., a dead Firearms 3 agent becomes a Wraith with Firearms 3).
 
 === Corruption Threshold and Behavior
 
-The Corruption thresholds from `docs/chapters/07-resonance-corruption.adoc` apply to NPCs as well as agents. For simplicity, the GM tracks NPC corruption with a three-stage shorthand:
+The Corruption thresholds from `docs/chapters/07-corruption.adoc` apply to NPCs as well as agents. For simplicity, the GM tracks NPC corruption with a three-stage shorthand:
 
 [%header,cols="^1,2,4"]
 |===

--- a/docs/chapters/18-gm-guidance.adoc
+++ b/docs/chapters/18-gm-guidance.adoc
@@ -207,4 +207,4 @@ Roll when you need an unexpected complication mid-case, when a scene is going to
 * Artifact properties and Tiers: `docs/chapters/12-artifacts.adoc`
 * Rival faction behavior and agendas: `docs/chapters/15-rival-factions.adoc`
 * Entity stat blocks and Fear ratings: `docs/chapters/17-bestiary.adoc`
-* Corruption consequences: `docs/chapters/07-resonance-corruption.adoc`
+* Corruption consequences: `docs/chapters/07-corruption.adoc`

--- a/docs/chapters/19-travel.adoc
+++ b/docs/chapters/19-travel.adoc
@@ -43,7 +43,7 @@ Each leg, the driver (or lead navigator on foot) makes a skill roll:
 
 === Phase 3 — Arrival
 
-On arrival, any Conditions accumulated during travel are active. Any gear that was pushed during travel may be degraded. The team notes which scene they arrive in (Phase 4 or 5 of the Case File structure).
+On arrival, any damage or injuries sustained during travel remain in effect. Any gear that was pushed during travel may be degraded. The team notes which scene they arrive in (Phase 4 or 5 of the Case File structure).
 
 ---
 
@@ -129,7 +129,7 @@ If the team reaches the destination with a tail still on them:
 
 == Being Followed — Named Threat Complication
 
-If the tail is a Named Threat or a designated faction operative (introduced in the adventure), losing them requires a *Contested Roll*: the team's skill roll is opposed by the tail's relevant skill (Sneak or Investigate, Difficulty set by that NPC's Wits).
+If the tail is a Named Threat or a designated faction operative (introduced in the Case File), losing them requires a *Contested Roll*: the team's skill roll is opposed by the tail's relevant skill (Sneak or Investigate, Difficulty set by that NPC's Wits).
 
 If the Named Threat is allowed to arrive at the destination, they are briefed on the team's location. The GM may use this to introduce them as a threat in the Confrontation phase instead of an earlier scene.
 


### PR DESCRIPTION
## Summary

Full continuity review across all 21 chapter files. Fixes all dangling references to removed mechanics and ensures consistent terminology.

### Changes (9 files)

**File rename:**
- `07-resonance-corruption.adoc` → `07-corruption.adoc` — removes last "Resonance" from the codebase structure

**Cross-reference updates (7 files):**
- Updated all 10 cross-references to the renamed ch07 file across ch04, ch05b, ch06, ch13, ch17, ch18
- Fixed `08-skills.adoc` → `08-healing.adoc` (file didn't exist)
- Fixed `14-factions.adoc` → `15-rival-factions.adoc` (file didn't exist)
- Fixed `09-base-management.adoc` → `14-headquarters.adoc` (file didn't exist)

**Term consistency fixes:**
- ch07: Removed "Resonance pool" disclaimer (unnecessary post-simplification)
- ch06: "Condition" → "Status" in death states table header; "Dying condition" → "Dying state"
- ch19: "any Conditions accumulated during travel" → "any damage or injuries sustained during travel" (removed Conditions system reference)
- ch13: "Fear roll" → "Fear check" (per standard terminology)
- ch10: "perks" → "abilities" (per standard terminology)
- ch19: "adventure" → "Case File" (per standard terminology)

### Verified clean
- Only 2 "resonance" instances remain: narrative lore in ch16 ("alchemical resonance", "poetic resonance") — English words, not game mechanics
- All "Condition" uses are now either gear condition, artifact activation condition, or weather/medical context — no references to the removed Conditions system
- Step numbering (1–12) verified consistent between overview, detail, and worked example

Closes #76