### PR TITLE
Issue #124: Add General Talents section with Hair Trigger and Tactical Override initiative talents

### DIFF
--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -223,3 +223,20 @@ The following stunts may be purchased on *any* successful skill roll:
 | 1 | *Decompress* | The person you're treating recovers 1 additional Wits or Empathy point beyond the normal healing (max to their normal maximum).
 | 2 | *Full Read* | You have comprehensively understood this person's psychological state. For the rest of the scene, you may treat all Psychoanalyze rolls against them as Difficulty 0 — you know them now.
 |===
+
+---
+
+== General Talents
+
+General Talents are cross-Division abilities available to any agent regardless of Division affiliation. They are acquired through advancement (cost: 1 Advancement Point each) and represent learned tradecraft, personal discipline, and survivor instincts.
+
+[%header,cols="2,1,2,1,4"]
+|===
+| Talent | Type | Prerequisites | Tag | Effect
+
+| *Hair Trigger* | Once per combat | AGI 3+ | _(Initiative)_ | After initiative cards are revealed but before the first action, discard your card and draw a new one, keeping the new result.
+
+| *Tactical Override* | Fast Action | EMP 3+, Command 2+ | _(Initiative)_ | Once per round, swap one ally's initiative card with the next hostile participant directly above them in the order. If no hostile is directly above the chosen ally, this talent has no valid target this round.
+|===
+
+> *Edge case — Tactical Override:* "Directly above" means the next hostile in turn order, not spatial proximity. Cannot swap with another PC — the participant directly above must be hostile.

--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -24,6 +24,8 @@ At the start of any hostile confrontation, each participant draws an *Initiative
 
 Initiative uses card draw only. Do not add initiative modifiers for posture, terrain, or gear. Those factors still matter through cover, surprise, action economy, and range penalties.
 
+> *Initiative Talents:* Some General Talents interact with initiative card draws. See xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills → General Talents].
+
 === Surprise and Ambush
 
 A *surprise* occurs when one side is unaware of the other at the moment combat begins.


### PR DESCRIPTION
Establishes the **General Talents** framework — cross-Division abilities available to any agent. Implements the first two initiative-interacting talents agreed in design.

## Changes

### `docs/chapters/04-attributes-skills.adoc`
- New `== General Talents` section appended after the skill stunt tables
- Framework description: acquired via 1 AP each, cross-Division, represent learned tradecraft
- **Hair Trigger** — Once per combat, AGI 3+: after cards are revealed but before first action, discard your card and redraw
- **Tactical Override** — Fast Action, EMP 3+ + Command 2+: swap one ally's initiative card with the next hostile directly above them in order
- Edge case callout: "directly above" = turn order, not spatial; cannot swap with another PC

### `docs/chapters/05-combat.adoc`
- Added cross-reference note to the Initiative Procedure Note section pointing to General Talents in the Attributes & Skills chapter

> *Note on Elevated terrain:* The Elevated zone feature grants +2 to initiative card value (Zone Features table, line ~159). This is a terrain rule exception, not a character stat modifier, and is consistent with the "no initiative modifiers for posture/gear" note. No change needed.

Closes #124