### PR TITLE
CH-TERM-06: Rename Front → Organization in 21-glossary.adoc

### DIFF
--- a/docs/chapters/21-glossary.adoc
+++ b/docs/chapters/21-glossary.adoc
@@ -28,7 +28,7 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
-| *Case File* | A structured operation built from shifts, scenes, contacts, fronts, a relic timeline, and Containment Truths. Case Files are playable in flexible order rather than through a fixed phase script. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
+| *Case File* | A structured operation built from shifts, scenes, contacts, organizations, a relic timeline, and Containment Truths. Case Files are playable in flexible order rather than through a fixed phase script. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 | *Clearance Level (CL)* | Seniority and authorization rank within the Covenant. Equals Division base CL plus Age Group modifier (Young −1, Experienced +0, Senior +1), minimum 1. Determines gear access and organizational authority. See xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
 | *Contact* | A person or institution that grants access, information, leverage, cover, or packet routing during a Case File. Contacts often unlock scenes or routes rather than solving the case directly. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 | *Containment Truth* | Information necessary for safe resolution of a case, such as a relic's trigger, appetite, tether, shielding method, quiescence condition, or transfer sequence. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
@@ -47,7 +47,7 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 | *Death Check* | A single d6 roll required when a Critical Injury is marked †. On 1–2: the character dies (or is permanently retired for mental death). On 3–6: survival, but the Critical Injury still applies. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 | *Department* | Specialization within a Division. Wayfinder agents choose Wings, Keep agents choose Departments, and Recovery agents choose Operational Paradigms instead. Stack is a *Keep department*, not a separate Division. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 | *Difficulty* | The number of successes (6s) required to pass a standard skill roll. Default Difficulty is 1 if a rule does not state otherwise. Opposed rolls compare totals instead of using a fixed Difficulty, and a few special rolls such as Fear checks use their own binary rules. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
-| *Director of Agents (DA)* | The table's facilitator role. The DA presents scenes, adjudicates uncertainty, tracks fronts and relic timelines, and portrays the world and opposition. See xref:chapters/14-gm-guidance.adoc#chapter-gm-guidance[Director of Agents Guidance].
+| *Director of Agents (DA)* | The table's facilitator role. The DA presents scenes, adjudicates uncertainty, tracks organizations and relic timelines, and portrays the world and opposition. See xref:chapters/14-gm-guidance.adoc#chapter-gm-guidance[Director of Agents Guidance].
 | *Disposition* | An NPC's current openness to engagement in Social Conflict, tracked from 1 (Closed) to 5 (Open). At Disposition 3 or higher, direct low-risk questions are answered without a roll; social rolls are reserved for sensitive disclosures or requests against self-interest. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict].
 | *Division* | Character class within the Verdant Covenant. The three playable Divisions are Wayfinder (research/intelligence), Recovery (field retrieval), and The Keep (vault security, custody, and logistics). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 | *Division Item* | A signature supernatural object issued to every member of a Division. Wayfinder: Verdant Codex. Recovery: Verdant Satchel. Keep: Warden's Bracer. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
@@ -70,7 +70,7 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 | *Fear Check* | A special binary Wits roll triggered by supernatural horror. One or more 6s = success. Any 1s = +1 Corruption. No 6s = failure (+1 Corruption + Panic Table roll). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
 | *Fear Rating* | Narrative classification (0–5) of how terrifying a creature or event is. Used by the DA to determine when to call for a Fear check. 0 = no check triggered. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
 | *Free Action* | An action in combat that requires negligible effort: speaking a short sentence, dropping an item, or glancing at surroundings. Unlimited per turn. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
-| *Front* | External reactive pressure during a Case File, such as rival recovery operations, police inquiry, media exposure, or Church seizure attempts. A front is not the artifact itself. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
+| *Organization* | External reactive pressure during a Case File, such as rival recovery operations, police inquiry, media exposure, or Church seizure attempts. An organization is not the artifact itself. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 |===
 
 == G
@@ -130,7 +130,7 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
-| *Relic Timeline* | The progression of what an anomaly does if it remains active, mishandled, or unresolved. Distinct from fronts, which represent external reactive pressure. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
+| *Relic Timeline* | The progression of what an anomaly does if it remains active, mishandled, or unresolved. Distinct from organizations, which represent external reactive pressure. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 |===
 
 


### PR DESCRIPTION
Updates glossary entry from Front to Organization. Updates cross-references in Case File, DA, and Relic Timeline entries.

Resolves #288