### PR TITLE
feat(#101,#107,#111): globalize language and add Country of Origin to worked example

### DIFF
--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -220,7 +220,7 @@ Choose a name appropriate for your campaign's 1980s setting. Record your *Countr
 
 > *Country of Origin Guidance:* This is primarily narrative. Use it to inform your accent, contacts, cultural references, and how local authorities read you in the field. Do not apply mandatory mechanical modifiers.
 
-> *1980s Name Inspiration:* The era favors names like Karen, Debbie, Steve, Randall, Tracy, Rick, Tamara, Dale, Connie, Barry. Use names and surnames that fit your country of origin and assignment history.
+> *1980s Name Inspiration:* Choose names authentic to your character's country of origin and cultural background. British Isles: Margaret, Colin, Siobhan, Alistair. France: Isabelle, François, Nathalie, Michel. Germany: Ursula, Dieter, Heike, Jürgen. Japan: Kenji, Noriko, Takeshi, Yuki. Use surnames that fit your cultural heritage and the era — the 1980s had specific naming fashions in every country.
 
 ---
 
@@ -319,6 +319,9 @@ Petra records the *Verdant Satchel* automatically. From the Recovery Kit she tak
 
 > *Dark Secret:* Petra's former DEA supervisor is now working for *The Vantablack Compact*. She has not reported this.
 
-=== Step 11: Biography
+=== Step 11: Name, Country of Origin, and Biography
 
-_"Petra Vasquez, former DEA Special Agent, six years in field operations before the Tucson Incident. The Covenant found her two days after the raid. She's never asked them how they knew."_
+* *Name:* Petra Vasquez
+* *Country of Origin:* United States (California)
+
+> _"Former DEA Special Agent, six years in field operations before the Tucson Incident. The Covenant found her two days after the raid. She's never asked them how they knew."_

--- a/docs/chapters/14-gm-guidance.adoc
+++ b/docs/chapters/14-gm-guidance.adoc
@@ -52,7 +52,7 @@ Every Case File (mission) is built on five elements. You don't need all five ful
 |===
 | Element | Question | Design Note
 
-| *Location* | Where is this happening? | One specific place — a town, a building, a neighborhood. Not a region. One gas station in rural Wyoming. One hospital. One concert venue. The 1980s location should feel tactile and era-specific.
+| *Location* | Where is this happening? | One specific place — a town, a building, a neighborhood. Not a region. One petrol station on a rural motorway. One hospital. One concert venue. The 1980s setting should feel tactile and era-specific — wherever your campaign is based, the location must have a physical reality your players can picture.
 | *Artifact* | What is the sourcebook item? | The thing that caused events to spiral. Every case has one artifact. Define its *Tier* (1–4), its *apparent property* (what it seems to do), and its *real effect* (what it actually does to the world around it).
 | *Threat* | What is the immediate danger? | The presenting problem: the entity, the cultist cell, the MJ-12 investigation, the cover-up. This is what the Covenant is responding to.
 | *Rival Faction* | Who else wants the artifact? | Even low-stakes cases should have a second party. The Compact, a private collector, a true believer. Rival factions create competing agendas and prevent simple extraction.
@@ -65,7 +65,7 @@ Write one sentence that describes the full case:
 
 _"A [Tier X artifact] has surfaced in [Location], attracting [Threat]. [Rival Faction] is already present. The complication: [personal element]."_
 
-Example: *"A Tier 2 artifact has surfaced in a shuttered Ohio psychiatric hospital, attracting Echoing Remnants that have begun killing the urban explorers who found the site. The Hellfire Consortium has purchased the property and has a crew inside. The complication: one of the explorers is the sister of Agent Castellano's disappeared informant."*
+Example: *"A Tier 2 artifact has surfaced in a shuttered psychiatric hospital outside Palermo, attracting Echoing Remnants that have begun killing the urban explorers who found the site. The Hellfire Consortium has purchased the property and has a crew inside. The complication: one of the explorers is the sister of Agent Castellano's disappeared informant."*
 
 If your mystery statement doesn't fit in one sentence, you have too much. Cut.
 

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -329,12 +329,12 @@ Use this procedure to run from nothing to a playable case in one pass:
 > *Location:* 2 (Research laboratory — university).
 > *Complication:* 3 (Media attention — journalist, 48-hour deadline).
 >
-> **Case Setup:** The physics department at Holbrook University in Columbus, Ohio
+> **Case Setup:** The physics department at Holbrook University in Aberdeen, Scotland
 > has been receiving anomalous radio transmissions for three weeks. A Covenant analyst
 > matched the frequency signature to a Tier 2 artifact: a surplus military radio receiver
 > modified with components sourced from a 1943 German ESP research program. A local
-> science reporter is writing a "mystery signal" human-interest piece for the Columbus
-> Dispatch — deadline Friday.
+> science reporter is writing a "mystery signal" human-interest piece for the Aberdeen
+> Herald — deadline Friday.
 >
 > **Clock:** The journalist's article runs Friday morning. If the artifact is not
 > secured by then, the story triggers federal interest and the Covenant loses access


### PR DESCRIPTION
Closes #101, #107, #111\n\n## Changes\n\n- **#111 / #101**: Updated Petra Vasquez worked example (Step 11) to explicitly show `Name:` and `Country of Origin:` as separate fields, demonstrating the new character-identity step in practice.\n- **#107 / #101**: Replaced US-centric 1980s name examples (Karen, Debbie, Steve, etc.) with a globally representative list covering British Isles, French, German, and Japanese names.\n- **#107**: Globalized the Five-Element Mystery location example in DA Guidance — replaced \"gas station in rural Wyoming\" with neutral phrasing and \"Ohio psychiatric hospital\" with \"psychiatric hospital outside Palermo\".\n- **#107**: Replaced \"Columbus, Ohio\" and \"Columbus Dispatch\" in the Case File worked example with \"Aberdeen, Scotland\" and \"Aberdeen Herald\".\n\n## Done When Checklist\n- [x] Step 11 text includes Country of Origin prompt\n- [x] At least one example character shows the new field in use\n- [x] No US-only default framing remains in player-facing rules\n- [x] Tone and clarity remain consistent"