### PR TITLE
CH-FORM-02: Remove scene node sections from case file form

### DIFF
--- a/assets/case-file-form.html
+++ b/assets/case-file-form.html
@@ -397,40 +397,6 @@
     display: inline-block;
   }
 
-  /* ── SCENE NODE BLOCK ── */
-  .scene-block {
-    border: 1.5px solid var(--rule);
-    padding: 5px 7px 6px;
-    background: var(--field-bg);
-    margin-bottom: 7px;
-  }
-  .scene-name-field {
-    border-bottom: 1.5px solid var(--ink);
-    min-height: 16px;
-    font-family: var(--font-fill); font-size: 9pt;
-    font-weight: bold;
-    margin-bottom: 4px;
-  }
-  .scene-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 3px 10px;
-  }
-  .scene-field-label {
-    font-family: var(--font-main);
-    font-size: 5.5pt; text-transform: uppercase; letter-spacing: 1px;
-    color: var(--ink-faded);
-  }
-  .scene-field-value {
-    border-bottom: 1px dotted var(--rule-light);
-    min-height: 14px;
-    font-family: var(--font-fill); font-size: 7.5pt;
-    margin-bottom: 2px;
-  }
-  .scene-field-value.wide {
-    min-height: 28px;
-  }
-
   /* ── NPC BLOCK ── */
   .npc-block {
     border: 1.5px solid var(--rule);
@@ -641,7 +607,7 @@
   <div class="footer">
     <span>VC-12 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
-    <span>Page 1 of 6</span>
+    <span>Page 1 of 5</span>
   </div>
 </div>
 
@@ -750,7 +716,7 @@
   <div class="footer">
     <span>VC-12 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
-    <span>Page 2 of 6</span>
+    <span>Page 2 of 5</span>
   </div>
 </div>
 
@@ -866,12 +832,12 @@
   <div class="footer">
     <span>VC-12 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
-    <span>Page 3 of 6</span>
+    <span>Page 3 of 5</span>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════
-     PAGE 4 — ADDITIONAL ORGANIZATIONS & SCENE NODES
+     PAGE 4 — ADDITIONAL ORGANIZATIONS & NPCs
      ══════════════════════════════════════════════════ -->
 <div class="page page-break">
   <div class="watermark">COVENANT</div>
@@ -982,104 +948,8 @@
     <div style="margin-top:3px;"><span class="field-label">Player-Facing Signs</span><div class="field-value" style="min-height:14px;"></div></div>
   </div>
 
-  <!-- SECTION IX: SCENE NODES -->
-  <div class="section-title green">Section IX &mdash; Scene Nodes</div>
-
-  <!-- Scene 1 -->
-  <div class="scene-block">
-    <div class="field-label">Scene Name</div>
-    <div class="scene-name-field"></div>
-    <div class="scene-grid">
-      <div><span class="scene-field-label">Availability</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Time Cost</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Purpose</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Key Activity</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Risked Organizations</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">May Reveal</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">May Unlock</span><div class="scene-field-value"></div></div>
-    </div>
-  </div>
-
-  <!-- Scene 2 -->
-  <div class="scene-block">
-    <div class="field-label">Scene Name</div>
-    <div class="scene-name-field"></div>
-    <div class="scene-grid">
-      <div><span class="scene-field-label">Availability</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Time Cost</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Purpose</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Key Activity</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Risked Organizations</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">May Reveal</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">May Unlock</span><div class="scene-field-value"></div></div>
-    </div>
-  </div>
-
-  <!-- FOOTER PAGE 4 -->
-  <div class="footer">
-    <span>VC-12 &bull; The Verdant Covenant &bull; DA Use Only</span>
-    <span>Neon Relic &copy; 2025</span>
-    <span>Page 4 of 6</span>
-  </div>
-</div>
-
-<!-- ══════════════════════════════════════════════════
-     PAGE 5 — SCENE NODES (CONT.) & NPCs
-     ══════════════════════════════════════════════════ -->
-<div class="page page-break">
-  <div class="watermark">COVENANT</div>
-  <div class="perf-strip">○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○ ○</div>
-
-  <div class="cont-header">
-    <div>
-      <div class="cont-title">Neon Relic</div>
-      <div class="cont-subtitle">Case File &mdash; The Verdant Covenant</div>
-    </div>
-    <div class="cont-right">
-      <div>Form VC-12 &bull; Rev. 1987 &bull; Continuation Sheet</div>
-      <div style="color:var(--red-stamp); letter-spacing:1px; font-size:5.5pt;">TOP SECRET &mdash; DA EYES ONLY</div>
-      <div class="cont-case-ref">
-        <span>Case ID:</span>
-        <span class="cont-case-line"></span>
-      </div>
-    </div>
-  </div>
-
-  <!-- SCENE NODES CONTINUED -->
-  <div class="section-title green">Section IX (Cont.) &mdash; Scene Nodes</div>
-
-  <!-- Scene 3 -->
-  <div class="scene-block">
-    <div class="field-label">Scene Name</div>
-    <div class="scene-name-field"></div>
-    <div class="scene-grid">
-      <div><span class="scene-field-label">Availability</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Time Cost</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Purpose</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Key Activity</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Risked Organizations</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">May Reveal</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">May Unlock</span><div class="scene-field-value"></div></div>
-    </div>
-  </div>
-
-  <!-- Scene 4 -->
-  <div class="scene-block">
-    <div class="field-label">Scene Name</div>
-    <div class="scene-name-field"></div>
-    <div class="scene-grid">
-      <div><span class="scene-field-label">Availability</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Time Cost</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Purpose</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">Key Activity</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">Risked Organizations</span><div class="scene-field-value"></div></div>
-      <div><span class="scene-field-label">May Reveal</span><div class="scene-field-value"></div></div>
-      <div style="grid-column:1/3;"><span class="scene-field-label">May Unlock</span><div class="scene-field-value"></div></div>
-    </div>
-  </div>
-
-  <!-- SECTION X: KEY NPCs & CONTACTS -->
-  <div class="section-title">Section X &mdash; Key NPCs &amp; Contacts</div>
+  <!-- SECTION IX: KEY NPCs & CONTACTS -->
+  <div class="section-title">Section IX &mdash; Key NPCs &amp; Contacts</div>
 
   <!-- NPC 1 -->
   <div class="npc-block">
@@ -1123,16 +993,16 @@
     </div>
   </div>
 
-  <!-- FOOTER PAGE 5 -->
+  <!-- FOOTER PAGE 4 -->
   <div class="footer">
     <span>VC-12 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
-    <span>Page 5 of 6</span>
+    <span>Page 4 of 5</span>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════
-     PAGE 6 — NPCs (CONT.), SHIFT TIMELINE & PACKETS
+     PAGE 5 — NPCs (CONT.), SHIFT TIMELINE & PACKETS
      ══════════════════════════════════════════════════ -->
 <div class="page">
   <div class="watermark">COVENANT</div>
@@ -1154,7 +1024,7 @@
   </div>
 
   <!-- ADDITIONAL NPCs -->
-  <div class="section-title">Section X (Cont.) &mdash; Additional NPCs</div>
+  <div class="section-title">Section IX (Cont.) &mdash; Additional NPCs</div>
 
   <div style="display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-bottom:4px;">
     <!-- NPC 4 (compact) -->
@@ -1189,8 +1059,8 @@
     </div>
   </div>
 
-  <!-- SECTION XI: SHIFT TIMELINE -->
-  <div class="section-title">Section XI &mdash; Shift Timeline</div>
+  <!-- SECTION X: SHIFT TIMELINE -->
+  <div class="section-title">Section X &mdash; Shift Timeline</div>
 
   <table class="shift-grid">
     <tr>
@@ -1213,8 +1083,8 @@
     <tr><td class="day-label">5</td><td></td><td></td><td></td><td></td><td style="border:none; background:none;"></td><td class="day-label">10</td><td></td><td></td><td></td><td></td></tr>
   </table>
 
-  <!-- SECTION XII: COVENANT REQUEST PACKET LOG -->
-  <div class="section-title green">Section XII &mdash; Covenant Request Packet Log</div>
+  <!-- SECTION XI: COVENANT REQUEST PACKET LOG -->
+  <div class="section-title green">Section XI &mdash; Covenant Request Packet Log</div>
 
   <table class="packet-table">
     <tr>
@@ -1231,8 +1101,8 @@
     <tr><td class="center"></td><td></td><td class="center"></td><td class="center"></td></tr>
   </table>
 
-  <!-- SECTION XIII: DELAYED RESULTS -->
-  <div class="section-title">Section XIII &mdash; Delayed Results &amp; Pending Returns</div>
+  <!-- SECTION XII: DELAYED RESULTS -->
+  <div class="section-title">Section XII &mdash; Delayed Results &amp; Pending Returns</div>
 
   <table class="packet-table">
     <tr>
@@ -1254,11 +1124,11 @@
     <div class="notes-line"></div>
   </div>
 
-  <!-- FOOTER PAGE 6 -->
+  <!-- FOOTER PAGE 5 -->
   <div class="footer">
     <span>VC-12 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
-    <span>Page 6 of 6</span>
+    <span>Page 5 of 5</span>
   </div>
 </div>
 


### PR DESCRIPTION
Remove all scene node sections from the case file form. Scene nodes are replaced by separate Location, NPC Card, and Information Card templates in subsequent issues.

**Changes:**
- Removed scene-block CSS (6 style rules)
- Removed Section IX (Scene Nodes) — 4 scene blocks across old pages 4-5
- Moved NPCs 1-3 to page 4 after organization blocks
- Eliminated old page 5, consolidated into 5-page form
- Renumbered sections IX-XII (was X-XIII)
- Updated all page footers (6→5 pages)

Closes #338