### PR TITLE
Issue #220: Decide whether Stack is a Keep department or a fourth playable division, then normalize terminology everywhere

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -91,7 +91,7 @@ Within the Covenant there are *three Divisions*, each responsible for a differen
 
 [NOTE]
 ====
-*Note on Stack:* The Keep's Department of Logistics -- informally known as *"Stack"* -- operates with enough autonomy and unique expertise to function as its own playable division for game purposes. See xref:chapters/09-divisions.adoc#division-4-stack[Division 4: Stack] for details.
+*Note on Stack:* The Keep's Department of Logistics -- informally known as *"Stack"* -- has a strong field identity, but it is still part of *The Keep*, not a fourth playable Division. See xref:chapters/09-divisions.adoc#stack-logistics[Stack (Logistics)] for details.
 ====
 
 ---

--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -357,12 +357,14 @@ Working in coordination with the Wayfinder Division's Counterintelligence Wing, 
 | *Debriefing Protocol* _(Healing)_ | — | Once per session, after conducting a successful internal investigation or clearing a suspect, heal 1 Corruption.
 |===
 
-[[division-4-stack]]
-*Stack (Logistics)*
+[[stack-logistics]]
+*Stack (Logistics Department)*
 
 _"Queue up, agents."_
 
 The Department of Logistics — informally known as *"Stack"* — is a department of the Keep composed of technicians, quartermasters, archivists of equipment, engineers, and inventors who maintain the Covenant's stores of specialized gear.
+
+Stack is *not* a separate playable Division. Agents choose *The Keep* at character creation, then select Stack as their department if they want the Covenant's logistics, engineering, and requisition-focused play style.
 
 [NOTE]
 ====

--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -63,6 +63,8 @@ There are no rules for voluntary activation, mandatory exposure, or faction cons
 
 === Stack Dark Secrets (Keep — Logistics Department)
 
+Use this list only if the character belongs to *The Keep* and selected *Stack (Logistics)* as their department during character creation.
+
 [%header,cols="2,5"]
 |===
 | Secret | Details

--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -56,7 +56,7 @@ A specific hidden fact from the character's past — an event, decision, or rela
 A single d6 roll required when a Critical Injury is marked †. On 1–2: the character dies (or is permanently retired for mental death). On 3–6: survival, but the Critical Injury still applies. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 
 *Department*::
-Specialization within a Division (Wayfinder, Keep, Stack). Determines the character's field expertise and Department Skill. Recovery uses Backgrounds instead. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
+Specialization within a Division. Wayfinder agents choose Wings, Keep agents choose Departments, and Recovery agents choose Operational Paradigms instead. Stack is a *Keep department*, not a separate Division. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 
 *Director of Agents (DA)*::
 The table's facilitator role. The DA presents scenes, adjudicates uncertainty, advances clocks, and portrays the world and opposition. See xref:chapters/14-gm-guidance.adoc#chapter-gm-guidance[Director of Agents Guidance].
@@ -65,7 +65,7 @@ The table's facilitator role. The DA presents scenes, adjudicates uncertainty, a
 The number of successes (6s) required to pass a standard skill roll. Default Difficulty is 1 if a rule does not state otherwise. Opposed rolls compare totals instead of using a fixed Difficulty, and a few special rolls such as Fear checks use their own binary rules. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 
 *Division*::
-Character class within the Verdant Covenant. Four playable Divisions: Wayfinder (research/intelligence), Recovery (field retrieval), The Keep (vault security), and Stack (logistics). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
+Character class within the Verdant Covenant. The three playable Divisions are Wayfinder (research/intelligence), Recovery (field retrieval), and The Keep (vault security, custody, and logistics). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 
 *Division Item*::
 A signature supernatural object issued to every member of a Division. Wayfinder: Verdant Codex. Recovery: Verdant Satchel. Keep: Warden's Bracer. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
@@ -152,7 +152,7 @@ Extra successes (6s) beyond the required Difficulty on a roll that allows stunt 
 == T
 
 *The Verdant Covenant*::
-The ancient secret society the player characters serve. Discovers, recovers, and contains supernatural artifacts to protect humanity. Organized into three operational Divisions (Wayfinder, Recovery, The Keep) plus Stack (Logistics). See xref:chapters/01-introduction.adoc#_the_verdant_covenant[The Verdant Covenant].
+The ancient secret society the player characters serve. Discovers, recovers, and contains supernatural artifacts to protect humanity. Organized into three operational Divisions (Wayfinder, Recovery, The Keep). Stack (Logistics) is a department within The Keep. See xref:chapters/01-introduction.adoc#_the_verdant_covenant[The Verdant Covenant].
 
 == V
 


### PR DESCRIPTION
Closes #220

## Summary
Normalizes the manuscript so Stack is consistently treated as a Keep department rather than a fourth playable Division.

## Changes
- Rewrote the introduction note on Stack to align with the three-Division structure
- Retitled the Stack section in Divisions as a Keep department and added explicit selection guidance
- Clarified the Stack dark-secrets entry in Advancement
- Updated glossary definitions for Department, Division, and the Verdant Covenant

## Design Notes
This preserves Stack's distinct logistical and engineering identity without forcing a top-level class rewrite across character creation and advancement.

## References Consulted
- docs/chapters/01-introduction.adoc
- docs/chapters/02-character-creation.adoc
- docs/chapters/09-divisions.adoc
- docs/chapters/13-advancement.adoc
- docs/chapters/20-glossary.adoc