### PR TITLE
Issue #119: Add 2-column layout to PDF theme

### DIFF
--- a/docs/themes/neon-relic-theme.yml
+++ b/docs/themes/neon-relic-theme.yml
@@ -17,6 +17,8 @@ page:
   background-color: '#f0ead6'
   margin: [22mm, 20mm, 24mm, 20mm]
   size: LETTER
+  columns: 2
+  column-gap: 5mm
 
 # ── TITLE PAGE (custom SVG, so keep this minimal) ──────────────────────────────────────
 title-page:


### PR DESCRIPTION
Adds `columns: 2` and `column-gap: 5mm` to the `page:` block in the PDF theme to enable two-column body layout.

**Note:** This requires a local PDF build to verify no tables or wide content breaks across columns. If issues are found, individual wide blocks can be exempted with `[%unbreakable]` or moved to single-column sections.

Closes #119