### PR TITLE
Issue #214: Unify the canonical skill list and eliminate undefined skill references across the core rules

### DIFF
--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -71,7 +71,7 @@ Distribute your *Attribute Points* across your four core attributes. Each attrib
 
 == Step 4: Distribute Skill Points
 
-Distribute your *Skill Points* (determined by your Age Group in Step 3) across the twelve core skills. No single skill may exceed *3* at character creation.
+Distribute your *Skill Points* (determined by your Age Group in Step 3) across the thirteen core skills. No single skill may exceed *3* at character creation.
 
 [%header,cols="2,1,2,4"]
 |===
@@ -86,6 +86,7 @@ Distribute your *Skill Points* (determined by your Age Group in Step 3) across t
 | Investigate | WIT | 3 | Wayfinder, Keep (Stack)
 | Tech | WIT | 3 | Wayfinder, Keep (Stack)
 | Lore | WIT | 3 | Wayfinder, Keep
+| Heal | WIT | 3 | Keep
 | Manipulate | EMP | 3 | Wayfinder
 | Command | EMP | 3 | Keep
 | Psychoanalyze | EMP | 3 | Wayfinder, Keep
@@ -237,7 +238,7 @@ After completing all steps, your sheet should record:
 | *Clearance Level* | Division base CL + Age Group modifier (minimum 1)
 | *Age Group / Age* | Chosen in Step 3 (Young / Experienced / Senior)
 | *Attributes (STR / AGI / WIT / EMP)* | Attribute Points distributed per Age Group, 2–5 each
-| *Skills (12)* | Skill Points distributed per Age Group, 0–3 each
+| *Skills (13)* | Skill Points distributed per Age Group, 0–3 each
 | *Division Talent or General Talent* | One chosen from Division list or General Talents list (Advancement chapter)
 | *Wing, Paradigm, or Department Talent* | One chosen from sub-group talent list within Division (Advancement chapter)
 | *Background Talent* | One chosen from Background Talents list (Advancement chapter)
@@ -291,7 +292,7 @@ _(13 points spent: 4 + 4 + 3 + 2 = 13)_
 | Endure | 1 | Agency conditioning
 |===
 
-_(12 points spent: 3 + 3 + 2 + 2 + 1 + 1 = 12. Remaining 6 skills at 0.)_
+_(12 points spent: 3 + 3 + 2 + 2 + 1 + 1 = 12. Remaining 7 skills at 0.)_
 
 === Step 5: Starting Talents
 

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -13,9 +13,9 @@ Characters are defined by *four core attributes*, representing their fundamental
 | *Empathy* | Raw charisma, social intuition, ability to read human behavior, and emotional resilience against psychological horror.
 |===
 
-== The Twelve Core Skills
+== The Thirteen Core Skills
 
-The twelve core skills are mapped to these four attributes, tailored to support urban exploration, analog hacking, and occult research:
+The thirteen core skills are mapped to these four attributes, tailored to support urban exploration, analog hacking, and occult research:
 
 [%header,cols="1,1,4"]
 |===
@@ -31,10 +31,11 @@ The twelve core skills are mapped to these four attributes, tailored to support 
 | Sleight of Hand | Picking locks, pocketing small artifacts, disarming mechanical traps.
 | Firearms | Utilizing period-accurate weaponry (.38 revolvers, pump-action shotguns).
 
-.3+| *Wits*
+.4+| *Wits*
 | Investigate | Searching crime scenes for anomalous evidence, analyzing forensic data.
 | Tech | Operating 1980s mainframes, hacking BBS networks, repairing analog equipment.
 | Lore | Decoding ancient occult texts, identifying mythological creatures and artifact origins.
+| Heal | Field medicine, triage, emergency stabilization, and treating physical injuries in the field or at base.
 
 .3+| *Empathy*
 | Manipulate | Bribing informants, deceiving rivals, leveraging secrets.

--- a/docs/chapters/07-health-damage-armor.adoc
+++ b/docs/chapters/07-health-damage-armor.adoc
@@ -161,7 +161,7 @@ Roll when Broken by *Strength or Agility* damage.
 | 26 | *Severe Bruising* | −1 Strength maximum until healed (cannot be healed above 3). | Heal roll (Difficulty 2) + 1 downtime phase.
 | 31 | *Deep Laceration* | Bleeds 1 Strength per round until treated (First Aid, Difficulty 1). | Bandaging stops bleed; full recovery = 1 downtime.
 | 32 | *Fractured Arm* | Non-dominant arm: useless. Dominant arm: −2 dice STR. | Cast + 2 downtime phases.
-| 33 | *Broken Nose (Insight)* | *+1 die on Intimidate rolls forever* (you look dangerous now). | No mechanical healing needed. Defect: cosmetic disfiguration.
+| 33 | *Broken Nose (Insight)* | *+1 die on Command rolls made through threat or intimidation forever* (you look dangerous now). | No mechanical healing needed. Defect: cosmetic disfiguration.
 | 34 | *Shattered Kneecap* | Movement speed halved permanently (1 zone costs Slow Action). Surgery can restore. | Keep surgical facility + 2 downtime phases.
 | 35 | *Punctured Lung* | −2 dice on all STR and AGI rolls. Strenuous action triggers Endure roll (Difficulty 2) or collapse. | Heal roll (Difficulty 3) + 2 downtime phases.
 | 36 | *Blinding Strike* | One eye damaged: −1 die on all ranged attack and Investigate rolls permanently. Insight: *+1 die on Empathy rolls* (you understand fragility now). | Cannot be fully healed; monocle/patch is acquired (CL 1).

--- a/docs/chapters/10-equipment.adoc
+++ b/docs/chapters/10-equipment.adoc
@@ -11,13 +11,13 @@ To reflect the covert nature of the Covenant, characters do not use personal cas
 |===
 | Item | Gear Bonus & Effect | Enc. | CL
 
-| *Heavy-Duty Maglite* | +1 to Investigate/Scout in the dark. Can act as blunt weapon (Damage 1). | ½ | 1
+| *Heavy-Duty Maglite* | +1 to Investigate in the dark. Can act as blunt weapon (Damage 1). | ½ | 1
 | *Micro-Cassette Recorder* | +1 to Psychoanalyze. Captures EVPs (Electronic Voice Phenomena). | ½ | 1
 | *Polaroid SX-70 Camera* | +2 to Lore when studying a crime scene. Produces instant evidence. | 1 | 2
 | *Air Ion Counter* | +1 to Investigate. Bulky spirit detector measuring static drops. | 1 | 2
 | *Acoustic Coupler Modem* | +1 to Tech. Interface with remote mainframes via payphone. | 1 | 2
 | *P-SB7 Spirit Box Prototype* | +2 to Lore when deciphering entity motives. Sweeps radio frequencies. | 1 | 3
-| *Thermal / Infrared Camera* | +2 to Scout. Heavy early-80s tech. Spot invisible entities via cold spots. | 2 | 4
+| *Thermal / Infrared Camera* | +2 to Investigate when tracking heat signatures, cold spots, or invisible entities. Heavy early-80s tech. | 2 | 4
 |===
 
 == Standard Tools & Survival Gear
@@ -270,7 +270,7 @@ The *pursuing vehicle* wins by moving to or holding position 1–2.
 
 Each round of a chase, both drivers make a roll:
 
-* *Driving (WIT):* The primary chase skill. Represents reading traffic, anticipating routes, and making calculated maneuvers.
+* *Tech (WIT):* The primary chase skill. Represents reading traffic, anticipating routes, and making calculated maneuvers with vehicles under pressure.
 * *Evasion (AGI):* Used when attempting sudden unpredictable movement — cutting through a building site, reversing against traffic, going off-road. Higher risk, higher reward.
 
 Both sides roll simultaneously. The side with more successes moves the Contact Track one position in their favor. Ties: no position change.
@@ -291,8 +291,8 @@ Declare before rolling. No cost unless noted.
 |===
 | Maneuver | Skill | Effect
 
-| *Ram* | Force (WIT) | Only available at Contact. Roll Force opposed by opponent's Driving. On success: both vehicles take 1–3 damage (equal to Force successes); Contact Track does not change; occupants of both vehicles take 1 Agility damage (thrown around). Cannot ram a vehicle more than two speed tiers faster.
-| *PIT Maneuver* | Driving (WIT) Difficulty 3 | Available at Contact only. On success: target vehicle spins — they lose their next action and the pursuer moves to Contact. On failure: the maneuvering driver's vehicle takes 1 Wear.
+| *Ram* | Force (WIT) | Only available at Contact. Roll Force opposed by opponent's Tech. On success: both vehicles take 1–3 damage (equal to Force successes); Contact Track does not change; occupants of both vehicles take 1 Agility damage (thrown around). Cannot ram a vehicle more than two speed tiers faster.
+| *PIT Maneuver* | Tech (WIT) Difficulty 3 | Available at Contact only. On success: target vehicle spins — they lose their next action and the pursuer moves to Contact. On failure: the maneuvering driver's vehicle takes 1 Wear.
 | *Gunfire from Vehicle* | Firearms (standard roll) | Available at Following or closer. −1 die on all shooting rolls from a moving vehicle unless the shooter has the *Stable Platform* talent. A passenger shooting from a moving car is at −1 die; a driver shooting is at −2 dice.
 | *Off-Road Break* | AGI Difficulty 2 | Drive off the paved route. On success: move one position on the Contact Track toward Escaped. On failure: vehicle takes 1 Wear and no position change. If in a vehicle with off-road penalty (Motorcycle in rain, Van, Helicopter equivalent): add +1 Difficulty.
 | *Blending In* | WIT (Sneak) Difficulty 2 | Abandon the direct chase and disappear into traffic or terrain. On success: move directly to Escaped (skip the track). On failure: no change and opponent moves one step toward Contact.
@@ -353,7 +353,7 @@ Broken). A **Broken** item cannot be used until repaired.
 
 === Repair Rules
 
-Repairing gear requires **time**, **parts**, and a **Craft** roll.
+Repairing gear requires **time**, **parts**, and a **Tech** roll.
 
 [[repair-roll]]
 ==== The Repair Roll
@@ -361,7 +361,7 @@ Repairing gear requires **time**, **parts**, and a **Craft** roll.
 [cols="1,3",frame=sides,grid=rows]
 |===
 | *Attribute* | Wits (WIT)
-| *Skill*     | Craft _(Stack signature skill)_
+| *Skill*     | Tech _(Stack signature skill)_
 | *Base Difficulty* | Varies by condition (see table below)
 | *Time Required* | Varies (see table below)
 | *Tools Required* | Basic toolkit (most repairs); specialized kit for electronics/artifacts
@@ -458,7 +458,7 @@ at reduced effectiveness and carry a higher risk of failure.
 
 ==== Crafting Improvised Items
 
-Roll **Craft** (WIT), using the difficulty from the table below. Requires at
+Roll **Tech** (WIT), using the difficulty from the table below. Requires at
 minimum a **Junk Die (d6)** as parts; step it down after crafting.
 
 Improvised items begin with a **d8 Gear Die** (never start at d10 or d12 —
@@ -466,7 +466,7 @@ they're held together with duct tape and prayer).
 
 [%header,cols="2,1,1,4"]
 |===
-| Improvised Item     | Craft Diff | Time | Notes
+| Improvised Item     | Tech Diff | Time | Notes
 
 | *Club / Makeshift Bludgeon* | 1 | 1 minute | Damage 1, Slow. No Gear Die — it's a pipe.
 | *Shiv / Field Knife*        | 1 | 5 minutes | Damage 1, Fast. Gear d8. Breaks on 1–2.
@@ -515,7 +515,7 @@ gives Stack agents mechanical advantages no other Division matches.
 |===
 | Advantage | Effect
 
-| *Craft Bonus*         | Stack agents add **+1 die** to all Craft rolls (repair and improvised item creation).
+| *Tech Bonus*          | Stack agents add **+1 die** to all Tech rolls made for repair and improvised item creation.
 | *Faster Repairs*      | Quick Repairs take 5 minutes instead of 15. Full Repairs take 2 hours instead of a full Shift.
 | *Parts Economy*       | Stack agents never step down a Junk Die on a successful repair — only failed repairs consume parts.
 | *Known Contacts*      | Once per case, a Stack agent can source **Hardware Components (d8)** without a Covenant requisition (a contact comes through).

--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -154,7 +154,7 @@ General Talents are specialized abilities available to *any character*, providin
 | *Street Medic* | Restore 2 physical Attribute points instead of 1 when successfully using Heal.
 | *Cathartic Release* _(Healing)_ | Once per session, dedicate a moment to breaking down, screaming, or venting. Heal 1 Corruption.
 | *Hair-Trigger* | Draw a weapon as a free action instead of a fast action. Critical edge in ambushes.
-| *Paranormal Intuition* | When entering a room, roll Wits (Scout). On success, the DA must tell you if a supernatural entity has been here in the last 24 hours.
+| *Paranormal Intuition* | When entering a room, roll Wits (Investigate). On success, the DA must tell you if a supernatural entity has been here in the last 24 hours.
 | *Heavy Packer* | Carry items equal to twice your Strength without becoming encumbered.
 | *Skeptic's Shield* | Once per session, outright ignore a minor supernatural effect by rigidly refusing to acknowledge the impossible.
 | *Night Owl* | Ignore all penalties from sleep deprivation. Operate perfectly in the dark.


### PR DESCRIPTION
Closes #214

## Summary
Normalizes the manuscript around a single canonical skill roster. `Heal` is now a formal Wits skill, and downstream references that pointed to undefined skills have been remapped to existing skills so the core rules no longer contradict themselves.

## Changes
- Updated character creation and the core skills chapter from 12 skills to 13, adding `Heal` as a canonical Wits skill
- Replaced undefined skill references in equipment, injuries, and advancement with canonical equivalents
- Normalized chase and repair text to use `Tech`, investigative gear text to use `Investigate`, and coercive social fallout to use `Command`
- Verified no remaining `Scout`, `Craft`, `Driving`, or `Intimidate` skill references remain in `docs/chapters`

## Design Notes
This follows the least-disruptive fix discussed on the issue. `Heal` was already deeply embedded across injury, downtime, Keep, and equipment rules, so promoting it to a real skill was lower-risk than rewriting those subsystems. The other rogue references behaved like carryovers from adjacent YZE games and were folded into the closest existing Neon Relic skills instead of expanding the roster further.

## References Consulted
- `tools/core-rules-gap-analysis.md` — prior audit noting undefined skill references and the need to anchor repair medicine to canonical skills
- Issue #214 discussion — design-decision comment establishing the minimal-change mapping for rogue skills