### PR TITLE
Issue #221: Reconcile Headquarters upgrade costs, standing gates, and cross-chapter editorial consistency

### DIFF
--- a/docs/chapters/12-headquarters.adoc
+++ b/docs/chapters/12-headquarters.adoc
@@ -32,6 +32,7 @@ DP is spent immediately during downtime (Phase 8) or banked for future Case File
 
 ---
 
+[[hq-upgrade-tree]]
 == HQ Upgrade Tree
 
 Upgrades are organized into three tiers. Higher-tier upgrades require specific lower-tier facilities to be built first.
@@ -323,13 +324,13 @@ Standing threshold is met.
 |===
 | Facility | DP Cost | Min. Standing
 
-| *Microfiche Archive* (Tier 2)          | 3 DP | 5
-| *Occult Laboratory* (Tier 2)           | 4 DP | 5
-| *Faraday Cage* (Tier 2)               | 3 DP | 5
-| *Field Intel Network* (Tier 3)         | 5 DP | 10
+| *Microfiche Archive* (Tier 2)           | 3 DP | 5
+| *Occult Laboratory* (Tier 2)            | 3 DP | 5
+| *Faraday Cage* (Tier 2)                 | 4 DP | 5
+| *Field Intelligence Network* (Tier 3)   | 5 DP | 10
 | *Corruption Dampening Vault* (Tier 3)   | 6 DP | 10
-| *Safe House Network* (Tier 3)          | 4 DP | 15
-| *Covenant Armorer* (Tier 3)            | 5 DP | 10
+| *Safe House Network* (Tier 3)           | 6 DP | 15
+| *Covenant Armorer* (Tier 3)             | 5 DP | 10
 |===
 
 > **Design Note:** Standing gates exist because Tier 2 and 3 facilities represent

--- a/docs/chapters/19-bestiary.adoc
+++ b/docs/chapters/19-bestiary.adoc
@@ -308,8 +308,8 @@ For quick reference when building encounters:
 == Cross-References
 
 * Fear ratings and check triggers: xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing]
-* Faction affiliations and politics: xref:chapters/17-rival-factions.adoc#chapter-rival-factions[Rival Factions] _(Issue #14)_
-* Artifacts and what spawns Constructs: xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts] _(Issue #9 origin)_
+* Faction affiliations and politics: xref:chapters/17-rival-factions.adoc#chapter-rival-factions[Rival Factions]
+* Artifacts and what spawns Constructs: xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts]
 * Corruption gain from supernatural sources: xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing]
 
 ---

--- a/docs/chapters/20-glossary.adoc
+++ b/docs/chapters/20-glossary.adoc
@@ -30,7 +30,7 @@ State when any Attribute reaches 0. The character is incapacitated and rolls on 
 == C
 
 *Case File*::
-A structured mystery/investigation for the team to complete. The standard episodic play format, divided into phases: Briefing, Travel, Investigation, Confrontation, and Resolution. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
+A structured mystery/investigation for the team to complete. The standard episodic play format, divided into eight phases: Prologue, Invitation, Preparation & Equipping, Journey, Arrival, Places, Confrontation, and Aftermath. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 
 *Clearance Level (CL)*::
 Seniority and authorization rank within the Covenant. Equals Division base CL plus Age Group modifier (Young −1, Experienced +0, Senior +1), minimum 1. Determines gear access and organizational authority. See xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
@@ -111,6 +111,9 @@ A talent available to any character regardless of Division, providing a mechanic
 *Headquarters (HQ)*::
 The Covenant facility serving as the team's base of operations between Case Files. Provides medical care, equipment requisition, research facilities, and downtime activities. See xref:chapters/12-headquarters.adoc#chapter-headquarters[Headquarters].
 
+*Development Points (DP)*::
+The shared resource the cell earns during Aftermath and spends on Headquarters facilities, personnel, and infrastructure upgrades. See xref:chapters/12-headquarters.adoc#chapter-headquarters[Headquarters].
+
 == I
 
 *Insight*::
@@ -160,15 +163,15 @@ The ancient secret society the player characters serve. Discovers, recovers, and
 == V
 
 *Verdant Codex*::
-Wayfinder Division Item. An enchanted field journal that secures memory, decodes language, maps artifact locations, and preserves documents. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
+Wayfinder Division Item. An enchanted field journal that secures memory, assists with language and symbol work, highlights likely historical correlations, and preserves documents. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 
 *Verdant Satchel*::
-Recovery Division Item. A specially enchanted field bag that suppresses artifact aura, seals cursed items, warns of instability, and produces basic tools on demand. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
+Recovery Division Item. A specially enchanted field bag that masks minor artifact signatures, stabilizes transport, warns of instability, and keeps basic field tools ready. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 
 == W
 
 *Warden's Bracer*::
-Keep Division Item. Suppresses artifact magic, warns of containment failure, enables safe handling of cursed objects, absorbs 1 Corruption per session, and grants +1 Armor Rating. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
+Keep Division Item. Dampens nearby emissions during handling, warns of containment failure, enables safer handling of cursed objects, absorbs 1 Corruption per session, and grants +1 Armor Rating. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 
 == Z
 


### PR DESCRIPTION
Closes #221

## Summary
Resolves the manuscript's remaining high-visibility editorial consistency issues in HQ tables, release-facing cross-references, and stale glossary entries.

## Changes
- Reconciled HQ standing-gate costs and naming with the authoritative upgrade tree
- Added the missing HQ upgrade-tree anchor used by Standing rewards
- Removed issue-number placeholders from Bestiary cross-references
- Updated glossary entries to match current Case File structure and Division item behavior

## Design Notes
This is a polish pass only; it does not introduce new mechanics, just removes visible assembly drift and stale terminology.

## References Consulted
- docs/chapters/12-headquarters.adoc
- docs/chapters/19-bestiary.adoc
- docs/chapters/20-glossary.adoc