### PR TITLE
chore: versioned PDF filename, version on title page, stable README links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,6 +450,16 @@ xref:XX-name.adoc[Chapter Title]
 
 Fix all hits before proceeding with the build.
 
+### 1b. Set Release Version
+
+Set the `$version` variable in PowerShell — it flows through the build and release commands. Set it **once** here and copy-paste each subsequent step without modifications:
+
+```powershell
+$version = "X.Y.Z"  # ← Replace with the actual version (no "v" prefix, e.g. "1.2.0")
+```
+
+> **Note:** The `v` prefix is added automatically in the git tag and `gh release create` command.
+
 ### 2. Build PDF Output
 
 Generate the PDF from the master AsciiDoc document. Run from the repo root:
@@ -458,16 +468,16 @@ Generate the PDF from the master AsciiDoc document. Run from the repo root:
 # Ensure output directory exists
 New-Item -ItemType Directory -Force -Path docs/output | Out-Null
 
-# Build PDF from master document
-asciidoctor-pdf docs/neon-relic.adoc -D docs/output -o neon-relic.pdf
+# Build PDF — versioned filename, version number injected into title page
+asciidoctor-pdf docs/neon-relic.adoc -D docs/output -o "neon-relic-$version.pdf" -a revnumber=$version
 ```
 
-This produces `docs/output/neon-relic.pdf`. The `docs/output/` directory is gitignored — the PDF is generated fresh each release and attached as a release artifact.
+This produces `docs/output/neon-relic-$version.pdf`. The `docs/output/` directory is gitignored — the PDF is generated fresh each release and attached as a release artifact.
 
 Verify the build succeeded:
 
 ```powershell
-Test-Path docs/output/neon-relic.pdf
+Test-Path "docs/output/neon-relic-$version.pdf"
 ```
 
 Expected output: `True`
@@ -504,15 +514,18 @@ Neon Relic $version
 - Summary item three
 "@
 
-gh release create v$version docs/output/neon-relic.pdf `
+gh release create v$version "docs/output/neon-relic-$version.pdf#neon-relic.pdf" `
   --repo bruceamoser/neon-relic `
   --title $version `
-  --notes $notes
+  --notes $notes `
+  --latest
 ```
 
 Notes:
 - Use semantic version tags (`v1.0.0`, `v1.0.1`, etc.).
 - Keep release title numeric (`1.0.0`) and tag prefixed (`v1.0.0`).
+- The `#neon-relic.pdf` suffix renames the asset on GitHub. The local file is versioned (`neon-relic-X.Y.Z.pdf`), but GitHub stores it as `neon-relic.pdf` — this keeps the README download URL (`/releases/latest/download/neon-relic.pdf`) permanently valid without updating it each release.
+- The `--latest` flag explicitly marks this release as the latest on GitHub.
 - Attach only generated artifacts intended for consumers.
 - Do **not** pass literal `\n` escape sequences in release notes. Use an actual multiline body.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ neon-relic/
 | `docs/chapters/*.adoc` | **Canonical chapter source files** for the current compiled rulebook. |
 | `docs/neon-relic.adoc` | Master AsciiDoc book that assembles the full release-ready rulebook. |
 | `docs/neon-relic-core-rules.md` | Markdown reference version of the rules text and design material. |
-| `docs/output/neon-relic.pdf` | Generated PDF artifact used for release packaging. |
+| `docs/output/neon-relic-X.Y.Z.pdf` | Generated PDF artifact (versioned). Gitignored — uploaded to each GitHub release as `neon-relic.pdf` to keep the download URL stable. |
 | `docs/references/*.md` | Year Zero Engine reference material from existing YZE games. Used for mechanical consistency and inspiration. |
 
 ## Year Zero Engine References

--- a/docs/themes/neon-relic-theme.yml
+++ b/docs/themes/neon-relic-theme.yml
@@ -36,8 +36,8 @@ title-page:
     font-size: 1
     font-color: '#e8e0c8'
   revision:
-    font-size: 1
-    font-color: '#e8e0c8'
+    font-size: 9
+    font-color: '#4a5a38'
 
 # ── RUNNING HEADER / FOOTER ──────────────────────────────────────────────────────
 header:


### PR DESCRIPTION
## Summary

Three related process improvements to make releases consistent and self-documenting.

## Changes

### `docs/themes/neon-relic-theme.yml`
- Made `title-page.revision` visible (`font-size: 9`, `font-color: '#4a5a38'`)
- Version number now appears on the title page when built with `-a revnumber=X.Y.Z`

### `CONTRIBUTING.md` — Release Process
- Added **Step 1b** to define `$version` once upfront; it flows through Steps 2 and 5
- Updated Step 2 build command to output `neon-relic-$version.pdf` and inject version into title page via `-a revnumber=$version`
- Updated `Test-Path` check to match versioned filename
- Updated Step 5 `gh release create` to use `neon-relic-$version.pdf#neon-relic.pdf` — versioned locally, but stored as `neon-relic.pdf` on GitHub for stable download URL
- Added `--latest` flag to `gh release create` to explicitly mark the release as latest
- Added notes explaining the `#neon-relic.pdf` naming strategy and `--latest` flag

### `README.md`
- Updated Key Files table to reflect versioned local filename and stable GitHub asset name
- The download link (`/releases/latest/download/neon-relic.pdf`) never needs updating

## Design Notes

The `#asset-name` suffix in `gh release create` renames the attachment on GitHub without affecting the local file. This means the README's `/releases/latest/download/neon-relic.pdf` URL stays valid permanently across all future releases.