### PR TITLE
fix(#705): unify gear degradation to single Gear Bonus model (Ch 3/7/10)

### DIFF
--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -74,6 +74,18 @@ Whatever form it takes, pushing means your contaminated mind is offering you a s
 
 The analog nature of 1980s technology perfectly complements this mechanical attrition. Pushing a gear-assisted roll might degrade the item — short-circuiting alkaline batteries or jamming mechanisms — effectively reducing its inherent bonus until it can be repaired during downtime.
 
+=== Gear Degradation
+
+When you roll a dice pool that includes *Gear Dice*, you risk damaging the item. If any Gear Die in the *initial roll* shows a *1*, the item's *Gear Bonus is permanently reduced by 1* (until repaired by Stack during downtime).
+
+*Gear Dice are never rerolled when pushing.* When you push, you pick up only your Attribute and Skill Dice — Gear Dice keep their initial values. If a Gear Die already showed a 1 on the initial roll, that degradation has already occurred before the push.
+
+An item whose Gear Bonus has been reduced to *0* is *Broken* — it provides no dice to rolls and cannot be used until repaired.
+
+> This rule applies identically to all gear: weapons (Gear Bonus reduced by 1), armor (Armor Rating reduced by 1), and tools. Improvised items break outright when their sole Gear Die shows a 1 — see xref:chapters/10-equipment.adoc#_improvised_item_failure[Improvised Item Failure].
+
+> For full repair rules, see xref:chapters/10-equipment.adoc#crafting-and-repair[Crafting and Repair].
+
 ---
 
 == Opposed Rolls

--- a/docs/chapters/07-health-damage-armor.adoc
+++ b/docs/chapters/07-health-damage-armor.adoc
@@ -263,4 +263,6 @@ Armor protects against *physical damage only*. When an agent suffers physical da
 . Every *6* rolled absorbs *1 point* of incoming damage before it reduces your Strength.
 . *Degradation:* If you roll any *1s* on an armor save, the Armor Rating is permanently reduced by 1 until repaired by Stack during downtime.
 
-*Gear Dice cannot be pushed.* When you push a roll, you reroll all non-6 dice from your Attribute and Skill pools. Gear Dice are never rerolled — they represent equipment performance, not personal effort. However, any 1s rolled on Gear Dice still cause degradation (reduce the item's Gear Bonus or Armor Rating by 1) whether the roll is pushed or not.
+*Gear Dice cannot be pushed.* When you push a roll, you reroll all non-6 dice from your Attribute and Skill pools. Gear Dice are never rerolled — they represent equipment performance, not personal effort. Any 1s rolled on Gear Dice cause degradation (reduce the item's Armor Rating by 1) on the initial roll.
+
+> *Unified degradation rule:* Armor Rating is an item's Gear Bonus for defensive rolls. The same degradation rule applies to all gear — weapons, armor, and tools alike. See xref:chapters/03-core-resolution.adoc#_gear_degradation[Core Resolution → Gear Degradation] for the authoritative rule.

--- a/docs/chapters/10-equipment.adoc
+++ b/docs/chapters/10-equipment.adoc
@@ -343,13 +343,21 @@ agent can manage a field fix if the situation demands it.
 
 ---
 
-=== Gear Degradation Recap
+=== Gear Degradation
 
-Every piece of equipment with a **Gear Die** risks degradation when that die rolls
-a **1**. Gear degrades one step down the die chain (d12 → d10 → d8 → d6 → d4 →
-Broken). A **Broken** item cannot be used until repaired.
+Every item with a *Gear Bonus* risks degradation when any Gear Die in the pool
+rolls a *1* on the initial roll. The item's Gear Bonus is permanently reduced by 1
+until repaired. An item reduced to Gear Bonus 0 is *Broken* and cannot be used.
 
-> Stack Division Talent *Jury-Rig* can restore a broken item mid-scene at the cost
+This works consistently across all item types:
+
+* *Weapons and tools:* A 1 on any Gear Die reduces the Gear Bonus by 1 (fewer dice on the next roll).
+* *Armor:* A 1 on any armor-save Gear Die reduces the Armor Rating by 1.
+* *Improvised items:* Begin with Gear Bonus 1 (one black d6). A 1 breaks them immediately — roll on the Improvised Item Failure table below instead of reducing Gear Bonus.
+
+Gear Dice are never rerolled on a push. See xref:chapters/03-core-resolution.adoc#_gear_degradation[Core Resolution → Gear Degradation] for the full rule.
+
+> Stack Division Talent *Jury-Rig* can restore a Broken item mid-scene at the cost
 > of +1 Corruption. Formal repair rules below handle everything else.
 
 ---
@@ -372,18 +380,18 @@ Repairing gear requires **time**, **parts**, and a **Tech** roll.
 
 [%header,cols="2,1,2,3"]
 |===
-| Condition | Gear Die | Repair Diff | Time Required
+| Condition | Gear Bonus | Repair Diff | Time Required
 
-| *Degraded* (d10–d4)        | Any step below max | 1 | Quick Repair: 15 minutes (1 scene)
-| *Broken* (non-electronic)  | —                  | 2 | Full Repair: 1 Shift (~4 hours)
-| *Broken* (electronic/mechanical) | —            | 3 | Full Repair: 1 Shift; requires Power Tools
-| *Combat-Damaged Vehicle*   | Reliability die    | 3 | Full Day; requires Auto Repair kit
-| *Artifact-Adjacent Damage* | —                  | 4 | Requires Occult Lab or Wayfinder consult
+| *Degraded* (Gear Bonus below max) | Below max (≥1) | 1 | Quick Repair: 15 minutes (1 scene)
+| *Broken* (Gear Bonus 0, non-electronic) | 0 | 2 | Full Repair: 1 Shift (~4 hours)
+| *Broken* (Gear Bonus 0, electronic/mechanical) | 0 | 3 | Full Repair: 1 Shift; requires Power Tools
+| *Combat-Damaged Vehicle* | See Reliability | 3 | Full Day; requires Auto Repair kit
+| *Artifact-Adjacent Damage* | — | 4 | Requires Occult Lab or Wayfinder consult
 |===
 
-**Success:** Each success restores the Gear Die one step (up to its maximum).
-A single Quick Repair roll can only ever restore to the step *above* Broken — a
-Broken item must be fully repaired before it can be used again.
+**Success:** Each success restores Gear Bonus by 1 (up to the item's maximum).
+A single Quick Repair roll can restore a Degraded item but not a Broken one —
+a Broken item requires a Full Repair before it can be used again.
 
 **Failure:** The repair attempt fails but does not make things worse.
 **Complication (Pushed roll only):** A pushed Repair roll that fails delivers a
@@ -464,23 +472,23 @@ at reduced effectiveness and carry a higher risk of failure.
 Roll **Tech** (WIT), using the difficulty from the table below. Requires at
 minimum a **Junk Die (d6)** as parts; step it down after crafting.
 
-Improvised items begin with a **d8 Gear Die** (never start at d10 or d12 —
-they're held together with duct tape and prayer).
+Improvised items begin with *Gear Bonus 1* (one black d6 in the pool — never
+more, they're held together with duct tape and prayer).
 
 [%header,cols="2,1,1,4"]
 |===
 | Improvised Item     | Tech Diff | Time | Notes
 
 | *Club / Makeshift Bludgeon* | 1 | 1 minute | Damage 1, Slow. No Gear Die — it's a pipe.
-| *Shiv / Field Knife*        | 1 | 5 minutes | Damage 1, Fast. Gear d8. Breaks on 1–2.
-| *Molotov Cocktail*          | 1 | 10 minutes | Blast 1, Fire. No Gear Die — single use.
-| *Improvised First Aid Kit*  | 2 | 20 minutes | Functions as Basic First Aid (d8). Gear d8.
-| *Signal Jammer*             | 2 | 1 hour | Blocks comms in zone. Gear d8. Electronics.
+| *Shiv / Field Knife*        | 1 | 5 minutes | Damage 1, Fast. Gear Bonus 1. Breaks on 1 (failure table).
+| *Molotov Cocktail*          | 1 | 10 minutes | Blast 1, Fire. No Gear Bonus — single use.
+| *Improvised First Aid Kit*  | 2 | 20 minutes | Functions as Basic First Aid. Gear Bonus 1.
+| *Signal Jammer*             | 2 | 1 hour | Blocks comms in zone. Gear Bonus 1. Electronics.
 | *Tripwire / Alarm Trap*     | 2 | 30 minutes | Spend; triggers on intruder entry. Single use.
-| *Garrote Wire*              | 1 | 5 minutes | Grapple-linked attack. No Gear Die — simple tool.
-| *Lockpick Set (crude)*      | 3 | 1 hour | Sleight of Hand −1 die compared to proper picks.
-| *Improvised Bug Detector*   | 3 | 2 hours | Detect surveillance; −1 die vs. professional gear.
-| *Field Radio Booster*       | 3 | 2 hours | Extend comms range by 1 zone. Gear d8. Electronics.
+| *Garrote Wire*              | 1 | 5 minutes | Grapple-linked attack. No Gear Bonus — simple tool.
+| *Lockpick Set (crude)*      | 3 | 1 hour | Sleight of Hand −1 die compared to proper picks. Gear Bonus 1.
+| *Improvised Bug Detector*   | 3 | 2 hours | Detect surveillance; −1 die vs. professional gear. Gear Bonus 1.
+| *Field Radio Booster*       | 3 | 2 hours | Extend comms range by 1 zone. Gear Bonus 1. Electronics.
 |===
 
 > Improvised items **cannot** be upgraded with proper parts after the fact —
@@ -490,8 +498,8 @@ they're held together with duct tape and prayer).
 
 ==== Improvised Item Failure
 
-When a Gear Die on an improvised item comes up **1**, it does not simply degrade —
-roll on the following table:
+When a Gear Die on an improvised item comes up **1**, it does not simply reduce Gear Bonus —
+the item fails outright. Roll on the following table:
 
 [%header,cols="1,3"]
 |===


### PR DESCRIPTION
## Summary

Resolves the three incompatible gear degradation systems identified in #705.

## Changes

### Ch 3: Added formal Gear Degradation rule section (was flavor text only)
### Ch 7: Clarified armor degradation; cross-ref to Ch 3
### Ch 10: Replaced step-die chain with Gear Bonus model; fixed improvised items; updated repair table

## Design Decision
Option A (Ch 3/7 black d6 model). Consistent with YZE precedent.

Closes #705