### PR TITLE
feat(#98,#110): add large zone edge case to Zone-to-Grid conversion

### DIFF
--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -141,6 +141,8 @@ Zones remain the canonical movement/range system. For VTT or tactical play, use 
 
 *Verticality:* Moving one significant elevation change (one story, catwalk, roof transition) usually costs one zone even if square distance is short.
 
+*Large or open zones:* Some zones (car parks, fields, warehouse floors, concert halls) are physically large. The DA sets zone extent before combat begins. A large zone may span 20–50 squares; players and the DA should confirm expected grid width before the first round. Open-zone features do not reduce zone count — only the Fast Action cost applies.
+
 === Zone Features
 
 Every zone has optional *terrain features* the DA can invoke:


### PR DESCRIPTION
Closes #98, #110\n\n## Changes\n\n- Added explicit **large/open zone edge case** note to the Zone-to-Grid Conversion section in the Combat chapter.\n- Clarifies that large zones (car parks, fields, warehouses) may span 20–50 squares, and that the DA sets zone extent before combat begins.\n\n## Done When Checklist\n- [x] Conversion table appears in combat chapter\n- [x] Core movement/range examples include at least one dual-format example\n- [x] Guidance covers edge cases (large zones ✓, verticality ✓, obstacles ✓)\n- [x] Guidance states zones remain canonical with grid translation optional"