### PR TITLE
feat(#94,#105,#106): convert all backtick path refs to xref: format; add PDF link validation step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -428,6 +428,28 @@ git status
 
 Ensure the working tree is clean before release packaging.
 
+### 1a. Validate AsciiDoc Cross-References
+
+Before building, verify that no chapter file contains raw file-path references that render as broken links in the PDF. Run from the repo root — the command should return **no output**:
+
+```powershell
+Select-String -Path docs/chapters/*.adoc -Pattern '`docs/chapters/'
+```
+
+If any lines are returned, convert each match from:
+
+```adoc
+`docs/chapters/XX-name.adoc`
+```
+
+to the proper AsciiDoc cross-reference format:
+
+```adoc
+xref:XX-name.adoc[Chapter Title]
+```
+
+Fix all hits before proceeding with the build.
+
 ### 2. Build/Verify Output Artifact
 
 The release asset should be a zip containing the generated output file(s) from `docs/output/`.

--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -20,7 +20,7 @@ Your *Division* is your character class. It defines your role within the Covenan
 
 > *Clearance Level (CL)* represents your seniority and authorization within the Covenant. A higher CL grants access to better gear requisitions and more sensitive intelligence. Your final CL equals your Division's base CL plus your Age Group modifier (minimum 1).
 
-Read the full Division descriptions in `docs/chapters/09-divisions.adoc` before making your choice.
+Read the full Division descriptions in xref:09-divisions.adoc[Divisions] before making your choice.
 
 ---
 

--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -32,7 +32,7 @@ However, pushing represents the character exerting maximum physical, mental, or 
 
 * You immediately gain *+1 Corruption*.
 
-> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see `docs/chapters/08-corruption-fear-healing.adoc` for the full rules.
+> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing] for the full rules.
 
 The analog nature of 1980s technology perfectly complements this mechanical attrition. Pushing a gear-assisted roll might degrade the item — short-circuiting alkaline batteries or jamming mechanisms — effectively reducing its inherent bonus until it can be repaired during downtime.
 

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -57,7 +57,7 @@ When you roll more 6s than the *minimum needed to succeed*, each extra 6 is a *S
 * You may split stunt points across multiple effects if both are available on the same skill.
 * On a *pushed roll*, stunt points still apply from the new result.
 
-> *Cross-reference:* Combat stunts — spending stunt points during an attack roll — are defined in the Combat chapter (`docs/chapters/05-combat.adoc`). The stunt economy is the same.
+> *Cross-reference:* Combat stunts — spending stunt points during an attack roll — are defined in the Combat chapter (xref:05-combat.adoc[Combat]). The stunt economy is the same.
 
 === Generic Stunts (Any Skill)
 

--- a/docs/chapters/06-social-conflict.adoc
+++ b/docs/chapters/06-social-conflict.adoc
@@ -132,7 +132,7 @@ Social encounters with entities, artifacts, or cult members may cross into super
 * *Direct supernatural revelation during a Manipulate scene* (the NPC says something that cannot be explained naturally): Fear check, Fear Rating 1 or 2.
 * *Psychoanalyze roll on a contaminated NPC* (someone who has long-term artifact exposure): Roll Psychoanalyze as normal. On any failure, the agent picks up a psychic echo — immediate Fear check, Fear Rating 2. On success, the agent gets the information but gains +1 Corruption.
 
-See `docs/chapters/08-corruption-fear-healing.adoc` for full Fear check rules.
+See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing] for full Fear check rules.
 
 ---
 
@@ -168,7 +168,7 @@ Another Manipulate roll at Difficulty 2 (they're now at 3). Marcus rolls: 6, 5, 
 
 == Cross-References
 
-* Skills in context: `docs/chapters/04-attributes-skills.adoc`
-* Fear checks during social scenes: `docs/chapters/08-corruption-fear-healing.adoc`
-* Using Manipulate stunts: `docs/chapters/04-attributes-skills.adoc` (Skill Stunts)
-* NPC Faction relationships: `docs/chapters/17-rival-factions.adoc`
+* Skills in context: xref:04-attributes-skills.adoc[Attributes & Skills]
+* Fear checks during social scenes: xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing]
+* Using Manipulate stunts: xref:04-attributes-skills.adoc[Attributes & Skills] (Skill Stunts)
+* NPC Faction relationships: xref:17-rival-factions.adoc[Rival Factions]

--- a/docs/chapters/07-health-damage-armor.adoc
+++ b/docs/chapters/07-health-damage-armor.adoc
@@ -238,11 +238,11 @@ Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Corru
 
 === Cross-References
 
-* *Corruption gain* from mental criticals is applied immediately (see `docs/chapters/08-corruption-fear-healing.adoc`).
+* *Corruption gain* from mental criticals is applied immediately (see xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing]).
 * *Healing in the field:* First Aid Kit, Heal skill, Psychoanalyze skill — see xref:08-corruption-fear-healing.adoc#_healing_corruption[Healing Corruption].
-* *Downtime recovery:* Between-mission phases and Keep medical access — see `docs/chapters/12-headquarters.adoc`.
+* *Downtime recovery:* Between-mission phases and Keep medical access — see xref:12-headquarters.adoc[Headquarters].
 * *Death and dying procedure:* Full death check rules with autopsy and Covenant notification — see _(Issue #13)_.
-* *Artifact Imprint and Veil Burn:* Interaction with artifact containment rituals — see `docs/chapters/11-artifacts.adoc` _(Issue #9)_.
+* *Artifact Imprint and Veil Burn:* Interaction with artifact containment rituals — see xref:11-artifacts.adoc[Artifacts] _(Issue #9)_.
 
 == Armor Mechanics
 

--- a/docs/chapters/08-corruption-fear-healing.adoc
+++ b/docs/chapters/08-corruption-fear-healing.adoc
@@ -165,6 +165,6 @@ Fear Rating is a *narrative tool* for the DA — it classifies how terrifying a 
 | *5* | Annihilating | A Class-5 entity. A tear in physical space. Direct contact with whatever the artifacts are *for*.
 |===
 
-Fear Ratings are a property of supernatural *entities* and *events*, not of individual characters. Add the Fear Rating stat to entity stat blocks in the Bestiary (`docs/chapters/19-bestiary.adoc`).
+Fear Ratings are a property of supernatural *entities* and *events*, not of individual characters. Add the Fear Rating stat to entity stat blocks in the Bestiary (xref:19-bestiary.adoc[Bestiary]).
 
 

--- a/docs/chapters/10-equipment.adoc
+++ b/docs/chapters/10-equipment.adoc
@@ -113,7 +113,7 @@ Supplies can be restocked:
 | *Artifact Components* (optional) | d6 | — | Ritual components, containment salts, reactive chemicals. Roll after each artifact interaction requiring preparation materials. DA may waive this for simple artifact containment.
 |===
 
-> *Ammo in combat:* The combat chapter tracks ammunition with an Ammo Resource Die by weapon class (see `docs/chapters/05-combat.adoc`). The values there override these defaults for in-combat rolls. The values above apply to *scene-level* tracking — they are rolled at the end of a fight, not per shot.
+> *Ammo in combat:* The combat chapter tracks ammunition with an Ammo Resource Die by weapon class (see xref:05-combat.adoc[Combat]). The values there override these defaults for in-combat rolls. The values above apply to *scene-level* tracking — they are rolled at the end of a fight, not per shot.
 
 === Scarcity in the 1980s Field
 
@@ -245,7 +245,7 @@ Coastal/river access. Cannot be followed by road vehicles. Night operations: −
 
 === Vehicle Conflict — Actions and Chase Rules
 
-Vehicle conflict follows the same chase structure as foot chases (`docs/chapters/05-combat.adoc`), with vehicle-specific modifications.
+Vehicle conflict follows the same chase structure as foot chases (xref:05-combat.adoc[Combat]), with vehicle-specific modifications.
 
 ==== Chase Structure
 
@@ -523,5 +523,5 @@ gives Stack agents mechanical advantages no other Division matches.
 
 > **Cross-reference:** Stack Division full description, background options, and Talents
 > (including *Jury-Rig*, *Prototyper*, *Duct Tape & WD-40*) are in
-> `docs/chapters/09-divisions.adoc`.
+> xref:09-divisions.adoc[Divisions].
 

--- a/docs/chapters/12-headquarters.adoc
+++ b/docs/chapters/12-headquarters.adoc
@@ -116,7 +116,7 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 | 6
 | Faraday Cage + Occult Laboratory
 | A reinforced sub-chamber within the Faraday Cage, retrofitted with seven-layer lead shielding, hand-drawn containment circles, and rotating salt-line maintenance. Costly to maintain and terrifying to enter alone.
-| Store up to *3 active artifacts* without passive corruption leaking to carriers. Artifacts in the vault do not add Enc. pressure (see `docs/chapters/11-artifacts.adoc`). Vault must be re-consecrated after 3 Case Files (Lore Difficulty 2; failure = 1 random artifact "wakes up").
+| Store up to *3 active artifacts* without passive corruption leaking to carriers. Artifacts in the vault do not add Enc. pressure (see xref:11-artifacts.adoc[Artifacts]). Vault must be re-consecrated after 3 Case Files (Lore Difficulty 2; failure = 1 random artifact "wakes up").
 
 | *Safe House Network*
 | 6

--- a/docs/chapters/14-gm-guidance.adoc
+++ b/docs/chapters/14-gm-guidance.adoc
@@ -258,8 +258,8 @@ Containment cases benefit from clocks with *loss conditions linked to exposure*,
 
 == Cross-References
 
-* Case File structure (8-phase structure, Countdown mechanics): `docs/chapters/15-case-file.adoc`
-* Artifact properties and Tiers: `docs/chapters/11-artifacts.adoc`
-* Rival faction behavior and agendas: `docs/chapters/17-rival-factions.adoc`
-* Entity stat blocks and Fear ratings: `docs/chapters/19-bestiary.adoc`
-* Corruption consequences: `docs/chapters/08-corruption-fear-healing.adoc`
+* Case File structure (8-phase structure, Countdown mechanics): xref:15-case-file.adoc[Case Files]
+* Artifact properties and Tiers: xref:11-artifacts.adoc[Artifacts]
+* Rival faction behavior and agendas: xref:17-rival-factions.adoc[Rival Factions]
+* Entity stat blocks and Fear ratings: xref:19-bestiary.adoc[Bestiary]
+* Corruption consequences: xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing]

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -23,7 +23,7 @@ Conducted at the player's Headquarters:
 
 . *Research* — Players use base facilities to research the entity or artifact.
 . *Equipping* — Players visit Stack to acquire gear. Roll a pool of dice equal to your *Clearance Level (CL)*. Every *6* allows you to requisition one item equal to or lower than your CL rating. Standard items (CL 1) are given freely within reason.
-. *Supply Acquisition* — All consumable supplies (ammunition, medical kits, batteries, rations) reset to their *starting die size* at no cost during this phase. See `docs/chapters/10-equipment.adoc` for the Resource Die system and per-category die sizes.
+. *Supply Acquisition* — All consumable supplies (ammunition, medical kits, batteries, rations) reset to their *starting die size* at no cost during this phase. See xref:10-equipment.adoc[Equipment] for the Resource Die system and per-category die sizes.
 
 == Phase 4: The Journey
 
@@ -57,7 +57,7 @@ Survivors return to base. During this phase:
 * Check if Critical Injury effects require ongoing treatment
 * Initiate new Headquarters upgrades
 
-During the Aftermath, the team earns *Development Points (DP)* based on their performance and spends them to build or expand the Headquarters upgrade tree (see `docs/chapters/12-headquarters.adoc` for the full upgrade tree, costs, and prerequisites). The Threat Meter is also updated — if the team was fully covert, it decreases by 1.
+During the Aftermath, the team earns *Development Points (DP)* based on their performance and spends them to build or expand the Headquarters upgrade tree (see xref:12-headquarters.adoc[Headquarters] for the full upgrade tree, costs, and prerequisites). The Threat Meter is also updated — if the team was fully covert, it decreases by 1.
 
 ---
 
@@ -157,9 +157,9 @@ Faster clocks create urgency but reduce investigation time. Slower clocks allow 
 
 == Cross-References
 
-* DA guidance for building and calibrating Countdown clocks: `docs/chapters/14-DA-guidance.adoc`
-* Corruption gain mechanics: `docs/chapters/08-corruption-fear-healing.adoc`
-* Wayfinder Division rituals: `docs/chapters/17-rival-factions.adoc` (and Issue #15)
+* DA guidance for building and calibrating Countdown clocks: xref:14-gm-guidance.adoc[Director of Agents Guidance]
+* Corruption gain mechanics: xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing]
+* Wayfinder Division rituals: xref:17-rival-factions.adoc[Rival Factions] (and Issue #15)
 
 ---
 

--- a/docs/chapters/19-bestiary.adoc
+++ b/docs/chapters/19-bestiary.adoc
@@ -39,9 +39,9 @@ Motivation: One sentence describing what this adversary wants in this scene.
 * *Attributes* are used exactly as PC attributes — as both dice pool maximums and health pools. When Strength reaches 0, the adversary is Broken.
 * *Skills not listed* default to 0.
 * *Armor Rating* functions identically to PC armor — Gear dice rolled against incoming damage.
-* *Fear Rating* applies to supernatural entities and rare humans. 0 = no Fear check triggered. See `docs/chapters/08-corruption-fear-healing.adoc`.
+* *Fear Rating* applies to supernatural entities and rare humans. 0 = no Fear check triggered. See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing].
 * *Broken State* defines what happens when the adversary's Strength hits 0.
-* *Damage types* in special abilities should specify their type and target: Physical (STR or AGI), Mental (WIT or EMP), or Corruption. See `docs/chapters/07-health-damage-armor.adoc`.
+* *Damage types* in special abilities should specify their type and target: Physical (STR or AGI), Mental (WIT or EMP), or Corruption. See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 === Simplified Humanoid Format
 
@@ -306,10 +306,10 @@ For quick reference when building encounters:
 
 == Cross-References
 
-* Fear ratings and check triggers: `docs/chapters/08-corruption-fear-healing.adoc`
-* Faction affiliations and politics: `docs/chapters/17-rival-factions.adoc` _(Issue #14)_
-* Artifacts and what spawns Constructs: `docs/chapters/11-artifacts.adoc` _(Issue #9 origin)_
-* Corruption gain from supernatural sources: `docs/chapters/08-corruption-fear-healing.adoc`
+* Fear ratings and check triggers: xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing]
+* Faction affiliations and politics: xref:17-rival-factions.adoc[Rival Factions] _(Issue #14)_
+* Artifacts and what spawns Constructs: xref:11-artifacts.adoc[Artifacts] _(Issue #9 origin)_
+* Corruption gain from supernatural sources: xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing]
 
 ---
 
@@ -509,7 +509,7 @@ profile (e.g., a dead Firearms 3 agent becomes a Wraith with Firearms 3).
 
 === Corruption Threshold and Behavior
 
-The Corruption thresholds from `docs/chapters/08-corruption-fear-healing.adoc` apply to NPCs as well as agents. For simplicity, the DA tracks NPC corruption with a three-stage shorthand:
+The Corruption thresholds from xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing] apply to NPCs as well as agents. For simplicity, the DA tracks NPC corruption with a three-stage shorthand:
 
 [%header,cols="^1,2,4"]
 |===

--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -1,4 +1,4 @@
-= Glossary of Game Terms
+﻿= Glossary of Game Terms
 
 Quick reference for all game-specific terms used in the Neon Relic core rules. Entries are alphabetical. Cross-references point to the chapter where the full rules appear.
 
@@ -7,38 +7,38 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 == A
 
 *Age Group*::
-Character creation choice determining starting Attribute and Skill point pools. Three tiers: Young (14 attribute / 10 skill), Experienced (13 / 12), Senior (12 / 14). See `docs/chapters/02-character-creation.adoc`.
+Character creation choice determining starting Attribute and Skill point pools. Three tiers: Young (14 attribute / 10 skill), Experienced (13 / 12), Senior (12 / 14). See xref:02-character-creation.adoc[Character Creation].
 
 *Anchor*::
 A physical object linked to a humanizing memory. Once per session, a character may interact with their Anchor to heal 1d4 Corruption. See xref:08-corruption-fear-healing.adoc#_anchors[Anchors].
 
 *Armor Rating*::
-The number of Gear dice rolled to absorb incoming damage. Each 6 rolled cancels one point of damage. See `docs/chapters/07-health-damage-armor.adoc`.
+The number of Gear dice rolled to absorb incoming damage. Each 6 rolled cancels one point of damage. See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 *Attribute Dice*::
-White dice in the pool, equal to the relevant Attribute score (Strength, Agility, Wits, or Empathy). See `docs/chapters/03-core-resolution.adoc`.
+White dice in the pool, equal to the relevant Attribute score (Strength, Agility, Wits, or Empathy). See xref:03-core-resolution.adoc[Core Resolution].
 
 == B
 
 *Background*::
-Recovery Division's equivalent of Departments. Defines the agent's pre-Covenant expertise and grants narrative hooks. See `docs/chapters/09-divisions.adoc`.
+Recovery Division's equivalent of Departments. Defines the agent's pre-Covenant expertise and grants narrative hooks. See xref:09-divisions.adoc[Divisions].
 
 *Broken*::
-State when any Attribute reaches 0. The character is incapacitated and rolls on the appropriate Critical Injury table (Physical or Mental). See `docs/chapters/07-health-damage-armor.adoc`.
+State when any Attribute reaches 0. The character is incapacitated and rolls on the appropriate Critical Injury table (Physical or Mental). See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 == C
 
 *Case File*::
-A structured mystery/investigation for the team to complete. The standard episodic play format, divided into phases: Briefing, Travel, Investigation, Confrontation, and Resolution. See `docs/chapters/15-case-file.adoc`.
+A structured mystery/investigation for the team to complete. The standard episodic play format, divided into phases: Briefing, Travel, Investigation, Confrontation, and Resolution. See xref:15-case-file.adoc[Case Files].
 
 *Clearance Level (CL)*::
-Seniority and authorization rank within the Covenant. Equals Division base CL plus Age Group modifier (Young −1, Experienced +0, Senior +1), minimum 1. Determines gear access and organizational authority. See `docs/chapters/02-character-creation.adoc`.
+Seniority and authorization rank within the Covenant. Equals Division base CL plus Age Group modifier (Young −1, Experienced +0, Senior +1), minimum 1. Determines gear access and organizational authority. See xref:02-character-creation.adoc[Character Creation].
 
 *Corruption*::
-Cumulative psychological and occult damage track. Gained from pushing rolls, Division Talent activation, Fear, artifact use, and supernatural exposure. *Maximum Corruption Threshold* = 10 + Empathy score; exceeding it causes permanent catatonia and character retirement. See `docs/chapters/08-corruption-fear-healing.adoc`.
+Cumulative psychological and occult damage track. Gained from pushing rolls, Division Talent activation, Fear, artifact use, and supernatural exposure. *Maximum Corruption Threshold* = 10 + Empathy score; exceeding it causes permanent catatonia and character retirement. See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing].
 
 *Critical Injury*::
-A specific wound or trauma rolled on a D66 table when a character becomes Broken. Physical criticals use the Physical table (STR/AGI = 0); mental criticals use the Mental & Emotional table (WIT/EMP = 0). Some entries are marked † (Death Check). See `docs/chapters/07-health-damage-armor.adoc`.
+A specific wound or trauma rolled on a D66 table when a character becomes Broken. Physical criticals use the Physical table (STR/AGI = 0); mental criticals use the Mental & Emotional table (WIT/EMP = 0). Some entries are marked † (Death Check). See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 == D
 
@@ -46,87 +46,87 @@ A specific wound or trauma rolled on a D66 table when a character becomes Broken
 A roll of two six-sided dice read as a two-digit number (first die = tens, second = units). Used for Critical Injury tables. Range: 11–66.
 
 *Damage Type*::
-One of three categories: *Physical* (targets STR or AGI), *Mental* (targets WIT or EMP), or *Corruption* (added directly to the Corruption track). See `docs/chapters/07-health-damage-armor.adoc`.
+One of three categories: *Physical* (targets STR or AGI), *Mental* (targets WIT or EMP), or *Corruption* (added directly to the Corruption track). See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 *Dark Secret*::
-A specific hidden fact from the character's past — an event, decision, or relationship someone wants buried. Serves as a roleplay device and XP hook ("Did your Dark Secret complicate the mission?" = +1 XP). See `docs/chapters/13-advancement.adoc`.
+A specific hidden fact from the character's past — an event, decision, or relationship someone wants buried. Serves as a roleplay device and XP hook ("Did your Dark Secret complicate the mission?" = +1 XP). See xref:13-advancement.adoc[Advancement].
 
 *Death Check*::
-A single d6 roll required when a Critical Injury is marked †. On 1–2: the character dies (or is permanently retired for mental death). On 3–6: survival, but the Critical Injury still applies. See `docs/chapters/07-health-damage-armor.adoc`.
+A single d6 roll required when a Critical Injury is marked †. On 1–2: the character dies (or is permanently retired for mental death). On 3–6: survival, but the Critical Injury still applies. See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 *Department*::
-Specialization within a Division (Wayfinder, Keep, Stack). Determines the character's field expertise and Department Skill. Recovery uses Backgrounds instead. See `docs/chapters/09-divisions.adoc`.
+Specialization within a Division (Wayfinder, Keep, Stack). Determines the character's field expertise and Department Skill. Recovery uses Backgrounds instead. See xref:09-divisions.adoc[Divisions].
 
 *Director of Agents (DA)*::
 The table's facilitator role. The DA presents scenes, adjudicates uncertainty, advances clocks, and portrays the world and opposition. See xref:14-gm-guidance.adoc[Director of Agents Guidance].
 
 *Difficulty*::
-The number of successes (6s) required to pass a skill roll. Standard range: 1 (routine) to 5+ (extreme). See `docs/chapters/03-core-resolution.adoc`.
+The number of successes (6s) required to pass a skill roll. Standard range: 1 (routine) to 5+ (extreme). See xref:03-core-resolution.adoc[Core Resolution].
 
 *Division*::
-Character class within the Verdant Covenant. Four playable Divisions: Wayfinder (research/intelligence), Recovery (field retrieval), The Keep (vault security), and Stack (logistics). See `docs/chapters/09-divisions.adoc`.
+Character class within the Verdant Covenant. Four playable Divisions: Wayfinder (research/intelligence), Recovery (field retrieval), The Keep (vault security), and Stack (logistics). See xref:09-divisions.adoc[Divisions].
 
 *Division Item*::
-A signature supernatural object issued to every member of a Division. Wayfinder: Verdant Codex. Recovery: Verdant Satchel. Keep: Warden's Bracer. See `docs/chapters/09-divisions.adoc`.
+A signature supernatural object issued to every member of a Division. Wayfinder: Verdant Codex. Recovery: Verdant Satchel. Keep: Warden's Bracer. See xref:09-divisions.adoc[Divisions].
 
 *Division Talent*::
-A class-specific ability unique to one Division. Costs +1 Corruption to activate (most talents). See `docs/chapters/09-divisions.adoc`.
+A class-specific ability unique to one Division. Costs +1 Corruption to activate (most talents). See xref:09-divisions.adoc[Divisions].
 
 *Dying*::
-State when a Broken character has an active Death Check Critical Injury (result marked †) that has not yet been resolved. An untreated Dying character will die. See `docs/chapters/07-health-damage-armor.adoc`.
+State when a Broken character has an active Death Check Critical Injury (result marked †) that has not yet been resolved. An untreated Dying character will die. See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 == F
 
 *Fast Action*::
-One of three action types in combat. Represents a quick or secondary effort: moving one zone, drawing a weapon, taking cover, or using a small item. See `docs/chapters/05-combat.adoc`.
+One of three action types in combat. Represents a quick or secondary effort: moving one zone, drawing a weapon, taking cover, or using a small item. See xref:05-combat.adoc[Combat].
 
 *Fear Check*::
-A Wits roll triggered by supernatural horror. Each 6 = success. Each 1 = +1 Corruption. No successes = failure (+1 Corruption + Panic Table roll). See `docs/chapters/08-corruption-fear-healing.adoc`.
+A Wits roll triggered by supernatural horror. Each 6 = success. Each 1 = +1 Corruption. No successes = failure (+1 Corruption + Panic Table roll). See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing].
 
 *Fear Rating*::
-Narrative classification (0–5) of how terrifying a creature or event is. Used by the DA to determine when to call for a Fear check. 0 = no check triggered. See `docs/chapters/08-corruption-fear-healing.adoc`.
+Narrative classification (0–5) of how terrifying a creature or event is. Used by the DA to determine when to call for a Fear check. 0 = no check triggered. See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing].
 
 *Free Action*::
-An action in combat that requires negligible effort: speaking a short sentence, dropping an item, or glancing at surroundings. Unlimited per turn. See `docs/chapters/05-combat.adoc`.
+An action in combat that requires negligible effort: speaking a short sentence, dropping an item, or glancing at surroundings. Unlimited per turn. See xref:05-combat.adoc[Combat].
 
 == G
 
 *Gear Dice*::
-Black dice in the pool contributed by equipment. Each 1 rolled on a Gear die causes the item to degrade one step. See `docs/chapters/03-core-resolution.adoc`.
+Black dice in the pool contributed by equipment. Each 1 rolled on a Gear die causes the item to degrade one step. See xref:03-core-resolution.adoc[Core Resolution].
 
 *General Talent*::
-A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. See `docs/chapters/13-advancement.adoc`.
+A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. See xref:13-advancement.adoc[Advancement].
 
 == H
 
 *Headquarters (HQ)*::
-The Covenant facility serving as the team's base of operations between Case Files. Provides medical care, equipment requisition, research facilities, and downtime activities. See `docs/chapters/12-headquarters.adoc`.
+The Covenant facility serving as the team's base of operations between Case Files. Provides medical care, equipment requisition, research facilities, and downtime activities. See xref:12-headquarters.adoc[Headquarters].
 
 == I
 
 *Insight*::
-A permanent mechanical bonus gained from certain Critical Injuries, marked *(Insight)* in the injury name or effect. Represents a silver lining from trauma — heightened perception, empathy, or expertise. Cannot be removed. See `docs/chapters/07-health-damage-armor.adoc`.
+A permanent mechanical bonus gained from certain Critical Injuries, marked *(Insight)* in the injury name or effect. Represents a silver lining from trauma — heightened perception, empathy, or expertise. Cannot be removed. See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 == M
 
 *Maximum Corruption Threshold*::
-The point at which a character's mind permanently fractures: 10 + Empathy score. Exceeding this value retires the character. See `docs/chapters/08-corruption-fear-healing.adoc`.
+The point at which a character's mind permanently fractures: 10 + Empathy score. Exceeding this value retires the character. See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing].
 
 == N
 
 *Named Threat*::
-A significant antagonist in a Case File — a faction operative, corrupted NPC, or supernatural entity important enough to have a name, motivations, and stat block. See `docs/chapters/15-case-file.adoc`.
+A significant antagonist in a Case File — a faction operative, corrupted NPC, or supernatural entity important enough to have a name, motivations, and stat block. See xref:15-case-file.adoc[Case Files].
 
 == P
 
 *Panic Table*::
-A d6 table rolled on Fear check failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See `docs/chapters/08-corruption-fear-healing.adoc`.
+A d6 table rolled on Fear check failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See xref:08-corruption-fear-healing.adoc[Corruption, Fear & Healing].
 
 *Push*::
-Re-roll all non-6 dice after a failed roll. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See `docs/chapters/03-core-resolution.adoc`.
+Re-roll all non-6 dice after a failed roll. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See xref:03-core-resolution.adoc[Core Resolution].
 
 *Psychoanalyze*::
-A skill used to treat mental and emotional Critical Injuries. Recovery difficulty and duration vary by injury severity. See `docs/chapters/07-health-damage-armor.adoc`.
+A skill used to treat mental and emotional Critical Injuries. Recovery difficulty and duration vary by injury severity. See xref:07-health-damage-armor.adoc[Health, Damage & Armor].
 
 == R
 
@@ -135,13 +135,13 @@ A skill used to treat mental and emotional Critical Injuries. Recovery difficult
 == S
 
 *Skill Dice*::
-Green dice in the pool, equal to the relevant Skill rating (0–5). See `docs/chapters/03-core-resolution.adoc`.
+Green dice in the pool, equal to the relevant Skill rating (0–5). See xref:03-core-resolution.adoc[Core Resolution].
 
 *Slow Action*::
-One of three action types in combat. Represents a committed effort: attacking, using a skill, administering first aid, or reloading a weapon. See `docs/chapters/05-combat.adoc`.
+One of three action types in combat. Represents a committed effort: attacking, using a skill, administering first aid, or reloading a weapon. See xref:05-combat.adoc[Combat].
 
 *Stunt Points*::
-Extra successes (6s) beyond the first on an attack roll, spent on special combat effects such as increased damage, disarming, or knockback. See `docs/chapters/05-combat.adoc`.
+Extra successes (6s) beyond the first on an attack roll, spent on special combat effects such as increased damage, disarming, or knockback. See xref:05-combat.adoc[Combat].
 
 == T
 
@@ -151,17 +151,17 @@ The ancient secret society the player characters serve. Discovers, recovers, and
 == V
 
 *Verdant Codex*::
-Wayfinder Division Item. An enchanted field journal that secures memory, decodes language, maps artifact locations, and preserves documents. See `docs/chapters/09-divisions.adoc`.
+Wayfinder Division Item. An enchanted field journal that secures memory, decodes language, maps artifact locations, and preserves documents. See xref:09-divisions.adoc[Divisions].
 
 *Verdant Satchel*::
-Recovery Division Item. A specially enchanted field bag that suppresses artifact aura, seals cursed items, warns of instability, and produces basic tools on demand. See `docs/chapters/09-divisions.adoc`.
+Recovery Division Item. A specially enchanted field bag that suppresses artifact aura, seals cursed items, warns of instability, and produces basic tools on demand. See xref:09-divisions.adoc[Divisions].
 
 == W
 
 *Warden's Bracer*::
-Keep Division Item. Suppresses artifact magic, warns of containment failure, enables safe handling of cursed objects, absorbs 1 Corruption per session, and grants +1 Armor Rating. See `docs/chapters/09-divisions.adoc`.
+Keep Division Item. Suppresses artifact magic, warns of containment failure, enables safe handling of cursed objects, absorbs 1 Corruption per session, and grants +1 Armor Rating. See xref:09-divisions.adoc[Divisions].
 
 == Z
 
 *Zone*::
-An abstract area of space used for combat positioning — a room, corridor, alley, or rooftop section. Moving one zone costs a Fast Action; moving two zones (running) costs both the Fast and Slow Action for the round. See `docs/chapters/05-combat.adoc`.
+An abstract area of space used for combat positioning — a room, corridor, alley, or rooftop section. Moving one zone costs a Fast Action; moving two zones (running) costs both the Fast and Slow Action for the round. See xref:05-combat.adoc[Combat].


### PR DESCRIPTION
## Summary

Converts all remaining `\`docs/chapters/X.adoc\`` backtick path references across 12 chapter files to proper AsciiDoc `xref:` format — producing live, clickable links in generated PDF output instead of inert code spans.

Also adds a pre-release validation step to `CONTRIBUTING.md` so future contributors catch any regressions before building release artifacts.

## Changes

### `docs/chapters/` — 12 files updated
- All 56 `\`docs/chapters/XX-name.adoc\`` references replaced with `xref:XX-name.adoc[Chapter Title]` (sibling-relative paths for Asciidoctor PDF)
- Cross-Reference sections at chapter ends are all live links
- **Typo fixed:** `14-DA-guidance.adoc` → `14-gm-guidance.adoc` in `15-case-file.adoc`
- Also updated: `20-glossary.adoc` (38 entries converted via bulk regex substitution)

### `CONTRIBUTING.md`
- Added **Step 1a: Validate AsciiDoc Cross-References** to the Release Process section — a one-line PowerShell command to verify zero backtick path references before every release build

## Closes
Closes #94, #105, #106