### PR TITLE
Issue #222: Clarify Neon Relic's intended power level and tone at the rules-text level

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -5,18 +5,22 @@
 
 The game uses the *Year Zero Engine (YZE)* dice-pool variant -- the same framework behind _Vaesen_, _Mutant: Year Zero_, _Forbidden Lands_, and the _Alien RPG_. If you have played any of those, the core dice mechanics will feel familiar. What makes Neon Relic different is its *Corruption* system: a steadily rising psychological damage track with no safe reset, turning every pushed roll and every artifact activation into a calculated gamble against your own sanity.
 
+Neon Relic's default protagonists are *competent but vulnerable containment specialists*. They are trained, resourced, and trusted enough to enter dangerous situations on the Covenant's behalf, but they are never powerful enough to dominate those situations safely. The intended fantasy is *solve and survive under pressure* -- not superheroic paranormal mastery.
+
 == What This Game Is
 
 * *Episodic investigation.* Each session follows a structured *Case File* -- a "artifact-of-the-week" mystery driven by artifact recovery, faction interference, and occult threats.
 * *Base management between missions.* The team maintains a *Headquarters* -- a Covenant facility they upgrade, staff, and defend over the course of a campaign.
 * *Psychological attrition.* The real threat is not the monsters. It is the toll the work takes on the agents. Corruption accumulates from pushing rolls, using supernatural abilities, and confronting the unnatural. It does not go away easily. Characters who cross the threshold are permanently retired.
 * *Analog procedural thriller.* No internet. No GPS. No cell phones. Investigations require physical legwork, face-to-face conversations, and fragile 1980s technology that degrades under use.
+* *Professional tradecraft under cost.* Agents have real tools, protocols, and institutional support, but those tools create access, leverage, and temporary control -- not effortless victories.
 
 == What This Game Is Not
 
 * Not a step-dice system. Neon Relic uses d6 dice pools, not the step-dice variant from _Twilight: 2000_ or _Blade Runner RPG_.
 * Not high fantasy or superhero action. Powers are rare, dangerous, and always come at a cost.
 * Not a dungeon crawl. There are no experience points for killing monsters. Advancement comes from completing missions, surviving trauma, and confronting your Dark Secret.
+* Not a game where Division gear or Talents replace investigation. The Covenant equips you to enter the problem, not to bypass it.
 
 ---
 

--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -1,13 +1,13 @@
 [#chapter-character-creation]
 = Creating Your Agent
 
-Every player in Neon Relic portrays a sworn agent of *The Verdant Covenant* — a specialist with a particular expertise, a history that brought them to this work, and a threshold for the horrors they are about to witness. Character creation follows these eleven steps in order.
+Every player in Neon Relic portrays a sworn agent of *The Verdant Covenant* — a specialist with a particular expertise, a history that brought them to this work, and a threshold for the horrors they are about to witness. You are building a trained containment operative, not an occult superhero. Character creation follows these eleven steps in order.
 
 ---
 
 == Step 1: Choose Your Division
 
-Your *Division* is your character class. It defines your role within the Covenant, your key attributes, your starting skills, and your access to supernatural Division Talents. There are three Divisions:
+Your *Division* is your character class. It defines your role within the Covenant, your key attributes, your starting skills, and your access to supernatural Division Talents. Your Division tells the group what kind of pressure you are trained to handle -- not that you can solve scenes cleanly on your own. There are three Divisions:
 
 [%header,cols="1,2,1,2"]
 |===
@@ -117,6 +117,8 @@ At creation, every agent selects *three* talents:
 
 Most Division Talents cost *+1 Corruption* to activate. One talent per list is a *Healing* talent, usable freely but once per session. General Talents are passive or per-session effects with no Corruption cost unless noted. Background Talents are always passive — no activation cost.
 
+Talents and Division items are meant to create *leverage*: a clue path, a brief edge, a safer handling window, a cleaner extraction. They should not change the game's default expectation that agents must still investigate, improvise, and pay a price for certainty.
+
 > *Talent Advancement:* Additional General, Division, or Wing/Paradigm/Department talents can be purchased during play using XP. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
 
 ---
@@ -147,9 +149,9 @@ Every agent receives their Division's *signature item* at induction. This item r
 |===
 | Division | Item | Granted Abilities
 
-| Wayfinder | *Verdant Codex* | Secures memory, decodes language and symbols, maps artifact locations, preserves documents.
-| Recovery | *Verdant Satchel* | Suppresses artifact aura, seals cursed items, warns of instability, produces basic tools on demand.
-| Keep | *Warden's Bracer* | Suppresses artifact magic nearby, warns of containment failure, safe handling of cursed objects, absorbs 1 Corruption/session, +1 Armor Rating.
+| Wayfinder | *Verdant Codex* | Secures memory, assists with language and symbol work, highlights likely historical correlations, preserves documents.
+| Recovery | *Verdant Satchel* | Masks minor artifact signatures, stabilizes transport, warns of instability, keeps basic field tools ready.
+| Keep | *Warden's Bracer* | Dampens nearby emissions during handling, warns of containment failure, makes cursed objects safer to manage, absorbs 1 Corruption/session, +1 Armor Rating.
 |===
 
 ---

--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -1,7 +1,7 @@
 [#chapter-divisions]
 = Covenant Divisions
 
-In Project Neon Relic, players are sworn members of *The Verdant Covenant*. Because no single person possesses the brains, brawn, network, and magical guardianship required to hunt dangerous artifacts, players choose a *Division* (their core class) which dictates their starting attributes, skills, and Clearance Level (CL).
+In Project Neon Relic, players are sworn members of *The Verdant Covenant*. Because no single person possesses the brains, brawn, network, and magical guardianship required to hunt dangerous artifacts, players choose a *Division* (their core class) which dictates their starting attributes, skills, and Clearance Level (CL). A Division marks *expertise and responsibility*, not a higher power tier than the danger facing the cell.
 
 Within that Division, players select a *Department* background. At character creation, agents choose *three* starting talents:
 
@@ -10,6 +10,8 @@ Within that Division, players select a *Department* background. At character cre
 * *One Background Talent* — chosen from the Background Talents list in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
 
 Most Division and sub-unit Talents cost *+1 Corruption* to activate, feeding directly into the game's risk-reward loop. Each talent list includes one *Healing* talent usable freely once per session.
+
+Unless a Talent explicitly says otherwise, read these abilities as *scene-shaping leverage*, not complete scene resolution. They should reveal a lead, buy time, create access, or improve odds under pressure rather than trivialize artifacts, rivals, or core investigation procedures.
 
 == Division 1: The Wayfinder
 
@@ -38,7 +40,7 @@ All Wayfinders bear the *Verdant Codex*, an enchanted field journal for recordin
 * Automatically preserves documents placed within its pages
 * Stores large scrolls without damage
 * Faintly glows near ancient magic
-* Contains a living map lining that slowly reveals artifact locations
+* Contains a living map lining that slowly reveals *suspected* artifact correlations and previously researched sites
 
 === Wayfinder Wings
 
@@ -66,8 +68,8 @@ _Research personnel do not retrieve artifacts._ Once an artifact's existence and
 |===
 | Talent | Cost | Effect
 
-| *Pattern Recognition* | +1 Corruption | When examining a document, site, or artifact for the first time, instantly identify one hidden connection to a previously catalogued case — the DA must reveal the link.
-| *Deep Archive Access* | +1 Corruption | Spend an action consulting restricted Covenant records. Gain +3 bonus dice on your next Lore or Investigate roll this scene.
+| *Pattern Recognition* | +1 Corruption | When examining a document, site, or artifact for the first time, identify one plausible connection to a previously catalogued case — the DA must reveal a useful lead, not the entire answer.
+| *Deep Archive Access* | +1 Corruption | Spend an action consulting restricted Covenant records. Gain +2 bonus dice on your next Lore or Investigate roll this scene.
 | *Methodical Review* _(Healing)_ | — | Spend a Shift organizing and cross-referencing your field notes. Heal 1 Corruption and grant one ally +1 bonus die on their next Investigate roll.
 |===
 
@@ -106,7 +108,7 @@ Through the vigilance of the Counterintelligence Wing, the Covenant ensures that
 |===
 | Talent | Cost | Effect
 
-| *The Antiquarian's Eye* | +1 Corruption | Instantly identify an artifact's primary activation trigger and base effect without a Lore roll.
+| *The Antiquarian's Eye* | +1 Corruption | On first inspection, identify either an artifact's likely activation trigger or its likely base effect without a Lore roll.
 | *Ghost in the Machine* | +1 Corruption | Use Tech to directly interface with electronic devices jammed or possessed by anomalous entities.
 | *The Hunch* | +1 Corruption | Ask the DA one yes/no question about a crime scene or NPC's motive. The DA must answer truthfully.
 | *Academic Grounding* _(Healing)_ | — | Spend an hour researching an entity and framing it in academic terms. Heal 1 Corruption for yourself or one ally.
@@ -147,7 +149,7 @@ All Recovery agents carry the *Verdant Satchel*, a specially enchanted field bag
 * Warns when nearby artifacts become unstable
 * Allows temporary sealing of cursed items
 * Contains a small dimensional containment compartment
-* Produces useful tools on demand (rope, chalk, spikes, vials, etc.)
+* Keeps a small selection of ordinary field tools immediately accessible (rope, chalk, spikes, vials, etc.)
 * Enchantment of Warding obscures any magical object placed inside from detection
 
 === Recovery Paradigms
@@ -173,8 +175,8 @@ Former intelligence or special forces. Trained in infiltration, extraction, and 
 |===
 | Talent | Cost | Effect
 
-| *Dead Drop Protocol* | +1 Corruption | Establish an instant covert information exchange with any NPC contact. Gain one critical piece of intelligence from the DA without a roll.
-| *Exfiltration Specialist* | +1 Corruption | When retreating or extracting under fire, you and all allies within Short range gain +2 bonus dice to their next Agility roll this round.
+| *Dead Drop Protocol* | +1 Corruption | Establish an instant covert information exchange with any NPC contact. Gain one actionable piece of intelligence from the DA without a roll.
+| *Exfiltration Specialist* | +1 Corruption | When retreating or extracting under fire, you and all allies within Short range gain +1 bonus die to their next Agility roll this round.
 | *Spycraft Discipline* _(Healing)_ | — | Once per session, after successfully completing a covert objective without being detected, heal 1 Corruption.
 |===
 
@@ -197,7 +199,7 @@ Brute-force specialist. Comfortable in direct violent confrontation above all el
 |===
 | Talent | Cost | Effect
 
-| *Wrecking Ball* | +1 Corruption | When attacking an inanimate object or structure (door, wall, barricade, vehicle), automatically succeed on the Force roll and inflict maximum damage.
+| *Wrecking Ball* | +1 Corruption | When attacking an inanimate object or structure (door, wall, barricade, vehicle), gain +3 bonus dice to the Force roll and inflict +2 damage on a success.
 | *Stand Your Ground* | +1 Corruption | Plant yourself and refuse to move. Until your next turn, you cannot be pushed, knocked down, or forcibly moved, and you gain +2 Armor Rating.
 | *Blunt Trauma Recovery* _(Healing)_ | — | Once per session, after winning a physical confrontation through brute force, heal 1 Corruption.
 |===
@@ -221,8 +223,8 @@ Expert in bypassing security, stealing valuable objects, and getting in and out 
 |===
 | Talent | Cost | Effect
 
-| *Ghost Entry* | +1 Corruption | Bypass a single locked door, security system, or physical barrier without a roll. Leave no trace of entry.
-| *The Long Con* | +1 Corruption | After at least one scene spent building rapport with an NPC, automatically succeed on a Manipulate roll to extract one specific piece of information or gain one specific favor.
+| *Ghost Entry* | +1 Corruption | Bypass a single ordinary locked door, security system, or physical barrier without a roll. Against hardened or anomalous protection, gain +3 bonus dice instead. Leave no trace of entry.
+| *The Long Con* | +1 Corruption | After at least one scene spent building rapport with an NPC, gain +3 bonus dice on a Manipulate roll to extract one specific piece of information or gain one specific favor.
 | *Clean Getaway* _(Healing)_ | — | Once per session, after successfully completing a theft, infiltration, or escape without triggering an alarm, heal 1 Corruption.
 |===
 
@@ -262,7 +264,7 @@ Members of the Keep are entrusted with the stewardship of the Covenant's most se
 
 All Keepers wear the *Warden's Bracer*, marking them as guardians of the Covenant's vaults. The Bracer symbolizes that the Keeper is bound to guard what others must never wield. It provides the following benefits:
 
-* Suppresses artifact magic in close proximity
+* Dampens artifact emissions in close proximity long enough for controlled handling
 * Warns the wearer if containment fails
 * Allows safe handling of cursed objects
 * Absorbs Corruption (soaks 1 Corruption per session)

--- a/docs/chapters/11-artifacts.adoc
+++ b/docs/chapters/11-artifacts.adoc
@@ -19,6 +19,8 @@ Furthermore, when invoked, the player rolls a specific *Artifact Die* (d8, d10, 
 
 In Neon Relic, artifact activation is not the default objective. Many missions are won by *preventing activation*, isolating carriers, or moving an item into secure containment under pressure.
 
+Artifact use should feel like *emergency leverage*, not a class feature the group relies on every session. If the cell chooses activation, that should signal desperation, a calculated sacrifice, or a failure to preserve a cleaner containment path.
+
 When framing a case, define at least one non-activation success path:
 
 * *Deny use:* Keep all actors from meeting activation conditions.

--- a/docs/chapters/14-gm-guidance.adoc
+++ b/docs/chapters/14-gm-guidance.adoc
@@ -17,6 +17,16 @@ Before the mechanical tools, three design priorities that should inform every se
 
 . *The artifacts are not neutral.* Every artifact has a trajectory — a direction it pulls the world. Make sure some of that pull lands on the agents. Corruption is not just a penalty; it is the story.
 
+=== Default Protagonist Power Level
+
+Run Neon Relic as a game about *competent but vulnerable specialists*.
+
+* Agents are trained enough to make plans, read a scene, and act decisively.
+* They are *not* safe enough to treat Talents, Division items, or artifact use as guaranteed solutions.
+* When a player ability fires, it should usually create access, buy time, reveal a lead, or reduce fallout -- not erase the need for investigation, containment, or hard choices.
+
+If a scene starts to feel like paranormal special forces effortlessly clearing the problem, add the costs back in: exposure, rival interference, frightened civilians, incomplete information, or Corruption pressure.
+
 ---
 
 == Session Zero
@@ -81,6 +91,8 @@ If your mystery statement doesn't fit in one sentence, you have too much. Cut.
 . *Identify the critical revelations.* What must the players learn to understand the case? Typically 3–5 things: the artifact's true nature, the faction's plan, the event that started everything, and the solution (or route to containment).
 
 . *For each critical revelation, write three paths.* One path should reward Investigate/Lore (physical search, forensic analysis, document study). One path should reward social skills (witness, NPC confession, Manipulate). One path should come through action (confrontation reveals the fact in dialogue, or artifact activation reveals the truth).
+
+. *Let abilities open paths, not replace the web.* If a Talent or Division item applies, use it to reveal a lead, bypass a narrow obstacle, or reduce risk on one path. Avoid letting it collapse the entire mystery into a single button press.
 
 . *Allow forward movement from partial information.* Players who know *something is wrong in the basement* should be able to proceed even if they don't know *exactly what*. Structure facts so that each revelation suggests the next action, even if the players haven't pursued all paths.
 

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -23,7 +23,7 @@ The characters receive the narrative hook. In the 80s setting, this could be:
 Conducted at the player's Headquarters:
 
 . *Research* — Players use base facilities to research the entity or artifact.
-. *Equipping* — Players visit Stack to acquire gear. Roll a pool of dice equal to your *Clearance Level (CL)*. Every *6* allows you to requisition one item equal to or lower than your CL rating. Standard items (CL 1) are given freely within reason.
+. *Equipping* — Players visit Stack to acquire gear. Roll a pool of dice equal to your *Clearance Level (CL)*. Every *6* allows you to requisition one item equal to or lower than your CL rating. Standard items (CL 1) are given freely within reason. Default to containment tools, transport gear, and investigative support before escalation gear.
 . *Supply Acquisition* — All consumable supplies (ammunition, medical kits, batteries, rations) reset to their *starting die size* at no cost during this phase. See xref:chapters/10-equipment.adoc#chapter-equipment[Equipment] for the Resource Die system and per-category die sizes.
 
 == Phase 4: The Journey
@@ -45,8 +45,8 @@ See *Countdown Mechanics* below for the full rules.
 The climax. Players must synthesize gathered clues to:
 
 * Enact a banishment ritual
-* Utilize an opposing artifact to neutralize the threat
-* Engage in desperate, lethal combat with the anomaly or rival cultists
+* Attempt a desperate artifact use or countermeasure, knowing it will leave scars
+* Engage in desperate, lethal combat with the anomaly or rival cultists when containment has already started to fail
 
 == Phase 8: The Aftermath
 
@@ -139,7 +139,7 @@ The agents can still succeed, but the cost has increased permanently. *Clock exp
 | *Multi-session arc* | 5–6 stages | 1 advance per session, plus triggered advances
 |===
 
-Faster clocks create urgency but reduce investigation time. Slower clocks allow thorough exploration but may reduce tension. Adjust based on player style — investigators who want to solve everything cleanly need a slower clock; players who enjoy pressure need it fast.
+Faster clocks create urgency but reduce investigation time. Slower clocks allow thorough exploration but may reduce tension. Adjust based on player style — but keep enough pressure that the cell feels like trained professionals trying to stay ahead of a bad situation, not operators leisurely clearing a map.
 
 === Sample Clock: The Meridian Hotel (One-Shot: 3 Stages)
 


### PR DESCRIPTION
Closes #222

## Summary
Clarifies Neon Relic's default protagonist fantasy as competent but vulnerable containment specialists and aligns the surrounding manuscript language to that stance.

## Changes
- Added an explicit tone/power statement to the introduction
- Reframed character-creation guidance around leverage, cost, and containment
- Tightened Division item and Talent language that implied clean scene resolution
- Added DA guidance for keeping abilities as path-openers instead of mystery-solvers
- Reframed case/confrontation language so artifact use reads as a desperate last resort

## Design Notes
This pass preserves the existing hybrid identity already implied by the Corruption and containment systems: trained Covenant professionals with real tradecraft, but not sanctioned paranormal superheroes.

## References Consulted
- docs/chapters/01-introduction.adoc
- docs/chapters/02-character-creation.adoc
- docs/chapters/09-divisions.adoc
- docs/chapters/11-artifacts.adoc
- docs/chapters/14-gm-guidance.adoc
- docs/chapters/15-case-file.adoc