### PR TITLE
Issue #217: Write the missing containment ritual framework referenced by artifacts, case files, and the bestiary

### DIFF
--- a/docs/chapters/07-health-damage-armor.adoc
+++ b/docs/chapters/07-health-damage-armor.adoc
@@ -223,14 +223,14 @@ Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Corru
 | 46 | *Catatonic Episode* † | Death check (mind, not body — failure = permanent catatonia, character retirement). Surviving: Wits and Empathy each reduced by 1. +2 Corruption immediately. | Intensive Psychoanalyze (Difficulty 4, Keep facility) over 2 downtime phases to stabilize.
 | 51 | *Obsessive Documentation* | Character must document everything (Insight: *+2 dice on Investigate* when reviewing notes from current mission). Compulsion: spends all available time writing; −1 die on social rolls (distracted). | Psychoanalyze campaign (3 downtime phases) to reduce compulsion; Insight remains.
 | 52 | *Broken Empathy* | Permanently −2 Empathy. All social skills lose 2 dice. | Cannot be healed — the connection is severed.
-| 53 | *Artifact Imprint* | +3 Corruption (additional). Character begins hearing the artifact that Broke them. DA may use this as a plot hook: the artifact calls them back. | Containment ritual (Issue #15) can suppress the call but not eliminate the imprint.
+| 53 | *Artifact Imprint* | +3 Corruption (additional). Character begins hearing the artifact that Broke them. DA may use this as a plot hook: the artifact calls them back. | Shielding ritual (see xref:chapters/11-artifacts.adoc#containment-rituals[Containment Rituals]) can suppress the call but not eliminate the imprint.
 | 54 | *Veil Burn* | +2 Corruption. Wits permanently −1. Insight: *+1 die on all artifact detection rolls* (you can feel them now). | Cannot be healed — the Veil has scorched your perception permanently.
 | 55 | *Shattered Will* † | Death check (mind). Surviving: Wits and Empathy max permanently reduced by 1 each. +2 Corruption. Cannot push rolls for remainder of campaign arc until psychological breakthrough (DA milestone). | Keep Psychoanalyze program (4 downtime phases, Difficulty 4).
 | 56 | *Cosmic Revelation* † | Death check (mind). Surviving: character learns something true and terrible about the Covenant's mission or the nature of artifacts. +3 Corruption, −2 Empathy permanently. Insight: *+2 dice on all Lore-type rolls forever* (Wayfinder skill equivalent). DA defines the revelation — it should reshape how the character sees the world. | Cannot be unlearned. Roleplay is mandatory.
 | 61 | *Memory Dissolution* | Permanently −1 Wits. Character loses one specific skill memory (DA chooses a skill at rank 1–2; it drops to 0). | Cannot recover lost skill without retraining (requires downtime advancement, Issue #2).
 | 62 | *Identity Crisis* | Character's Division Allegiance wavers. For 1 campaign arc, they cannot use their Division Talent. | Major roleplay scene with Covenant superior + Psychoanalyze (Difficulty 3).
 | 63 | *Veil Madness* | +4 Corruption immediately. Roll on this table *again* (ignore result 63 on reroll). | As per second roll result.
-| 64 | *Prophetic Fugue* † | Death check (mind). Surviving: +3 Corruption. Character enters a trance broadcasting the Covenant's location to hostile artifact entities until a Wayfinder performs a Shielding ritual (Issue #15). | Ritual seals the broadcast; Corruption remains.
+| 64 | *Prophetic Fugue* † | Death check (mind). Surviving: +3 Corruption. Character enters a trance broadcasting the Covenant's location to hostile artifact entities until a Shielding ritual is performed. | Ritual seals the broadcast; Corruption remains.
 | 65 | *Ego Death* † | Death check (mind). Surviving: character personality fundamentally alters. Player rewrites one Drive and one aspect of their biography. +3 Corruption. Insight: *+2 dice on all Empathy rolls* (dissolution breeds radical compassion — or fearlessness). | Cannot be undone. Roleplay the new self.
 | 66 | *Unraveling* † | Automatic mind death check (no bonus). Surviving: +4 Corruption, −1 to every Attribute permanently, character retires at end of current mission (they cannot continue as an operative). Final scene before retirement should be played. | Retirement is farewell — play it well.
 |===
@@ -243,7 +243,7 @@ Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Corru
 * *Healing in the field:* First Aid Kit, Heal skill, Psychoanalyze skill — see xref:chapters/08-corruption-fear-healing.adoc#_healing_corruption[Healing Corruption].
 * *Downtime recovery:* Between-mission phases and Keep medical access — see xref:chapters/12-headquarters.adoc#chapter-headquarters[Headquarters].
 * *Death and dying procedure:* Full death check rules with autopsy and Covenant notification — see _(Issue #13)_.
-* *Artifact Imprint and Veil Burn:* Interaction with artifact containment rituals — see xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts] _(Issue #9)_.
+* *Artifact Imprint and Veil Burn:* Interaction with artifact containment rituals — see xref:chapters/11-artifacts.adoc#containment-rituals[Artifacts → Containment Rituals].
 
 == Armor Mechanics
 

--- a/docs/chapters/11-artifacts.adoc
+++ b/docs/chapters/11-artifacts.adoc
@@ -276,6 +276,128 @@ kept inert during transport and what triggers it inadvertently.
 > containment. Without them, field containment relies on improvised measures and
 > Wayfinder knowledge.
 
+[[containment-rituals]]
+=== Containment Rituals
+
+Containment rituals are not spellcasting talents. They are risky *Lore-led procedures* used to suppress an artifact, shield a target from occult bleed, or disperse a manifestation long enough to regain custody. Wayfinders most often lead them, but any agent with Lore may attempt one.
+
+* *Who can lead:* Any agent with *Lore 1+* may attempt a *Quiescence* or *Shielding* ritual. *Banishment* rituals, or any ritual aimed at a *Tier 3+* artifact or a fully manifest entity, require *Lore 3+* or active Wayfinder support.
+* *What rituals do not do:* A ritual rarely solves the whole case by itself. If the anchor, artifact, or ritual site remains uncontrolled, the threat can return when the pressure rises again.
+* *Pushing:* Ritual rolls may be pushed as normal. If the ritual targets an artifact or entity that is already active, manifest, or broadcasting, the ritual leader gains *+1 Corruption* when the roll resolves, even on success.
+
+==== Minimum Inputs
+
+[%header,cols="2,4"]
+|===
+| Input | Requirement
+
+| *Boundary*
+| Chalk, salt, copper wire, black cloth, lead foil, or whatever the artifact's Containment Profile specifically requires.
+
+| *Target or Anchor*
+| The artifact, contaminated carrier, ritual site, or identified occult origin point must be present, physically reachable, or precisely fixed in the scene.
+
+| *Key*
+| A true name, activation condition, containment phrase, symbol pattern, or other specific clue learned through play. Rituals are procedures, not guesses.
+
+| *Working Window*
+| *Quiescence:* 10 minutes. *Shielding* or *Banishment:* one full scene. Combat, vehicle movement, or panicked crowds count as hostile conditions, not valid quiet setup.
+|===
+
+If the team lacks proper boundary materials or the correct key, add *+1 Difficulty* for each missing element. A *Verdant Codex* or a Keep containment kit counts as proper ritual material support in the field.
+
+==== Ritual Types
+
+[%header,cols="2,1,2,4"]
+|===
+| Ritual Type | Base Diff | Default Time | On Success
+
+| *Quiescence*
+| 2
+| 10 minutes
+| Suppress an artifact's activation or emission for one scene or one transport leg. If the artifact uses a *Ritual Quiescence* Containment Profile, the rite is considered renewed for the next 24 hours.
+
+| *Shielding*
+| 2
+| One full scene
+| Seal a person, object, or small zone against passive broadcast, imprint, or occult bleed until the end of the current case phase or until the boundary is broken.
+
+| *Banishment / Dispersal*
+| 3
+| One full scene
+| Disperse a manifestation, collapse an active ritual site, or force an entity back to its anchor. If the anchor is immediately contained or removed, the effect holds; if not, the threat may return on the next clock advance or major disturbance.
+|===
+
+Apply these modifiers unless an artifact or bestiary entry gives a fixed ritual Difficulty:
+
+* *+1* if the target is Tier 3, actively emitting, or spreading across multiple people.
+* *+2* if the target is Tier 4, catastrophic, or imposing itself across multiple zones.
+* *+1* if the ritual is performed while moving, under attack, or amid public panic.
+* *−1* if the team has the exact containment profile, true name, or recovered ritual notes.
+* *−1* if the rite is performed in a properly prepared HQ vault, Occult Lab, or equivalent secured site.
+
+Each *successful containment ritual* advances the artifact's *Decay* by *+1*, if the target has a Decay track.
+
+==== Support Actions
+
+Before the final ritual roll, allies may either help normally or perform one of the following support actions. Each successful support action may only benefit the ritual once:
+
+[%header,cols="2,2,4"]
+|===
+| Support Action | Skill | Effect
+
+| *Identify the Key*
+| Investigate or Lore
+| Remove one missing-key penalty by confirming the true name, activation condition, or anchor logic.
+
+| *Build the Boundary*
+| Tech or Sleight of Hand
+| Gain *+1 die* on the ritual roll or ignore one improvised-material penalty.
+
+| *Hold the Line*
+| Command, Firearms, Force, or Sneak
+| The next interruption, hostile push, or panic effect does *not* automatically break the ritual setup.
+
+| *Stabilize the Subject*
+| Heal or Psychoanalyze
+| A contaminated carrier, witness, or panicked ally can remain inside the boundary. On failure, they flee, lash out, or collapse — the ritual cannot begin until the situation is controlled.
+|===
+
+In practice, this usually means *Wayfinder leads, Recovery secures the target, Keep controls the perimeter, and Stack improvises shielding or material support*.
+
+==== Failure and Backlash
+
+On failure, the ritual does not take hold. The DA chooses or rolls one backlash from the table below. On a *pushed failure*, apply *two different* backlash results.
+
+[%header,cols="1,4"]
+|===
+| d6 | Backlash
+
+| 1
+| *Corruption Surge.* The leader and everyone inside the boundary gain *+1 Corruption*.
+
+| 2
+| *Boundary Rupture.* Materials burn out, spill, or crack. The next ritual attempt in this scene is *+1 Difficulty* until the boundary is rebuilt.
+
+| 3
+| *Clock Advance / Activation Spike.* Advance the nearest case clock by 1, or trigger the target's emission immediately if no clock is running.
+
+| 4
+| *Psychic Recoil.* The ritual leader takes *1 Wits or Empathy damage* (DA chooses to fit the fiction).
+
+| 5
+| *Anchor Shift.* The target relocates, hides, or changes the visible trigger. The team must re-establish the key before trying again.
+
+| 6
+| *Hostile Backlash.* The entity lashes out, a bystander becomes contaminated, or electronics in Near range lose *1 Gear Bonus* permanently.
+|===
+
+==== Starter Rituals
+
+* *Field Quiescence Rite:* Re-wrap, re-phrase, or re-seal an artifact before transport. This is the default answer to a *Ritual Quiescence* Containment Profile and the usual way to renew a temporary seal after mishandling.
+* *Lead-and-Salt Shield:* Used on contaminated carriers, artifact-imprinted survivors, and occult broadcasts. This is the default rite for suppressing *Artifact Imprint* and similar lingering calls.
+* *Anchor Dispersal Circuit:* Used against manifestations such as *The Mire* or *The Listening*. It does not destroy them permanently unless the anchor is simultaneously removed, isolated, or neutralized.
+
 ---
 
 === One-of-a-Kind vs. Replicable Artifacts

--- a/docs/chapters/14-gm-guidance.adoc
+++ b/docs/chapters/14-gm-guidance.adoc
@@ -162,7 +162,7 @@ Supernatural entities in Neon Relic do not think the way humans do. Avoid playin
 | *Echoing Remnant* | Acts on memory, not will. Repeats actions associated with its final emotional state. An Echoing Remnant from a violent event will reenact something about that event — not attack intelligently. Agents who understand the echo can sometimes avoid it entirely.
 | *Shard Construct* | Single-directive: protect the artifact. No curiosity, no self-preservation beyond mission, no social engagement. Cannot be persuaded or manipulated. Can be outmaneuvered (if you aren't between the Construct and the artifact, it doesn't care about you).
 | *Bound Entity* | Has a will, has a history, has something it wants. Bound Entities can be communicated with through Lore and Psychoanalyze (not Manipulate — they see through human social mechanics). They respond to truth, to acknowledgment of what happened to them. They can be bargained with.
-| *Manifest Presence* | A high-tier supernatural intrusion: an entity that has begun to impose its logic on local reality. Does not fight — it *redefines the situation*. Agents trying to act normally in its presence find that normality is no longer available. These entities are solved through removing their anchor (the artifact) or performing a Wayfinder containment ritual, not fought.
+| *Manifest Presence* | A high-tier supernatural intrusion: an entity that has begun to impose its logic on local reality. Does not fight — it *redefines the situation*. Agents trying to act normally in its presence find that normality is no longer available. These entities are solved through removing their anchor (the artifact) or performing a containment ritual, not fought.
 |===
 
 ---
@@ -236,6 +236,16 @@ Containment missions still have escalating pressure. Use these tools to maintain
 * *The containment profile creates constraints.* If the artifact cannot be exposed to light, the agents must plan their extraction around darkness, covered transport, and power failures. Constraints are interesting problems, not punishment.
 
 * *Rivalry without combat.* A rival faction wants the artifact activated; the agents want it contained. This is a race with a clock, not a firefight. Rival agents may intercept, deceive, or manufacture the activation conditions even as players try to prevent them.
+
+If ritual containment is a possible solution, seed *three discoverable facts* into the clue web before play begins:
+
+* *What forms the boundary* (salt, copper wire, lead foil, blackout cloth, a drawn sigil, etc.)
+* *What the key is* (true name, activation condition, phrase, symbol, or anchor logic)
+* *What must be physically contained afterward* (the anchor object, the carrier, the room, the recording equipment, the ritual site)
+
+Ritual scenes work best when the team *earns the procedure through investigation* and then executes it under pressure.
+
+Use xref:chapters/11-artifacts.adoc#containment-rituals[Artifacts → Containment Rituals] for the actual field procedure.
 
 === Measuring Success in Containment Cases
 

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -113,7 +113,7 @@ The clock can be *slowed* (the next tick is delayed) or *held* (one stage does n
 
 The clock *cannot typically be reversed* — once a stage is reached, its effects persist. However:
 
-* A successful *Wayfinder Division ritual* can reduce Stage 4 back to Stage 3 (the escalating corruption is pushed back).
+* A successful *containment ritual* can reduce Stage 4 back to Stage 3 (the escalating corruption is pushed back).
 * Eliminating the rival faction's active presence at a location may reduce Stage 3 back to Stage 2 for that location only (the faction was accelerating the threat independently).
 
 These require significant resources, time, and usually a Lore roll at Difficulty 3 or 4. They are not guaranteed.
@@ -160,7 +160,7 @@ Faster clocks create urgency but reduce investigation time. Slower clocks allow 
 
 * DA guidance for building and calibrating Countdown clocks: xref:chapters/14-gm-guidance.adoc#chapter-gm-guidance[Director of Agents Guidance]
 * Corruption gain mechanics: xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing]
-* Wayfinder Division rituals: xref:chapters/17-rival-factions.adoc#chapter-rival-factions[Rival Factions] (and Issue #15)
+* Containment rituals: xref:chapters/11-artifacts.adoc#containment-rituals[Artifacts → Containment Rituals]
 
 ---
 

--- a/docs/chapters/19-bestiary.adoc
+++ b/docs/chapters/19-bestiary.adoc
@@ -353,7 +353,7 @@ means. It can be dispersed by:
   (1) Removing the corrupting artifact at its core (Investigate Difficulty 3
       to locate it inside the zone, Lore Difficulty 2 to identify it
       as the anchor).
-  (2) A Containment Ritual (see Wayfinder Division abilities) performed
+  (2) A Containment Ritual (see xref:chapters/11-artifacts.adoc#containment-rituals[Containment Rituals]) performed
       by an agent with Lore 3+, taking one full scene.
   (3) Destroying the artifact at its core (Artifact Fracture; triggers
       a Corruption Cascade — everyone in the zone takes +3 Corruption).
@@ -446,7 +446,7 @@ used. It may use this information in the same or future scenes (DA's
 discretion).
 
 Intangible — The Listening cannot be harmed by physical attacks. It can
-only be targeted by a Containment Ritual or destroyed by removing all
+only be targeted by a Containment Ritual (see xref:chapters/11-artifacts.adoc#containment-rituals[Containment Rituals]) or destroyed by removing all
 corrupted surveillance equipment from its zone of origin and performing a
 Tech roll (Difficulty 3) to disrupt its signal network.
 ----


### PR DESCRIPTION
Closes #217

## Summary
Adds the missing containment ritual framework that the manuscript kept referencing without actually defining. Ritual scenes are now a playable, Lore-led procedure with roles, materials, difficulty, backlash, and starter rites instead of a placeholder promise.

## Changes
- Added a full `Containment Rituals` section to `Artifacts`, including inputs, ritual types, modifiers, support actions, failure/backlash, and starter rituals
- Clarified in GM guidance how to seed ritual solutions into clue webs for containment cases
- Updated `Case File` to point at the real ritual rules instead of the rival factions chapter
- Updated bestiary entries and mental critical injuries that relied on undefined ritual/shielding procedures
- Preserved the game's containment-first identity by making rituals suppress or disperse threats unless the anchor is also contained or removed

## Design Notes
The framework is procedural rather than magical spectacle. Rituals are a risky Lore action with required boundary materials, an anchor/target, and a discovered key; they are not a separate talent economy. Wayfinders remain the best ritual leads, but the whole team has concrete support roles so containment scenes stay collaborative. Failure was intentionally given structured backlash instead of a simple "nothing happens" result, because ritual scenes need to move clocks, escalate pressure, or scar the team when they go wrong.

## References Consulted
- Issue #217 body and issue-thread notes on containment-first play
- `docs/chapters/11-artifacts.adoc` — containment profiles, emissions, decay, and worked containment examples
- `docs/chapters/15-case-file.adoc` — countdown clocks and climax expectations
- `docs/chapters/19-bestiary.adoc` — entities explicitly requiring containment rituals