### PR TITLE
feat(#78): create glossary of game terms

### DIFF
--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -1,0 +1,165 @@
+= Glossary of Game Terms
+
+Quick reference for all game-specific terms used in the Neon Relic core rules. Entries are alphabetical. Cross-references point to the chapter where the full rules appear.
+
+---
+
+== A
+
+*Age Group*::
+Character creation choice determining starting Attribute and Skill point pools. Three tiers: Young (14 attribute / 10 skill), Experienced (13 / 12), Senior (12 / 14). See `docs/chapters/01-introduction.adoc`.
+
+*Anchor*::
+A physical object linked to a humanizing memory. Once per session, a character may interact with their Anchor to heal 1d4 Corruption. See `docs/chapters/08-healing.adoc`.
+
+*Armor Rating*::
+The number of Gear dice rolled to absorb incoming damage. Each 6 rolled cancels one point of damage. See `docs/chapters/06-health-damage-armor.adoc`.
+
+*Attribute Dice*::
+White dice in the pool, equal to the relevant Attribute score (Strength, Agility, Wits, or Empathy). See `docs/chapters/04-core-mechanics.adoc`.
+
+== B
+
+*Background*::
+Recovery Division's equivalent of Departments. Defines the agent's pre-Covenant expertise and grants narrative hooks. See `docs/chapters/09-divisions.adoc`.
+
+*Broken*::
+State when any Attribute reaches 0. The character is incapacitated and rolls on the appropriate Critical Injury table (Physical or Mental). See `docs/chapters/06-health-damage-armor.adoc`.
+
+== C
+
+*Case File*::
+A structured mystery/investigation for the team to complete. The standard episodic play format, divided into phases: Briefing, Travel, Investigation, Confrontation, and Resolution. See `docs/chapters/13-case-file.adoc`.
+
+*Clearance Level (CL)*::
+Seniority and authorization rank within the Covenant, ranging from 1 (probationary) to 4 (senior operative). Determines gear access and organizational authority. See `docs/chapters/01-introduction.adoc`.
+
+*Corruption*::
+Cumulative psychological and occult damage track. Gained from pushing rolls, Division Talent activation, Fear, artifact use, and supernatural exposure. *Maximum Corruption Threshold* = 10 + Empathy score; exceeding it causes permanent catatonia and character retirement. See `docs/chapters/07-corruption.adoc`.
+
+*Critical Injury*::
+A specific wound or trauma rolled on a D66 table when a character becomes Broken. Physical criticals use the Physical table (STR/AGI = 0); mental criticals use the Mental & Emotional table (WIT/EMP = 0). Some entries are marked † (Death Check). See `docs/chapters/06-health-damage-armor.adoc`.
+
+== D
+
+*D66*::
+A roll of two six-sided dice read as a two-digit number (first die = tens, second = units). Used for Critical Injury tables. Range: 11–66.
+
+*Damage Type*::
+One of three categories: *Physical* (targets STR or AGI), *Mental* (targets WIT or EMP), or *Corruption* (added directly to the Corruption track). See `docs/chapters/06-health-damage-armor.adoc`.
+
+*Dark Secret*::
+A specific hidden fact from the character's past — an event, decision, or relationship someone wants buried. Serves as a roleplay device and XP hook ("Did your Dark Secret complicate the mission?" = +1 XP). See `docs/chapters/10-advancement.adoc`.
+
+*Death Check*::
+A single d6 roll required when a Critical Injury is marked †. On 1–2: the character dies (or is permanently retired for mental death). On 3–6: survival, but the Critical Injury still applies. See `docs/chapters/06-health-damage-armor.adoc`.
+
+*Department*::
+Specialization within a Division (Wayfinder, Keep, Stack). Determines the character's field expertise and Department Skill. Recovery uses Backgrounds instead. See `docs/chapters/09-divisions.adoc`.
+
+*Difficulty*::
+The number of successes (6s) required to pass a skill roll. Standard range: 1 (routine) to 5+ (extreme). See `docs/chapters/04-core-mechanics.adoc`.
+
+*Division*::
+Character class within the Verdant Covenant. Four playable Divisions: Wayfinder (research/intelligence), Recovery (field retrieval), The Keep (vault security), and Stack (logistics). See `docs/chapters/09-divisions.adoc`.
+
+*Division Item*::
+A signature supernatural object issued to every member of a Division. Wayfinder: Verdant Codex. Recovery: Verdant Satchel. Keep: Warden's Bracer. See `docs/chapters/09-divisions.adoc`.
+
+*Division Talent*::
+A class-specific ability unique to one Division. Costs +1 Corruption to activate (most talents). See `docs/chapters/09-divisions.adoc`.
+
+*Dying*::
+State when a Broken character has an active Death Check Critical Injury (result marked †) that has not yet been resolved. An untreated Dying character will die. See `docs/chapters/06-health-damage-armor.adoc`.
+
+== F
+
+*Fast Action*::
+One of three action types in combat. Represents a quick or secondary effort: moving one zone, drawing a weapon, taking cover, or using a small item. See `docs/chapters/03b-combat.adoc`.
+
+*Fear Check*::
+A Wits roll triggered by supernatural horror. Each 6 = success. Each 1 = +1 Corruption. No successes = failure (+1 Corruption + Panic Table roll). See `docs/chapters/07-corruption.adoc`.
+
+*Fear Rating*::
+Narrative classification (0–5) of how terrifying a creature or event is. Used by the GM to determine when to call for a Fear check. 0 = no check triggered. See `docs/chapters/07-corruption.adoc`.
+
+*Free Action*::
+An action in combat that requires negligible effort: speaking a short sentence, dropping an item, or glancing at surroundings. Unlimited per turn. See `docs/chapters/03b-combat.adoc`.
+
+== G
+
+*Gear Dice*::
+Black dice in the pool contributed by equipment. Each 1 rolled on a Gear die causes the item to degrade one step. See `docs/chapters/04-core-mechanics.adoc`.
+
+*General Talent*::
+A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. See `docs/chapters/10-advancement.adoc`.
+
+== H
+
+*Headquarters (HQ)*::
+The Covenant facility serving as the team's base of operations between Case Files. Provides medical care, equipment requisition, research facilities, and downtime activities. See `docs/chapters/14-headquarters.adoc`.
+
+== I
+
+*Insight*::
+A permanent mechanical bonus gained from certain Critical Injuries, marked *(Insight)* in the injury name or effect. Represents a silver lining from trauma — heightened perception, empathy, or expertise. Cannot be removed. See `docs/chapters/06-health-damage-armor.adoc`.
+
+== M
+
+*Maximum Corruption Threshold*::
+The point at which a character's mind permanently fractures: 10 + Empathy score. Exceeding this value retires the character. See `docs/chapters/07-corruption.adoc`.
+
+== N
+
+*Named Threat*::
+A significant antagonist in a Case File — a faction operative, corrupted NPC, or supernatural entity important enough to have a name, motivations, and stat block. See `docs/chapters/13-case-file.adoc`.
+
+== P
+
+*Panic Table*::
+A d6 table rolled on Fear check failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See `docs/chapters/07-corruption.adoc`.
+
+*Push*::
+Re-roll all non-6 dice after a failed roll. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See `docs/chapters/04-core-mechanics.adoc`.
+
+*Psychoanalyze*::
+A skill used to treat mental and emotional Critical Injuries. Recovery difficulty and duration vary by injury severity. See `docs/chapters/06-health-damage-armor.adoc`.
+
+== R
+
+*Relationship*::
+An NPC bond defined during character creation. Three slots: a trusted contact, a dependent, and a rival/enemy. Used as roleplay anchors and GM hooks. See `docs/chapters/01-introduction.adoc`.
+
+== S
+
+*Skill Dice*::
+Green dice in the pool, equal to the relevant Skill rating (0–5). See `docs/chapters/04-core-mechanics.adoc`.
+
+*Slow Action*::
+One of three action types in combat. Represents a committed effort: attacking, using a skill, administering first aid, or reloading a weapon. See `docs/chapters/03b-combat.adoc`.
+
+*Stunt Points*::
+Extra successes (6s) beyond the first on an attack roll, spent on special combat effects such as increased damage, disarming, or knockback. See `docs/chapters/03b-combat.adoc`.
+
+== T
+
+*The Verdant Covenant*::
+The ancient secret society the player characters serve. Discovers, recovers, and contains supernatural artifacts to protect humanity. Organized into three operational Divisions (Wayfinder, Recovery, The Keep) plus Stack (Logistics). See `docs/chapters/02-verdant-covenant.adoc`.
+
+== V
+
+*Verdant Codex*::
+Wayfinder Division Item. An enchanted field journal that secures memory, decodes language, maps artifact locations, and preserves documents. See `docs/chapters/09-divisions.adoc`.
+
+*Verdant Satchel*::
+Recovery Division Item. A specially enchanted field bag that suppresses artifact aura, seals cursed items, warns of instability, and produces basic tools on demand. See `docs/chapters/09-divisions.adoc`.
+
+== W
+
+*Warden's Bracer*::
+Keep Division Item. Suppresses artifact magic, warns of containment failure, enables safe handling of cursed objects, absorbs 1 Corruption per session, and grants +1 Armor Rating. See `docs/chapters/09-divisions.adoc`.
+
+== Z
+
+*Zone*::
+An abstract area of space used for combat positioning — a room, corridor, alley, or rooftop section. Moving one zone costs a Fast Action; moving two zones (running) costs both the Fast and Slow Action for the round. See `docs/chapters/03b-combat.adoc`.


### PR DESCRIPTION
## Summary

Creates a comprehensive alphabetical glossary of all game-specific terms used throughout the Neon Relic core rules.

### New file
- `docs/chapters/20-glossary.adoc` — 165 lines, 40 defined terms

### Terms included (A–Z)
Age Group, Anchor, Armor Rating, Attribute Dice, Background, Broken, Case File, Clearance Level (CL), Corruption, Critical Injury, D66, Damage Type, Dark Secret, Death Check, Department, Difficulty, Division, Division Item, Division Talent, Dying, Fast Action, Fear Check, Fear Rating, Free Action, Gear Dice, General Talent, Headquarters (HQ), Insight, Maximum Corruption Threshold, Named Threat, Panic Table, Push, Psychoanalyze, Relationship, Skill Dice, Slow Action, Stunt Points, The Verdant Covenant, Verdant Codex, Verdant Satchel, Warden's Bracer, Zone

Each entry: bold term, one-sentence definition, cross-reference to the chapter containing the full rules.

Closes #78