### PR TITLE
Issue #203: Remove 'and Departments' from Chapter 9 title

### DIFF
--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -1,5 +1,5 @@
 [#chapter-divisions]
-= Covenant Divisions and Departments
+= Covenant Divisions
 
 In Project Neon Relic, players are sworn members of *The Verdant Covenant*. Because no single person possesses the brains, brawn, network, and magical guardianship required to hunt dangerous artifacts, players choose a *Division* (their core class) which dictates their starting attributes, skills, and Clearance Level (CL).
 


### PR DESCRIPTION
Closes #203

Renames chapter title from = Covenant Divisions and Departments to = Covenant Divisions. Departments are sub-sections and don't belong in the top-level heading.