### PR TITLE
Issue #245: Commit main book include for renumbered glossary chapter

### DIFF
--- a/docs/neon-relic.adoc
+++ b/docs/neon-relic.adoc
@@ -181,4 +181,4 @@ _Distribution: All Personnel_
 
 image::svg/placeholder-section.svg[Section image placeholder,align=center,pdfwidth=100%]
 
-include::chapters/20-glossary.adoc[leveloffset=+1]
+include::chapters/21-glossary.adoc[leveloffset=+1]


### PR DESCRIPTION
Closes #245

## Summary
Commits the missing main manuscript include update after the glossary chapter renumber.

## Changes
- Updated docs/neon-relic.adoc to include chapters/21-glossary.adoc
- Verified the file validates cleanly

## Design Notes
This completes the manuscript wiring after the glossary rename in #243.

## References Consulted
- Issue #245 body