### PR TITLE
Issue #216: Consolidate advancement and General Talents into one progression system

### DIFF
--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -111,13 +111,13 @@ Distribute your *Skill Points* (determined by your Age Group in Step 3) across t
 
 At creation, every agent selects *three* talents:
 
-* *One Division Talent* chosen from your Division's talent list (see the Advancement chapter). You may only choose from your own Division's list at creation. — *OR* — *One General Talent* chosen from the General Talents list (see the Advancement chapter). General Talents are available to every agent regardless of Division.
-* *One Wing, Paradigm, or Department Talent* chosen from your Wing, Paradigm, or Department's talent list (see the Advancement chapter). You may only choose from your own Wing, Paradigm, or Department list at creation.
-* *One Background Talent* chosen from the Background Talents list (see the Advancement chapter). Background Talents are available to every agent regardless of Division.
+* *One Division Talent* chosen from your Division's talent list in xref:chapters/09-divisions.adoc#chapter-divisions[Divisions]. You may only choose from your own Division's list at creation. — *OR* — *One General Talent* chosen from the General Talents list in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets]. General Talents are available to every agent regardless of Division.
+* *One Wing, Paradigm, or Department Talent* chosen from your Wing, Paradigm, or Department's talent list in xref:chapters/09-divisions.adoc#chapter-divisions[Divisions]. You may only choose from your own Wing, Paradigm, or Department list at creation.
+* *One Background Talent* chosen from the Background Talents list in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets]. Background Talents are available to every agent regardless of Division.
 
 Most Division Talents cost *+1 Corruption* to activate. One talent per list is a *Healing* talent, usable freely but once per session. General Talents are passive or per-session effects with no Corruption cost unless noted. Background Talents are always passive — no activation cost.
 
-> *Talent Advancement:* Additional talents can be purchased during play using experience points. See the Advancement chapter.
+> *Talent Advancement:* Additional General, Division, or Wing/Paradigm/Department talents can be purchased during play using XP. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
 
 ---
 
@@ -239,9 +239,9 @@ After completing all steps, your sheet should record:
 | *Age Group / Age* | Chosen in Step 3 (Young / Experienced / Senior)
 | *Attributes (STR / AGI / WIT / EMP)* | Attribute Points distributed per Age Group, 2–5 each
 | *Skills (13)* | Skill Points distributed per Age Group, 0–3 each
-| *Division Talent or General Talent* | One chosen from Division list or General Talents list (Advancement chapter)
-| *Wing, Paradigm, or Department Talent* | One chosen from sub-group talent list within Division (Advancement chapter)
-| *Background Talent* | One chosen from Background Talents list (Advancement chapter)
+| *Division Talent or General Talent* | One chosen from Divisions chapter or the General Talents list in Advancement
+| *Wing, Paradigm, or Department Talent* | One chosen from the sub-group talent list in Divisions
+| *Background Talent* | One chosen from the Background Talents list in Advancement
 | *Division Item* | Automatic per Division
 | *Starting Gear* | Division kit (department variant if applicable) ± optional items
 | *Corruption* | Starts at 0

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -229,15 +229,6 @@ The following stunts may be purchased on *any* successful skill roll:
 
 == General Talents
 
-General Talents are cross-Division abilities available to any agent regardless of Division affiliation. They are acquired through advancement (cost: 1 Advancement Point each) and represent learned tradecraft, personal discipline, and survivor instincts.
+General Talents are not defined in this chapter. The canonical advancement rules and full General Talents catalog live in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
 
-[%header,cols="2,1,2,1,4"]
-|===
-| Talent | Type | Prerequisites | Tag | Effect
-
-| *Hair Trigger* | Once per combat | AGI 3+ | _(Initiative)_ | After initiative cards are revealed but before the first action, discard your card and draw a new one, keeping the new result.
-
-| *Tactical Override* | Fast Action | EMP 3+, Command 2+ | _(Initiative)_ | Once per round, swap one ally's initiative card with the next hostile participant directly above them in the order. If no hostile is directly above the chosen ally, this talent has no valid target this round.
-|===
-
-> *Edge case — Tactical Override:* "Directly above" means the next hostile in turn order, not spatial proximity. Cannot swap with another PC — the participant directly above must be hostile.
+At character creation, an agent may choose one General Talent in place of their starting Division Talent, as described in xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].

--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -24,8 +24,6 @@ At the start of any hostile confrontation, each participant draws an *Initiative
 
 Initiative uses card draw only. Do not add initiative modifiers for posture, terrain, or gear. Those factors still matter through cover, surprise, action economy, and range penalties.
 
-> *Initiative Talents:* Some General Talents interact with initiative card draws. See xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills → General Talents].
-
 === Surprise and Ambush
 
 A *surprise* occurs when one side is unaware of the other at the moment combat begins.

--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -5,9 +5,9 @@ In Project Neon Relic, players are sworn members of *The Verdant Covenant*. Beca
 
 Within that Division, players select a *Department* background. At character creation, agents choose *three* starting talents:
 
-* *One Division Talent* — chosen from the Division's talent list — *or One General Talent* from the General Talents list.
-* *One Wing, Paradigm, or Department Talent* — chosen from the talent list of the specific Wing, Paradigm, or Department the agent belongs to.
-* *One Background Talent* — chosen from the Background Talents list.
+* *One Division Talent* — chosen from the Division's talent list in this chapter — *or one General Talent* from xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+* *One Wing, Paradigm, or Department Talent* — chosen from the talent list of the specific Wing, Paradigm, or Department the agent belongs to in this chapter.
+* *One Background Talent* — chosen from the Background Talents list in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
 
 Most Division and sub-unit Talents cost *+1 Corruption* to activate, feeding directly into the game's risk-reward loop. Each talent list includes one *Healing* talent usable freely once per session.
 

--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -1,6 +1,6 @@
----
-
 [#chapter-advancement]
+= Advancement, Talents, and Dark Secrets
+
 == Dark Secrets
 
 A *Dark Secret* is a specific fact from your character's past — something true, hidden, and consequential. It is not a personality flaw or a general backstory. It names something: an event, a decision, a relationship that *someone wants to remain buried*.
@@ -75,9 +75,9 @@ There are no rules for voluntary activation, mandatory exposure, or faction cons
 |===
 
 ---
-= Advancement and General Talents
+== Advancement
 
-Experience Points (XP) are awarded at the end of each Case File through a structured debriefing. The DA asks the group a series of questions — for every "yes," each player receives *1 XP* (maximum *5 XP per session*):
+Experience Points (XP) are the game's *only* advancement currency. They are awarded at the end of each Case File through a structured debriefing. The DA asks the group a series of questions — for every "yes," each player receives *1 XP* (maximum *5 XP per session*):
 
 [%header,cols="^1,5"]
 |===
@@ -90,7 +90,7 @@ Experience Points (XP) are awarded at the end of each Case File through a struct
 | 5 | Did you learn something new and significant about the supernatural threat or rival factions?
 |===
 
-== Spending XP
+=== Spending XP
 
 [%header,cols="3,1,2"]
 |===
@@ -145,7 +145,7 @@ The following shows a typical post-session debrief for *Agent Yusuf Demi*, a Kee
 
 == General Talents
 
-General Talents are specialized abilities available to *any character*, providing mechanical exceptions or situational bonuses:
+This is the *canonical General Talents list* used at character creation and during XP advancement. General Talents use the same concise format as the rest of the manuscript's talent lists: talent name plus effect text, with tags only when mechanically relevant.
 
 [%header,cols="2,4"]
 |===

--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -76,6 +76,11 @@ A class-specific ability unique to one Division. Costs +1 Corruption to activate
 *Dying*::
 State when a Broken character has an active Death Check Critical Injury (result marked †) that has not yet been resolved. An untreated Dying character will die. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 
+== E
+
+*Experience Points (XP)*::
+The game's only advancement currency. XP are awarded at the end of each Case File through debrief questions and spent to raise skills, buy new talents, or increase Clearance Level. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+
 == F
 
 *Fast Action*::
@@ -96,7 +101,7 @@ An action in combat that requires negligible effort: speaking a short sentence, 
 Black dice in the pool contributed by equipment. Each 1 rolled on a Gear die causes the item to degrade one step. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 
 *General Talent*::
-A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement].
+A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. General Talents are chosen at character creation in place of a Division Talent or purchased later for 6 XP. The canonical list lives in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
 
 == H
 


### PR DESCRIPTION
Closes #216

## Summary
Collapses the manuscript to one advancement/progression model. XP is now the only advancement currency, Chapter 13 is the canonical home for advancement and General Talents, and the leftover Chapter 4 mini-catalog no longer competes with the real rules.

## Changes
- Promoted Chapter 13 to the canonical advancement chapter with a coherent title/section structure
- Explicitly states that XP is the game's only advancement currency
- Removed the duplicate/conflicting General Talents table from `Attributes & Skills` and replaced it with a cross-reference to Chapter 13
- Updated character creation and division setup text so Division/sub-unit talents point to `Divisions`, while General/Background Talents point to `Advancement`
- Added an `Experience Points (XP)` glossary entry and clarified the `General Talent` glossary definition
- Removed the stale combat note that pointed readers to the superseded Chapter 4 talent table

## Design Notes
This takes the least speculative path: keep the broader XP-based system already embedded in Chapter 13 and retire the older Chapter 4 draft instead of trying to merge two incompatible talent catalogs. `Hair-Trigger` in Chapter 13 is now the canonical talent; the initiative-draw `Hair Trigger` and `Tactical Override` text were treated as superseded draft material rather than silently preserved as a second design direction. General Talents also inherit the manuscript's existing concise formatting standard instead of the abandoned type/tag/prerequisite schema from Chapter 4.

## References Consulted
- Issue #216 body and issue-thread consolidation notes
- `docs/chapters/04-attributes-skills.adoc` — superseded General Talents draft
- `docs/chapters/13-advancement.adoc` — XP economy, Dark Secrets, General Talents, Background Talents
- `docs/chapters/02-character-creation.adoc` and `docs/chapters/09-divisions.adoc` — player-facing talent selection flow