### PR TITLE
CH-FORM-04: Create NPC Card template

### DIFF
--- a/assets/npc-card.html
+++ b/assets/npc-card.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NEON RELIC — NPC Card</title>
+<style>
+  /* ── RESET ── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  /* ── FONTS ── */
+  @font-face {
+    font-family: 'SpecialElite';
+    src: url('../docs/themes/SpecialElite-Regular.ttf') format('truetype'),
+         local('Special Elite');
+    font-weight: normal; font-style: normal;
+  }
+  @font-face {
+    font-family: 'CourierPrime';
+    src: url('../docs/themes/CourierPrime-Regular.ttf') format('truetype'),
+         local('Courier New');
+    font-weight: normal; font-style: normal;
+  }
+
+  /* ── PAGE ── */
+  @page { size: letter portrait; margin: 0; }
+  @media print {
+    body { margin: 0; padding: 0; background: none; }
+    .page { box-shadow: none; margin: 0; }
+  }
+
+  :root {
+    --ink:          #1a1a18;
+    --ink-faded:    #4a4a42;
+    --ink-light:    #8a8a7e;
+    --paper:        #e8e4d8;
+    --green-stamp:  #2d5a27;
+    --red-stamp:    #8b1a1a;
+    --rule:         #999;
+    --rule-light:   #ccc;
+    --field-bg:     rgba(255,255,255,0.3);
+    --font-main:    'SpecialElite', 'Courier New', monospace;
+    --font-fill:    'CourierPrime', 'Courier New', monospace;
+  }
+
+  body {
+    background: #555;
+    font-family: var(--font-main);
+    font-size: 8pt;
+    line-height: 1.25;
+    color: var(--ink);
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .page {
+    width: 8.5in;
+    height: 11in;
+    margin: 0.3in auto;
+    background: var(--paper);
+    position: relative;
+    overflow: hidden;
+    box-shadow: 3px 3px 20px rgba(0,0,0,0.55);
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── PAPER TEXTURE ── */
+  .page::before {
+    content: '';
+    position: absolute; inset: 0;
+    background:
+      repeating-linear-gradient(0deg, transparent, transparent 11px,
+        rgba(0,0,0,0.012) 11px, rgba(0,0,0,0.012) 12px),
+      radial-gradient(ellipse at 15% 78%, rgba(139,119,80,0.07), transparent 55%),
+      radial-gradient(ellipse at 88% 18%, rgba(139,119,80,0.05), transparent 50%);
+    pointer-events: none; z-index: 0;
+  }
+  .page::after {
+    content: '';
+    position: absolute; inset: 0;
+    background-image: radial-gradient(circle, rgba(0,0,0,0.03) 1px, transparent 1px);
+    background-size: 3px 3px;
+    pointer-events: none; z-index: 2;
+  }
+  .page > * { position: relative; z-index: 1; }
+
+  /* ── CUT LINE ── */
+  .cut-line {
+    border-top: 1.5px dashed #aaa;
+    margin: 0;
+    position: relative;
+  }
+  .cut-line::before {
+    content: '✂';
+    position: absolute; left: 8px; top: -7px;
+    font-size: 8pt; color: #aaa;
+  }
+
+  /* ── NPC CARD ── */
+  .npc-card {
+    flex: 1;
+    padding: 0.25in 0.38in 0.2in;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── WATERMARK ── */
+  .watermark {
+    position: absolute; top: 50%; left: 50%;
+    transform: translate(-50%, -50%) rotate(-35deg);
+    font-family: var(--font-main);
+    font-size: 48pt; letter-spacing: 12px;
+    color: rgba(45,90,39,0.033);
+    text-transform: uppercase; white-space: nowrap;
+    pointer-events: none; z-index: 0;
+  }
+
+  /* ── CARD HEADER ── */
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    border-top: 2.5px solid var(--ink);
+    border-bottom: 1.5px solid var(--ink);
+    padding: 4px 0 5px;
+    margin-bottom: 6px;
+  }
+  .card-title {
+    font-family: var(--font-main);
+    font-size: 7pt; letter-spacing: 3px;
+    text-transform: uppercase; color: var(--ink-faded);
+  }
+  .card-stamp {
+    font-family: var(--font-main);
+    font-size: 6pt; letter-spacing: 3px;
+    color: var(--red-stamp);
+  }
+
+  /* ── NAME ROW ── */
+  .name-row {
+    display: flex; align-items: baseline; gap: 10px;
+    margin-bottom: 5px;
+  }
+  .npc-name {
+    flex: 1.5;
+    border-bottom: 2px solid var(--ink);
+    min-height: 18px;
+    font-family: var(--font-fill); font-size: 11pt; font-weight: bold;
+    padding: 1px 3px;
+  }
+  .npc-org {
+    flex: 1;
+    border-bottom: 1.5px solid var(--rule);
+    min-height: 16px;
+    font-family: var(--font-fill); font-size: 8pt;
+    padding: 1px 3px;
+    background: var(--field-bg);
+  }
+
+  /* ── FIELD COMPONENTS ── */
+  .field-label {
+    font-family: var(--font-main);
+    font-size: 5pt; text-transform: uppercase; letter-spacing: 1.5px;
+    color: var(--ink-faded); margin-bottom: 1px;
+  }
+  .field-value {
+    border-bottom: 1px solid var(--rule);
+    min-height: 14px; padding: 1px 3px;
+    background: var(--field-bg);
+    font-family: var(--font-fill); font-size: 7.5pt;
+    margin-bottom: 4px;
+  }
+  .field-value.med {
+    border: 1px solid var(--rule); border-bottom: 1.5px solid var(--rule);
+    min-height: 28px;
+  }
+  .field-value.tall {
+    border: 1px solid var(--rule); border-bottom: 1.5px solid var(--rule);
+    min-height: 38px;
+  }
+
+  .field-row { display: flex; gap: 8px; }
+  .field-col { flex: 1; display: flex; flex-direction: column; }
+
+  /* ── SECTION DIVIDER ── */
+  .section-label {
+    font-family: var(--font-main);
+    font-size: 5.5pt; text-transform: uppercase; letter-spacing: 2px;
+    color: var(--green-stamp);
+    border-bottom: 1px solid var(--green-stamp);
+    padding-bottom: 1px; margin: 4px 0 3px;
+  }
+  .section-label.red {
+    color: var(--red-stamp); border-color: var(--red-stamp);
+  }
+
+  /* ── CARD FOOTER ── */
+  .card-footer {
+    margin-top: auto;
+    font-family: var(--font-main);
+    font-size: 4.5pt; letter-spacing: 1.5px;
+    color: var(--ink-light);
+    border-top: 1px solid var(--rule-light);
+    padding-top: 3px;
+    text-transform: uppercase;
+    display: flex; justify-content: space-between;
+  }
+</style>
+</head>
+<body>
+
+<div class="page">
+
+  <!-- ── NPC CARD 1 ── -->
+  <div class="npc-card">
+    <div class="watermark">COVENANT</div>
+
+    <div class="card-header">
+      <div class="card-title">NPC Reference Card &mdash; Neon Relic</div>
+      <div class="card-stamp">DA Eyes Only</div>
+    </div>
+
+    <!-- Name & Organization -->
+    <div class="name-row">
+      <div style="flex:1.5;"><span class="field-label">Name</span><div class="npc-name"></div></div>
+      <div style="flex:1;"><span class="field-label">Organization (O#)</span><div class="npc-org"></div></div>
+    </div>
+
+    <!-- Secret & Goal -->
+    <div class="field-row">
+      <div class="field-col"><span class="field-label">Secret</span><div class="field-value med"></div></div>
+      <div class="field-col"><span class="field-label">Goal</span><div class="field-value med"></div></div>
+    </div>
+
+    <!-- Artifact Connection -->
+    <div><span class="field-label">Artifact Connection</span><div class="field-value med"></div></div>
+
+    <!-- Knowledge -->
+    <div class="section-label">Knowledge</div>
+    <div class="field-row">
+      <div class="field-col"><span class="field-label">Starting Knowledge (I#)</span><div class="field-value" style="min-height:18px;"></div></div>
+      <div class="field-col"><span class="field-label">Gained Knowledge (milestone-triggered)</span><div class="field-value" style="min-height:18px;"></div></div>
+    </div>
+
+    <!-- Locations -->
+    <div><span class="field-label">Locations (L#)</span><div class="field-value" style="min-height:14px;"></div></div>
+
+    <!-- Results -->
+    <div class="section-label red">Engagement Results</div>
+    <div class="field-row">
+      <div class="field-col"><span class="field-label">Positive Result</span><div class="field-value med"></div></div>
+      <div class="field-col"><span class="field-label">Negative Result</span><div class="field-value med"></div></div>
+    </div>
+
+    <div class="card-footer">
+      <span>VC-15 &bull; NPC Card</span>
+      <span>Neon Relic &copy; 2025</span>
+    </div>
+  </div>
+
+  <!-- ── CUT LINE ── -->
+  <div class="cut-line"></div>
+
+  <!-- ── NPC CARD 2 ── -->
+  <div class="npc-card">
+    <div class="watermark">COVENANT</div>
+
+    <div class="card-header">
+      <div class="card-title">NPC Reference Card &mdash; Neon Relic</div>
+      <div class="card-stamp">DA Eyes Only</div>
+    </div>
+
+    <!-- Name & Organization -->
+    <div class="name-row">
+      <div style="flex:1.5;"><span class="field-label">Name</span><div class="npc-name"></div></div>
+      <div style="flex:1;"><span class="field-label">Organization (O#)</span><div class="npc-org"></div></div>
+    </div>
+
+    <!-- Secret & Goal -->
+    <div class="field-row">
+      <div class="field-col"><span class="field-label">Secret</span><div class="field-value med"></div></div>
+      <div class="field-col"><span class="field-label">Goal</span><div class="field-value med"></div></div>
+    </div>
+
+    <!-- Artifact Connection -->
+    <div><span class="field-label">Artifact Connection</span><div class="field-value med"></div></div>
+
+    <!-- Knowledge -->
+    <div class="section-label">Knowledge</div>
+    <div class="field-row">
+      <div class="field-col"><span class="field-label">Starting Knowledge (I#)</span><div class="field-value" style="min-height:18px;"></div></div>
+      <div class="field-col"><span class="field-label">Gained Knowledge (milestone-triggered)</span><div class="field-value" style="min-height:18px;"></div></div>
+    </div>
+
+    <!-- Locations -->
+    <div><span class="field-label">Locations (L#)</span><div class="field-value" style="min-height:14px;"></div></div>
+
+    <!-- Results -->
+    <div class="section-label red">Engagement Results</div>
+    <div class="field-row">
+      <div class="field-col"><span class="field-label">Positive Result</span><div class="field-value med"></div></div>
+      <div class="field-col"><span class="field-label">Negative Result</span><div class="field-value med"></div></div>
+    </div>
+
+    <div class="card-footer">
+      <span>VC-15 &bull; NPC Card</span>
+      <span>Neon Relic &copy; 2025</span>
+    </div>
+  </div>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
New printable NPC Reference Card (Form VC-15) — two cards per letter page with cut line.

**All 10 NPC Card schema fields:**
- Name and Organization (O#)
- Secret and Goal (side-by-side)
- Artifact Connection
- Starting Knowledge (I#) and Gained Knowledge (milestone-triggered)
- Locations (L#)
- Positive/Negative Results (side-by-side)

Matches existing case file form aesthetic.

Closes #340