### PR TITLE
Issue #120: Center H2 section titles in PDF theme

### DIFF
--- a/docs/themes/neon-relic-theme.yml
+++ b/docs/themes/neon-relic-theme.yml
@@ -130,6 +130,7 @@ heading-h2:
   border-color: '#7a8a6a'
   border-width: 0 0 1 0
   padding: [1mm, 0, 1mm, 0]
+  text-align: center
   text-transform: uppercase
 
 heading-h3:


### PR DESCRIPTION
Adds `text-align: center` to the `heading-h2` block in the PDF theme. H3 remains left-aligned to preserve visual hierarchy.

Closes #120