### PR TITLE
feat(#93): add session debrief and CL advancement worked example

### DIFF
--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -102,6 +102,46 @@ Experience Points (XP) are awarded at the end of each Case File through a struct
 
 Clearance increases represent institutional trust and access expansion, not just personal capability. DAs should require a fiction trigger (mission performance, formal commendation, reassignment, or political sponsorship) before the increase is finalized.
 
+=== Worked Example: Session Debrief and CL Increase
+
+The following shows a typical post-session debrief for *Agent Yusuf Demi*, a Keep Warden currently at Clearance Level 2 with 8 XP carried over from the previous Case File.
+
+*The DA runs the debrief questions:*
+
+[%header,cols="3,1,2"]
+|===
+| Debriefing Question | Answer | Result
+
+| Did you participate in the session?
+| Yes
+| +1 XP
+
+| Did you risk your life for a fellow Covenant member or an innocent civilian?
+| Yes — Yusuf entered the artifact room to pull Agent Skovgaard to safety when triple-layer containment cracked.
+| +1 XP
+
+| Did your Dark Secret complicate the mission, or did you interact heavily with your Anchor?
+| Yes — the mission contact recognised Yusuf from the unauthorised transfer incident; Yusuf had to manage that conversation while the team worked.
+| +1 XP
+
+| Did the team successfully secure or contain an Occult Artifact?
+| Yes — the artifact reached the Keep vault intact.
+| +1 XP
+
+| Did you learn something new and significant about the supernatural threat or rival factions?
+| No — the team already knew the artifact's provenance from prior Wayfinder reports.
+| —
+|===
+
+*Result: 4 XP earned this session.* Added to 8 XP carried over: *12 XP total.*
+
+*Yusuf's player spends XP:*
+
+* *3 XP → Clearance Level increase (CL 2 → CL 3).* The Watch Commander issued a formal written commendation during the case closure review, explicitly noting the intact transport as mission-critical. The DA agrees this is a valid fiction trigger and approves the increase.
+* *9 XP remain* for future sessions.
+
+> *DA note:* CL increases are not automatic once the 3 XP threshold is met. A fiction trigger must exist — a commendation, a formal reassignment, or a documented mission assessment that the Covenant acknowledges. If the trigger hasn't been established in play, ask the player to name one before approving. The increase marks institutional recognition, not just personal growth.
+
 == General Talents
 
 General Talents are specialized abilities available to *any character*, providing mechanical exceptions or situational bonuses:


### PR DESCRIPTION
Closes #93\n\n## Changes\n\nAdded a **Worked Example: Session Debrief and CL Increase** section to `13-advancement.adoc`, inserted after the XP spend table's CL increase note.\n\nThe example:\n- Shows a full 5-question debrief for Agent Yusuf Demi (Keep Warden)\n- Demonstrates XP carry-over math (8 XP + 4 XP = 12 XP)\n- Shows a CL increase spend (3 XP, CL 2 → CL 3)\n- Includes a DA note explaining that CL increases require a fiction trigger — not automatic\n\n## Done When\n- [x] Worked example exists in advancement chapter\n- [x] Example covers the CL increase specifically\n- [x] DA note clarifies fiction trigger requirement"