### PR TITLE
Issue #233: Update section 1.4

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -44,23 +44,17 @@ The tactile, error-prone nature of 1980s technology maps flawlessly to the engin
 
 == The Verdant Covenant
 
-For as long as civilizations have risen and fallen, the world has produced objects of unusual power and importance -- relics of faith, symbols of kingdoms, forbidden texts, cursed idols, lost maps, sacred bones, and artifacts whose origins are long forgotten.
-
-Some inspire devotion. +
-Some bring prosperity. +
-Some bring ruin.
-
-Throughout history, wars have been fought over such objects. Empires have risen seeking them, and entire cultures have been erased because of them. To prevent the past from destroying the present, a quiet order was formed centuries ago.
+For as long as civilizations have risen and fallen, the world has produced objects of unusual power and importance -- relics of faith, symbols of kingdoms, forbidden texts, cursed idols, lost maps, sacred bones, and artifacts whose origins are long forgotten. Some inspire devotion. Some bring prosperity. Some bring ruin. Throughout history, wars have been fought over such objects. Empires have risen seeking them, and entire cultures have been erased because of them. To prevent the past from destroying the present, a quiet order was formed centuries ago.
 
 *The Verdant Covenant.*
 
-The Covenant is a secret society devoted to the *discovery, recovery, and protection of artifacts of magical, religious, occult, or cultural significance*. Its members believe that the greatest dangers in history have not been armies or kings -- but *objects that hold power beyond understanding*.
+The Verdant Covenant is a secret society devoted to the discovery, recovery, and protection of artifacts of magical, religious, occult, and cultural significance. Its members hold a singular, unwavering belief: that the greatest dangers in history have never been armies or kings, but the objects left behind in their wake -- relics imbued with power beyond understanding.
 
-The Covenant does not seek to own these relics for wealth or prestige. Its singular purpose is *stewardship*.
+The Covenant does not seek these artifacts for wealth, glory, or dominion. Its purpose is stewardship alone. To study them. To preserve them. And above all, to ensure they are never wielded by those who would bring ruin upon the world.
 
-* To *study* them.
-* To *preserve* them.
-* To *ensure they never fall into the wrong hands*.
+No single account agrees on the true origin of the Verdant Covenant, but most surviving records speak of a time when a catastrophe erased an entire civilization -- its cities silenced and its history fractured. At the center of these accounts is reference to a great green dragon, said to have witnessed the destruction and come to a grim understanding: that certain relics were not treasures, but instruments of ruin. The dragon began gathering such objects, cataloging and hiding them away from those who would misuse them. To some, it was a tyrant hoarding power. To others, a silent guardian preserving what remained of the world.
+
+What followed is told only in fragments. The dragon was slain -- whether by fearful kings, desperate scholars, or its own design is unknown. From its remains came the first tools of the Covenant: codices, satchels, and bracers fashioned from its hide, said to carry a trace of its purpose. Those who inherited its hoard became the first members of the Verdant Covenant, continuing its work of discovery, containment, and protection. And though the truth has long since blurred into legend, some within the order quietly wonder whether the dragon's will was ever truly extinguished -- or merely divided and carried forward in the hands of those who came after.
 
 === The Square of Harmony (The Rule of 441)
 


### PR DESCRIPTION
Closes #233

## Summary
Replaces the opening Verdant Covenant section before the Rule of 441 with the requested expanded stewardship and origin text.

## Changes
- Replaced the introductory Covenant prose in the introduction chapter
- Added the dragon-origin legend and the origin of codices, satchels, and bracers
- Preserved the existing Rule of 441 and organizational structure material below it

## Design Notes
This change deepens the Covenant's mythic foundation without changing downstream mechanics or organization.

## References Consulted
- Issue #233 body