### PR TITLE
Issue #204: Rename Recovery Backgrounds to Recovery Paradigms

### DIFF
--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -112,13 +112,13 @@ All Recovery agents carry the *Verdant Satchel*, a specially enchanted field bag
 * Produces useful tools on demand (rope, chalk, spikes, vials, etc.)
 * Enchantment of Warding obscures any magical object placed inside from detection
 
-=== Recovery Backgrounds
+=== Recovery Paradigms
 
-Choose one background that defines your agent's prior experience:
+Choose one paradigm that defines your agent's prior experience:
 
 [%header,cols="2,4"]
 |===
-| Background | Description
+| Paradigm | Description
 
 | *Ex-Agency Operative* | Former intelligence or special forces. Trained in infiltration, extraction, and covert operations.
 | *Heavy-Hitter (Brawler)* | Brute-force specialist. Comfortable in direct violent confrontation above all else.


### PR DESCRIPTION
Closes #204

Renames the Recovery sub-group specialization label from 'Backgrounds' to 'Paradigms' to avoid confusion with the new Background Talents mechanic (#199). Updates the section heading, intro sentence, and table column header.