### PR TITLE
Issue #215: Define the canonical success and difficulty model, then rewrite examples to match it

### DIFF
--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -16,7 +16,32 @@ The core philosophy of the Year Zero Engine is that *rolling dice should only oc
 | *Gear Dice* | Black | Mechanical bonus from tools/weapons | 0–3
 |===
 
-To achieve a basic success, the player must roll at least one *6* across the entire dice pool. Multiple sixes are surplus successes that can be spent on *stunts* — extra narrative or mechanical benefits such as:
+== Success, Difficulty, and Extra Successes
+
+Every standard skill roll has a *Difficulty*. If a rule does not list one, the default Difficulty is *1*.
+
+Each *6* rolled counts as *one success*.
+
+* *Standard roll:* You succeed if your total successes meet or exceed the Difficulty.
+* *Opposed roll:* Both sides roll, then compare total successes; the higher total wins.
+* *Special binary roll:* A few subsystems, especially *Fear checks*, define their own pass/fail rule instead of using Difficulty.
+
+Successes beyond what was needed are *extra successes*. If the roll supports stunts, each extra success becomes *1 Stunt Point*.
+
+[%header,cols="1,4"]
+|===
+| Difficulty | Use
+
+| *1* | Standard risky task. This is the default when no other Difficulty is listed.
+| *2* | Hard task, active resistance, or strong time pressure.
+| *3* | Severe pressure, expert resistance, or dangerous complexity.
+| *4* | Extreme task requiring unusual competence, leverage, or luck.
+| *5+* | Near-impossible task. Use only when failure pressure is central to the scene.
+|===
+
+> *Total successes vs. extra successes:* Unless a rule says otherwise, only successes beyond the required threshold become stunt points. If a subsystem explicitly says "each success" does something, count the total successes rolled after determining whether the roll passed.
+
+Extra successes can be spent on *stunts* — extra narrative or mechanical benefits such as:
 
 * Completing an action significantly faster
 * Uncovering secondary hidden clues during an investigation
@@ -27,7 +52,7 @@ The elegance of this system lies in its speed; it produces immediate, decisive r
 
 == The Push Mechanic and Attrition
 
-The primary driver of suspense and narrative tension is the *Push* mechanic. If an initial roll yields no sixes (a failure), or if the player desperately needs additional successes for stunts, they may choose to *push* the roll — picking up and re-rolling all dice that do not currently display a 6.
+The primary driver of suspense and narrative tension is the *Push* mechanic. If an initial roll does not meet its Difficulty, or if the player desperately needs additional successes for stunts, they may choose to *push* the roll — picking up and re-rolling all dice that do not currently display a 6.
 
 However, pushing represents the character exerting maximum physical, mental, or material effort, and it comes with severe risks:
 
@@ -49,6 +74,8 @@ When two characters are directly working against each other — a guard watching
 . Both roll simultaneously.
 . Count the number of *6s* each side rolled — these are their *successes*.
 . The side with more successes wins.
+
+If the winning roll supports stunts, each success beyond the opposing total is an extra success. Opposed rolls normally do *not* use a listed Difficulty. If a rule combines both, the acting character must first meet the listed Difficulty and then beat the opposing total.
 
 === Tie-Breaking
 
@@ -126,7 +153,7 @@ Some situations call for the *entire team to attempt the same action simultaneou
 === Procedure
 
 . Each character rolls their individual dice pool for the relevant skill.
-. Count how many characters *succeed* (rolled at least one 6).
+. Count how many characters *succeed* (met the roll's Difficulty, usually 1).
 . Compare against the *Group Success Threshold* set by the DA:
 
 [%header,cols="1,3"]
@@ -151,6 +178,14 @@ If the group fails to meet the threshold:
 ---
 
 == Worked Examples
+
+=== Standard Roll: Searching the Burned Office
+
+*Situation:* Agent Reyes is searching a ransacked office before the local police return. The DA sets *Investigate Difficulty 2*.
+
+* **Reyes rolls:** Investigate (WIT 4 + Investigate 2) = 6 dice. Rolls: 6, 6, 5, 4, 2, 1 → *2 successes*.
+* **Result:** Reyes succeeds. He finds the hidden ledger, but has no extra successes to spend.
+* If Reyes had rolled *3 successes* instead, the third success would become *1 Stunt Point* — enough to find the ledger faster or uncover a second clue.
 
 === Opposed Roll: The Tail Job
 
@@ -184,7 +219,7 @@ If Petra had rolled 0 successes and the operative also rolled 0, the tail contin
 
 * Petra (Sneak 3, AGI 4): 7 dice → 6, 4, 3, 2, 1, 1, 1 → *1 success* ✓
 * Reyes (Sneak 1, AGI 2): 3 dice → 5, 4, 2 → *0 successes* ✗
-* Osei (Sneak 0, EMP 3): 3 attribute dice → 6, 3, 1 → *1 success* ✓
+* Osei (Sneak 0, AGI 3): 3 attribute dice → 6, 3, 1 → *1 success* ✓
 * Kowalski (Sneak 2, AGI 4): 6 dice → 6, 6, 3, 2, 1, 1 → *2 successes* ✓
 
 Reyes failed. Threshold not met. The DA rules the guard hears something from Reyes' direction and starts to turn. *Reyes pushes* (gains +1 Corruption): re-rolls 3 dice → 6, 4, 2 → *1 success*. The group just barely makes it — but Reyes is now at 1 Corruption and the tension meter has ticked up.

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -54,7 +54,7 @@ When you roll more 6s than the *minimum needed to succeed*, each extra 6 is a *S
 === Stunt Economy
 
 * *1 extra 6 = 1 Stunt Point.*
-* You must succeed first (at least one 6 to meet the Difficulty), then extras are stunt points.
+* You must succeed first (roll successes equal to or greater than the Difficulty), then extras are stunt points.
 * Stunt Points must be spent immediately — they do not carry between rolls.
 * You may split stunt points across multiple effects if both are available on the same skill.
 * On a *pushed roll*, stunt points still apply from the new result.
@@ -222,7 +222,7 @@ The following stunts may be purchased on *any* successful skill roll:
 
 | 1 | *Pressure Point* | You've identified something this person fears or desperately needs. The DA must reveal one personal vulnerability, driving motivation, or exploitable need.
 | 1 | *Decompress* | The person you're treating recovers 1 additional Wits or Empathy point beyond the normal healing (max to their normal maximum).
-| 2 | *Full Read* | You have comprehensively understood this person's psychological state. For the rest of the scene, you may treat all Psychoanalyze rolls against them as Difficulty 0 — you know them now.
+| 2 | *Full Read* | You have comprehensively understood this person's psychological state. For the rest of the scene, all Psychoanalyze rolls against them gain +2 bonus dice and are treated as Difficulty 1 — you know them now.
 |===
 
 ---

--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -172,9 +172,9 @@ Declare your target (must be at Engaged range). Roll your dice pool:
 * *Heavy melee* (knife, crowbar, brawl against an armored target): *Force (STR)* + Weapon Gear Bonus
 * *Fast melee* (unarmed strikes, quick knife work): *Brawl (STR)* + Weapon Gear Bonus
 
-On a hit (at least one 6), deal the weapon's flat *Damage* value directly to the target's Strength. Armor intercepts first.
+On a hit (meeting the attack's Difficulty, usually 1), deal the weapon's flat *Damage* value directly to the target's Strength. Armor intercepts first.
 
-Extra successes (additional 6s) are *Stunt Points* — see Combat Stunts below.
+Successes beyond the attack's Difficulty are *Stunt Points* — see Combat Stunts below.
 
 === Unarmed Combat
 
@@ -276,7 +276,7 @@ Ammunition is tracked using a *Resource Die*. When you acquire a weapon or reloa
 
 == Combat Stunts
 
-Extra successes (6s beyond the first on any attack roll) are *Stunt Points*. Spend them from the table below. One stunt point = one effect unless listed otherwise.
+Extra successes (6s beyond the attack's required Difficulty, usually 1) are *Stunt Points*. Spend them from the table below. One stunt point = one effect unless listed otherwise.
 
 [%header,cols="^1,2,4"]
 |===

--- a/docs/chapters/06-social-conflict.adoc
+++ b/docs/chapters/06-social-conflict.adoc
@@ -17,9 +17,9 @@ Every NPC who is not immediately cooperative has a *Disposition* — a state des
 
 | 5 | *Open* | The NPC wants to help. They volunteer information. No roll needed for basic cooperation.
 | 4 | *Cautious* | The NPC is willing to talk but holds back. They answer simple questions but hedge on anything sensitive.
-| 3 | *Guarded* | The NPC is resistant. They answer only what they must. Social rolls are Difficulty 2.
+| 3 | *Guarded* | The NPC is resistant. They answer direct, low-risk questions, but social rolls on sensitive subjects are Difficulty 2.
 | 2 | *Hostile* | The NPC is actively uncooperative. They may lie, deflect, or attempt to end the scene. Social rolls are Difficulty 3.
-| 1 | *Closed* | The NPC will not engage. They may call for help, alert others, or physically leave. Social rolls are Difficulty 4.
+| 1 | *Closed* | The NPC will not engage. They may call for help, alert others, or physically leave. Raise them to 2 before social rolls are possible.
 |===
 
 === Starting Disposition
@@ -41,7 +41,7 @@ Disposition shifts up (toward Open) or down (toward Closed) based on agent actio
 
 === Actions that Shift Disposition Up (+1)
 
-* A successful Psychoanalyze roll (treating or reading the NPC)
+* A successful Psychoanalyze roll used to calm, stabilize, or reassure the NPC
 * A successful Manipulate roll that makes the NPC feel their interests are served
 * The agent voluntarily reveals information that helps the NPC (demonstrates good faith)
 * The NPC is shown physical evidence that confirms what they suspected
@@ -57,7 +57,7 @@ Disposition shifts up (toward Open) or down (toward Closed) based on agent actio
 
 === Disposition Thresholds
 
-* *Disposition 3 or higher:* The NPC will answer direct questions truthfully (though not necessarily fully). No roll required for general cooperation.
+* *Disposition 3 or higher:* The NPC will answer direct, low-risk questions truthfully (though not necessarily fully). No roll required for general cooperation. Sensitive asks, incriminating admissions, or requests against self-interest still call for a roll.
 * *Disposition 2:* The NPC requires a successful social roll to answer even basic questions. They will lie by default.
 * *Disposition 1:* The NPC is done with the scene. They must be brought back to 2 before any social rolls are possible. Physical containment is required for continued interrogation.
 
@@ -65,7 +65,7 @@ Disposition shifts up (toward Open) or down (toward Closed) based on agent actio
 
 == Social Rolls in Practice
 
-Social rolls use the normal dice pool (Attribute + Skill), difficulty set by current Disposition. You are always rolling against the NPC's *current state*, not their willpower or an abstract resistance.
+Social rolls use the normal dice pool (Attribute + Skill). When a roll is required to gain cooperation or extract something sensitive, the baseline Difficulty is set by current Disposition unless a skill entry says otherwise. You are always rolling against the NPC's *current state*, not their willpower or an abstract resistance.
 
 === Manipulate (Empathy)
 
@@ -89,6 +89,7 @@ Used to read, understand, or heal. In social conflict, Psychoanalyze has two mod
 
 *Reading:* You are trying to understand the NPC's underlying state — what they need, what they fear, what they're not saying.
 
+* Difficulty: Set by the DA based on how defended or emotionally opaque the NPC is, usually 1–3. Current Disposition is a guide, not a hard rule.
 * On success: DA must reveal one true thing about this NPC's psychological state, motivation, or deception. Disposition is not directly shifted, but the information can be used to inform subsequent Manipulate rolls (advantage: +1 die on the next Manipulate against this NPC if the revealed information is used).
 
 *Stabilizing:* You are treating an NPC's fear, trauma, or distress to make them more communicative.
@@ -143,7 +144,7 @@ See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption,
 
 *Starting Disposition:* 2 (Hostile). He's in zip ties. He's praying under his breath. He won't look at the agents directly.
 
-*Round 1:* Agent Petra Vasquez attempts Psychoanalyze (Read) — she wants to understand what Elias actually believes before making any demands. The DA sets Difficulty 2 (his Disposition).
+*Round 1:* Agent Petra Vasquez attempts Psychoanalyze (Read) — she wants to understand what Elias actually believes before making any demands. The DA sets Difficulty 2: Elias is hostile, but reading him is easier than persuading him or getting him to volunteer anything.
 
 Petra rolls Empathy 3 + Psychoanalyze 2 = 5 dice. Rolls: 6, 4, 3, 2, 1 — one success.
 
@@ -151,15 +152,15 @@ Petra rolls Empathy 3 + Psychoanalyze 2 = 5 dice. Rolls: 6, 4, 3, 2, 1 — one s
 
 *Round 2:* Using that information, Agent Marcus Osei attempts Manipulate. He doesn't argue about the artifact being dangerous — he asks about the sister. Where is she? Is she still safe? The agents can make sure she stays that way.
 
-Manipulate roll: Empathy 4 + Manipulate 3 = 7 dice. Difficulty 2. Rolls: 6, 6, 5, 3, 2, 1, 1 — two successes (one extra = 1 Stunt Point).
+Manipulate roll: Empathy 4 + Manipulate 3 = 7 dice. Difficulty 3. Rolls: 6, 6, 6, 6, 2, 1, 1 — four successes (one extra = 1 Stunt Point).
 
 *Success:* Elias answers the question about the sister (she's in Providence, she's fine). Disposition shifts to 3. 
 
 *Stunt Point spent:* Bought Silence — Elias will not tell the Accord that the agents know about his sister.
 
-*Round 3:* Disposition is now 3 (Guarded). Direct questions are possible. The agents ask who gave Elias the artifact to begin with.
+*Round 3:* Disposition is now 3 (Guarded). Direct questions are possible, but naming a supplier would still put Elias at risk. The DA calls for another Manipulate roll.
 
-Another Manipulate roll at Difficulty 2 (they're now at 3). Marcus rolls: 6, 5, 4, 4, 2, 2, 1 — one success.
+Another Manipulate roll at Difficulty 2 (Disposition 3, sensitive ask). Marcus rolls: 6, 6, 5, 4, 2, 2, 1 — two successes.
 
 *Elias gives the name*: a fence named Talvez, operating out of a pawn shop on the East Side. He works for several clients. Elias doesn't know who.
 

--- a/docs/chapters/08-corruption-fear-healing.adoc
+++ b/docs/chapters/08-corruption-fear-healing.adoc
@@ -114,6 +114,8 @@ The DA calls for a Fear check when a character directly confronts a source of ge
 
 === The Fear Check Procedure
 
+Fear checks are a *special binary roll*. They do *not* use the standard Difficulty system from xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
+
 . The DA calls for a Fear check when a character directly confronts supernatural horror.
 . Roll dice equal to your current *Wits* attribute (no skill modifier — Fear is instinctual, not trained).
 . *One or more 6s = success.* You hold it together.

--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -62,7 +62,7 @@ Specialization within a Division (Wayfinder, Keep, Stack). Determines the charac
 The table's facilitator role. The DA presents scenes, adjudicates uncertainty, advances clocks, and portrays the world and opposition. See xref:chapters/14-gm-guidance.adoc#chapter-gm-guidance[Director of Agents Guidance].
 
 *Difficulty*::
-The number of successes (6s) required to pass a skill roll. Standard range: 1 (routine) to 5+ (extreme). See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
+The number of successes (6s) required to pass a standard skill roll. Default Difficulty is 1 if a rule does not state otherwise. Opposed rolls compare totals instead of using a fixed Difficulty, and a few special rolls such as Fear checks use their own binary rules. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 
 *Division*::
 Character class within the Verdant Covenant. Four playable Divisions: Wayfinder (research/intelligence), Recovery (field retrieval), The Keep (vault security), and Stack (logistics). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
@@ -82,7 +82,7 @@ State when a Broken character has an active Death Check Critical Injury (result 
 One of three action types in combat. Represents a quick or secondary effort: moving one zone, drawing a weapon, taking cover, or using a small item. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
 
 *Fear Check*::
-A Wits roll triggered by supernatural horror. Each 6 = success. Each 1 = +1 Corruption. No successes = failure (+1 Corruption + Panic Table roll). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+A special binary Wits roll triggered by supernatural horror. One or more 6s = success. Any 1s = +1 Corruption. No 6s = failure (+1 Corruption + Panic Table roll). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
 
 *Fear Rating*::
 Narrative classification (0–5) of how terrifying a creature or event is. Used by the DA to determine when to call for a Fear check. 0 = no check triggered. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
@@ -124,7 +124,7 @@ A significant antagonist in a Case File — a faction operative, corrupted NPC, 
 A d6 table rolled on Fear check failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
 
 *Push*::
-Re-roll all non-6 dice after a failed roll. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
+Re-roll all non-6 dice after a roll fails to meet its Difficulty, or after a success when you want more successes. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 
 *Psychoanalyze*::
 A skill used to treat mental and emotional Critical Injuries. Recovery difficulty and duration vary by injury severity. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
@@ -142,7 +142,7 @@ Green dice in the pool, equal to the relevant Skill rating (0–5). See xref:cha
 One of three action types in combat. Represents a committed effort: attacking, using a skill, administering first aid, or reloading a weapon. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
 
 *Stunt Points*::
-Extra successes (6s) beyond the first on an attack roll, spent on special combat effects such as increased damage, disarming, or knockback. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
+Extra successes (6s) beyond the required Difficulty on a roll that allows stunt spending. In combat, they can be spent on special effects such as increased damage, disarming, or knockback. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
 
 == T
 


### PR DESCRIPTION
Closes #215

## Summary
Defines one canonical success model for the manuscript. Standard rolls now use `Difficulty = successes required` with a default Difficulty of 1, opposed rolls compare total successes, and Fear checks are explicitly called out as a binary exception instead of silently acting like a second rules engine.

## Changes
- Rewrote `Core Resolution` to teach threshold success, default Difficulty 1, extra successes, and mixed opposed/difficulty handling
- Added a new worked example for a Difficulty 2 standard roll
- Updated stunt wording in `Attributes & Skills` and `Combat` to key off required Difficulty instead of "beyond the first 6"
- Rewrote the `Social Conflict` difficulty text and worked example so its rolls are compatible with the canonical model
- Updated the glossary definitions for `Difficulty`, `Fear Check`, `Push`, and `Stunt Points`

## Design Notes
The least disruptive choice was to keep the manuscript's later threshold-success model and teach it properly up front, rather than rewrite every `Difficulty 2/3/4` subsystem back into binary success. This preserves the existing stunt economy and harder-task language already embedded throughout injuries, HQ, vehicles, case files, and the bestiary. Fear checks remain binary by design, but they are now explicitly framed as a special exception instead of an accidental contradiction.

## References Consulted
- Issue #215 body and issue-thread design notes
- `docs/chapters/03-core-resolution.adoc` — current success / opposed / group-roll teaching text
- `docs/chapters/06-social-conflict.adoc` — worked example and disposition difficulty language
- `docs/chapters/20-glossary.adoc` — canonical terminology definitions