### PR TITLE
Issue #202: Rename Memento Table to Anchor Table

### DIFF
--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -199,7 +199,7 @@ Every agent carries an *Anchor* — a tangible, physical object tied to a core h
 
 Choose one of the following options:
 
-* *Roll d66* on the Memento Table in the Healing chapter and accept the result as written.
+* *Roll d66* on the Anchor Table in the Healing chapter and accept the result as written.
 * *Invent your own:* name a specific object and the memory attached to it. Run it by your DA.
 
 Record your Anchor's name and the memory it represents on your character sheet.

--- a/docs/chapters/08-corruption-fear-healing.adoc
+++ b/docs/chapters/08-corruption-fear-healing.adoc
@@ -61,11 +61,11 @@ Because Corruption naturally builds toward lethal levels, characters must active
 
 Every character begins with an *Anchor* — a tangible, physical object linked to a core humanizing memory (e.g., a cassette tape recording of a lost spouse's voice). In a moment of quiet downtime, a character can dedicate a scene to interacting with their Anchor. This grounded roleplay provides powerful mechanical healing.
 
-=== Random 1980s Memento / Anchor Table (Roll d66)
+=== Random 1980s Anchor Table (Roll d66)
 
 [%header,cols="^1,4,^1,4"]
 |===
-| Roll | Memento | Roll | Memento
+| Roll | Anchor | Roll | Anchor
 
 | 11 | A severely chewed, red Bic pen belonging to a missing sibling. | 41 | A blood-stained matchbook from a notorious neon-lit nightclub.
 | 12 | A Polaroid photograph of a figure that no one else remembers. | 42 | A high school varsity jacket smelling faintly of cheap cologne and ozone.


### PR DESCRIPTION
Closes #202

Replaces all Memento Table references with Anchor Table. Updates the table heading in Ch.08 and the cross-reference in Ch.02 Step 9.