### PR TITLE
Issue #118: Use {chapter-title} in running headers to prevent overflow

### DIFF
--- a/docs/themes/neon-relic-theme.yml
+++ b/docs/themes/neon-relic-theme.yml
@@ -58,13 +58,13 @@ header:
       font-style: bold
       font-color: '#7a1212'
     right:
-      content: '{section-title}'
+      content: '{chapter-title}'
       font-family: Courier
       font-size: 8
       font-color: '#6a7a58'
   verso:
     left:
-      content: '{section-title}'
+      content: '{chapter-title}'
       font-family: Courier
       font-size: 8
       font-color: '#6a7a58'


### PR DESCRIPTION
Replaces `{section-title}` with `{chapter-title}` in both `header.recto.right` and `header.verso.left`. Chapter titles (e.g. "Combat", "Corruption & Fear") are always short and consistent, eliminating the overflow that occurs with long section titles in the Courier 8pt header slot.

Closes #118