### PR TITLE
CH-XREF-06: Final consistency audit

### DIFF
--- a/docs/chapters/12-headquarters.adoc
+++ b/docs/chapters/12-headquarters.adoc
@@ -24,7 +24,7 @@ The team earns DP collectively during *the Aftermath* of each Case File:
 | Case File fully resolved (mystery closed) | 3
 | Artifact securely contained and logged with the Covenant | 1
 | Named Threat neutralized (not just driven off) | 1
-| Primary objective completed under active case pressure (an organization or relic timeline was already in a dangerous state) | 1
+| Primary objective completed under active case pressure (an Organization was escalating or a phases-row milestone was approaching) | 1
 | Agent rescued from rival faction custody | 1
 |===
 

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -7,7 +7,7 @@ A Neon Relic *Case File* is a reactive operations board, not a scripted sequence
 The hidden engine is no longer the older phase-and-countdown model. The engine is:
 
 * an *Operations Board* with a phases row counting down days until catastrophe and organization countdown rows tracking external pressure
-* a set of *scene nodes* that can be approached in flexible order
+* a set of *Locations* that can be approached in flexible order
 * *relic milestones* keyed to the phases row, representing what the anomaly does if left uncontained
 * delayed *Covenant Request Packet* returns that make research and institutional support matter without being instant
 
@@ -507,7 +507,7 @@ A complete case file consists of the following documents:
 | 3
 | *Operations Board*
 | DA
-| Phases row (doubles as relic timeline) plus organization countdown rows. See <<operations-board>>.
+| Phases row (relic escalation track) plus Organization countdown rows. See <<operations-board>>.
 
 | 4
 | *Organization Reference*


### PR DESCRIPTION
Full audit of all chapters referencing the case file system. Fixed 3 remaining obsolete terms:
- 'scene nodes' -> 'Locations' (15-case-file.adoc)
- 'doubles as relic timeline' -> 'relic escalation track' (15-case-file.adoc)
- 'organization or relic timeline' -> 'Organization was escalating or a phases-row milestone' (12-headquarters.adoc)

All other terminology verified current across chapters 11, 12, 14, 15, 16, 17, 20, 21, glossary, and case-file-instructions.

Closes #352