### PR TITLE
Issue #219: Resolve contradictions in the social conflict subsystem and align the worked example to the actual rules

### DIFF
--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -199,12 +199,12 @@ If Petra had rolled 0 successes and the operative also rolled 0, the tail contin
 
 === Opposed Roll with Push: The Interrogation
 
-*Situation:* Wayfinder Agent Reyes is interrogating a frightened historian who knows where the artifact is. The historian desperately doesn't want to cooperate.
+*Situation:* Wayfinder Agent Reyes is trying to lie to a frightened historian who knows where the artifact is. The historian is already Guarded, so the DA sets *Manipulate Difficulty 2* and also calls for an opposed Psychoanalyze roll because the historian is actively trying to spot the lie.
 
 * **Reyes rolls:** Manipulate (EMP 4 + Manipulate 2) = 6 dice. Rolls: 5, 4, 4, 3, 2, 1 → *0 successes*.
 * Reyes decides to *push* (gains +1 Corruption, now at 1). Re-rolls all 5 non-6 dice: 6, 6, 3, 2, 1 → *2 successes*.
 * **Historian rolls:** Psychoanalyze (EMP 3 + Psychoanalyze 1) = 4 dice. Rolls: 6, 4, 3, 2 → *1 success*.
-* **Result:** Reyes wins (2 vs 1). The historian cracks. The extra success can be spent on a stunt — perhaps he volunteers more than just the location.
+* **Result:** Reyes meets the Difficulty and wins the opposed roll (2 vs 1). The lie holds, and the historian cracks. There are no extra successes left for stunts because one success was needed to beat the historian and the other was needed to meet Difficulty 2.
 
 === Helping: Cracking a Locked File Cabinet
 

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -38,9 +38,9 @@ The thirteen core skills are mapped to these four attributes, tailored to suppor
 | Heal | Field medicine, triage, emergency stabilization, and treating physical injuries in the field or at base.
 
 .3+| *Empathy*
-| Manipulate | Bribing informants, deceiving rivals, leveraging secrets.
-| Command | Directing panicked civilians, coordinating team actions under fire.
-| Psychoanalyze | Reading psychological states, detecting deception through behavior, stabilizing traumatized witnesses.
+| Manipulate | Bribing informants, deceiving rivals, leveraging secrets, or extracting sensitive disclosures.
+| Command | Directing panicked civilians, asserting emergency authority, and coordinating team actions under fire.
+| Psychoanalyze | Reading psychological states, detecting deception through behavior, and stabilizing traumatized witnesses so they can talk.
 |===
 
 > *Division Key Skill:* During character creation, each Division designates one Key Skill with a starting cap of *4* instead of the standard maximum of 3. See the Character Creation chapter for details.

--- a/docs/chapters/06-social-conflict.adoc
+++ b/docs/chapters/06-social-conflict.adoc
@@ -61,11 +61,28 @@ Disposition shifts up (toward Open) or down (toward Closed) based on agent actio
 * *Disposition 2:* The NPC requires a successful social roll to answer even basic questions. They will lie by default.
 * *Disposition 1:* The NPC is done with the scene. They must be brought back to 2 before any social rolls are possible. Physical containment is required for continued interrogation.
 
+=== What Counts as a Roll-Free Question?
+
+At *Disposition 3 or higher*, use the following rule of thumb:
+
+* *Direct, low-risk question:* No roll. The NPC answers truthfully, though briefly or with omissions. Example: "Where were you when it happened?"
+* *Sensitive disclosure:* Roll required. The answer would expose fear, shame, a relationship, or knowledge the NPC would rather keep contained. Example: "Who else was there with you?"
+* *Against self-interest:* Roll required. The answer would endanger the NPC, implicate them, expose an ally, or materially help the agents at the NPC's expense. Example: "Give me the supplier's name."
+
+The point of raising Disposition is to move the scene from *access* problems to *leverage* problems. Once an NPC is talking, stop rolling for every ordinary question.
+
 ---
 
 == Social Rolls in Practice
 
 Social rolls use the normal dice pool (Attribute + Skill). When a roll is required to gain cooperation or extract something sensitive, the baseline Difficulty is set by current Disposition unless a skill entry says otherwise. You are always rolling against the NPC's *current state*, not their willpower or an abstract resistance.
+
+Use these defaults when a roll is actually required:
+
+* *Disposition 4 or 5:* Difficulty 1 for sensitive asks.
+* *Disposition 3:* Difficulty 2 for sensitive asks.
+* *Disposition 2:* Difficulty 3 for almost any ask.
+* *Disposition 1:* No social roll possible until the NPC is brought back into the scene.
 
 === Manipulate (Empathy)
 
@@ -79,7 +96,8 @@ Used to deceive, persuade, bribe, leverage, or appeal to self-interest. Manipula
 
 Used to assert authority, direct behavior under pressure, or coordinate. Command does not persuade — it *compels through confidence and force of presence*. It works when the NPC is uncertain what to do, when the agents represent a legitimate authority, or when the situation is dangerous enough that someone taking charge feels like relief.
 
-* *Command does not work at Disposition 2 or lower.* An NPC who is already hostile cannot be commanded — you have no authority in their frame.
+* *Command normally does not create cooperation at Disposition 2.* At *Disposition 2*, it only works for immediate emergency direction when the agents clearly have situational authority: "Get down," "Move away from the door," "Stay behind me." It does not extract information or create trust.
+* *Command does not work at Disposition 1.* An NPC who is fully closed will not accept authority from the agents at all.
 * *On success:* NPC complies fully for the immediate scene. No Disposition shift.
 * *On failure:* NPC fails to comply. No Disposition shift, but the failed authority assertion may have social consequences at the DA's discretion.
 
@@ -103,8 +121,10 @@ Used to read, understand, or heal. In social conflict, Psychoanalyze has two mod
 
 NPCs can also read agents. A canny NPC may actively attempt to read or manipulate the agents in return. The DA may call for:
 
-* *Opposed Psychoanalyze roll:* DA rolls on behalf of the NPC. On NPC success, Disposition shifts are reversed for that action, OR the NPC identifies a specific agent as the social focal point (they will now direct deflection at that agent).
+* *Opposed Psychoanalyze roll:* DA rolls on behalf of the NPC. Use this when the NPC is actively reading the agents rather than merely resisting. On NPC success, Disposition shifts are reversed for that action, OR the NPC identifies a specific agent as the social focal point (they will now direct deflection at that agent).
 * *Lie detection:* The DA may roll NPC Wits (no skill) against an agent's Manipulate roll. On NPC success, the deception is detected and Disposition shifts −1 immediately.
+
+If the DA calls for active social defense during a Manipulate attempt, treat it as a *combined test*: the agent must meet the Disposition-based Difficulty *and* beat the NPC's opposing roll.
 
 These are at DA discretion, not every NPC has this capability. Social defense is for NPCs with relevant training: intelligence operatives, therapists, con artists, experienced detectives.
 
@@ -150,21 +170,21 @@ Petra rolls Empathy 3 + Psychoanalyze 2 = 5 dice. Rolls: 6, 4, 3, 2, 1 — one s
 
 *DA reveals:* Elias genuinely believes the artifact protected his sister during a cancer diagnosis two years ago. He is not performing faith. He is terrified that if it leaves his possession, she will relapse. He is not lying about any of this.
 
-*Round 2:* Using that information, Agent Marcus Osei attempts Manipulate. He doesn't argue about the artifact being dangerous — he asks about the sister. Where is she? Is she still safe? The agents can make sure she stays that way.
+*Round 2:* Using that information, Petra shifts from reading to *Psychoanalyze (Stabilizing)*. She stops pressing Elias about doctrine and instead speaks to the real fear: his sister is sick, he thinks the artifact kept her alive, and now he is trapped in a van with strangers who want to take it away.
 
-Manipulate roll: Empathy 4 + Manipulate 3 = 7 dice. Difficulty 3. Rolls: 6, 6, 6, 6, 2, 1, 1 — four successes (one extra = 1 Stunt Point).
+Petra rolls Empathy 3 + Psychoanalyze 2 = 5 dice. The DA sets Difficulty 2: Elias is distressed and hostile, but Petra is addressing the real wound. Rolls: 6, 6, 4, 2, 1 — two successes.
 
-*Success:* Elias answers the question about the sister (she's in Providence, she's fine). Disposition shifts to 3. 
+*Success:* Elias calms enough to talk. Disposition shifts from 2 to 4. He stops reciting under his breath and finally meets Petra's eyes.
 
-*Stunt Point spent:* Bought Silence — Elias will not tell the Accord that the agents know about his sister.
+*Round 3:* Elias is now at Disposition 4 (Cautious). Marcus asks a *direct, low-risk question*: "Where is your sister right now?" No roll is required. Elias answers truthfully: Providence. She's alive. She's with an aunt.
 
-*Round 3:* Disposition is now 3 (Guarded). Direct questions are possible, but naming a supplier would still put Elias at risk. The DA calls for another Manipulate roll.
+*Round 4:* Marcus now pushes for something *against Elias's interests*: the name of the fence who moved the relic. That would expose Elias to retaliation, so the DA calls for a Manipulate roll.
 
-Another Manipulate roll at Difficulty 2 (Disposition 3, sensitive ask). Marcus rolls: 6, 6, 5, 4, 2, 2, 1 — two successes.
+Manipulate roll: Empathy 4 + Manipulate 3 = 7 dice. Difficulty 1 (Disposition 4, sensitive ask). Rolls: 6, 6, 5, 4, 2, 2, 1 — two successes.
 
-*Elias gives the name*: a fence named Talvez, operating out of a pawn shop on the East Side. He works for several clients. Elias doesn't know who.
+*Success:* Elias gives the name: a fence named Talvez, operating out of a pawn shop on the East Side. He works for several clients. Elias doesn't know who.
 
-*Outcome:* The scene ends having extracted the key information. Disposition is still 3 — Elias is not exactly cooperative, but he's no longer hostile. The agents have a lead and a lever (the sister) if they need him again.
+*Outcome:* The scene demonstrates the full loop. Read first to find the leverage. Stabilize to move the NPC into conversation. Ask direct questions for free once Disposition is high enough. Roll only when the agents want disclosure that still carries risk for the target.
 
 ---
 

--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -58,6 +58,9 @@ A single d6 roll required when a Critical Injury is marked †. On 1–2: the ch
 *Department*::
 Specialization within a Division. Wayfinder agents choose Wings, Keep agents choose Departments, and Recovery agents choose Operational Paradigms instead. Stack is a *Keep department*, not a separate Division. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 
+*Disposition*::
+An NPC's current openness to engagement in Social Conflict, tracked from 1 (Closed) to 5 (Open). At Disposition 3 or higher, direct low-risk questions are answered without a roll; social rolls are reserved for sensitive disclosures or requests against self-interest. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict].
+
 *Director of Agents (DA)*::
 The table's facilitator role. The DA presents scenes, adjudicates uncertainty, advances clocks, and portrays the world and opposition. See xref:chapters/14-gm-guidance.adoc#chapter-gm-guidance[Director of Agents Guidance].
 
@@ -132,7 +135,7 @@ A d6 table rolled on Fear check failure. Determines the character's involuntary 
 Re-roll all non-6 dice after a roll fails to meet its Difficulty, or after a success when you want more successes. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 
 *Psychoanalyze*::
-A skill used to treat mental and emotional Critical Injuries. Recovery difficulty and duration vary by injury severity. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
+A skill used to read psychological states, detect deception, stabilize distressed people during social scenes, and treat mental and emotional Critical Injuries. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict] and xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 
 == R
 


### PR DESCRIPTION
Closes #219

## Summary
Aligns the social conflict subsystem so the Disposition thresholds, skill usage, and worked examples all teach the same play loop.

## Changes
- Clarified when questions are roll-free versus when a social roll is required
- Standardized Difficulty expectations by Disposition only when a roll is actually needed
- Separated Psychoanalyze reading from stabilization
- Adjusted Command so it remains useful in emergencies without replacing persuasion
- Added explicit combined-test guidance for active NPC social defense
- Rewrote the worked example and aligned the core-resolution example and glossary

## Design Notes
This keeps the subsystem investigation-first and conversation-forward: improve Disposition to gain access, then roll only for secrets, leverage, or self-endangering disclosures.

## References Consulted
- docs/chapters/03-core-resolution.adoc
- docs/chapters/04-attributes-skills.adoc
- docs/chapters/06-social-conflict.adoc
- docs/chapters/20-glossary.adoc