### PR TITLE
CH-ENT-07: Update NPC motivation section for NPC Card schema

### DIFF
--- a/docs/chapters/14-gm-guidance.adoc
+++ b/docs/chapters/14-gm-guidance.adoc
@@ -292,20 +292,24 @@ The Operations Board is an operational tool, not a scoreboard. Players see the p
 
 == NPC Motivation Design
 
-Every significant NPC needs three things: a *secret*, a *goal*, and a *connection to the artifact*.
+Every significant NPC gets an *NPC Card* with the following fields. The first three define who the NPC is; the rest define how they function in the case.
 
 [%header,cols="1,4"]
 |===
-| Component | Design Note
+| Field | Design Note
 
 | *Secret* | Something the NPC is hiding from the agents. Not necessarily sinister — a witness might be hiding that they trespassed, not that they're a cultist. The secret creates the reason they don't just tell the agents everything at the start.
 | *Goal* | What the NPC is actively trying to accomplish right now. Not a background motivation — a current action. They are doing something during this case.
-| *Artifact connection* | How did this NPC encounter the case's artifact, and what effect has that proximity had on them? Even tangential NPCs should have a small Corruption consequence (nightmares, strange certainty about things they can't know).
+| *Artifact Connection* | How did this NPC encounter the case's artifact, and what effect has that proximity had on them? Even tangential NPCs should have a small Corruption consequence (nightmares, strange certainty about things they can't know).
+| *Starting Knowledge* | Information IDs (I#) the NPC knows at case start. A police detective knows the crime scene details (I1). A museum curator knows the artifact's provenance (I3). Starting knowledge determines what the NPC can share from the first encounter.
+| *Gained Knowledge* | Information the NPC learns at specific organization milestones. Write these as milestone triggers: "At O2M2: knows Compact handler name (I7)." Gained knowledge makes NPCs feel like active participants in a moving case, not static dispensers.
+| *Positive Result* | What happens when the agents engage the NPC successfully — Information IDs shared, introductions made, access granted. Write specific results so the DA reads from the card instead of improvising.
+| *Negative Result* | What happens when the encounter goes badly — organization advance on the Operations Board, tail placed, witness spooked, location access revoked. Negative results create consequences without requiring DA judgment calls.
 |===
 
 === The Motivated NPC Test
 
-Ask: *If the agents were not present, what would this NPC do?* If the answer is nothing — if the NPC only exists as a information dispenser — cut them or give them an active agenda. NPCs with active agendas create situations. Situation creators make sessions run.
+Ask: *If the agents were not present, what would this NPC do?* If the answer is nothing — if the NPC only exists as an information dispenser — cut them or give them an active agenda. NPCs with active agendas create situations. Situation creators make sessions run.
 
 ---
 


### PR DESCRIPTION
Align the NPC Motivation Design section with the NPC Card entity schema. Expand from 3 core fields (Secret, Goal, Artifact Connection) to 7 fields including Starting Knowledge, Gained Knowledge, Positive Result, and Negative Result.

Closes #313