### PR TITLE
fix(#706): unify vehicle chase rules across Ch 5/10/16

### DIFF
--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -304,12 +304,12 @@ When one side is fleeing and the other is pursuing, use the following chase rule
 A chase is divided into *chase rounds*. Each round, both the fleeing and pursuing party roll their relevant attribute + skill:
 
 * *On foot:* Agility + Sneak (for stealth flight) or Agility + Endure (for pure sprint)
-* *By vehicle:* Agility + Tech (operating the vehicle) — full vehicle rules are forthcoming (#21)
+* *By vehicle:* Wits + Tech (see xref:chapters/10-equipment.adoc#_vehicle_conflict_actions_and_chase_rules[Vehicle Chase Rules] for full vehicle chase procedure, speed modifiers, and maneuvers)
 
 === Chase Outcome Per Round
 
 * Compare successes. The side with more successes *gains distance* (fleeing) or *closes distance* (pursuing).
-* Track relative distance on a simple 5-step track: *Contact → Near → Far → Very Far → Escaped*.
+* Track relative distance on a 5-step track: *Contact → Following → Closing → Widening → Escaped*.
 * Start at Contact. Fleeing party wins a round → move one step toward Escaped. Pursuing party wins → move one step toward Contact.
 
 === Escape and Recapture
@@ -317,7 +317,7 @@ A chase is divided into *chase rounds*. Each round, both the fleeing and pursuin
 * The fleeing party *escapes* when they reach the Escaped position.
 * During a chase, characters may still attack (at whatever range the current position represents) but do so at *−1 die* (distraction of movement).
 * If the pursuing party reaches Contact: normal combat resumes.
-* *Hiding:* If the fleeing party is at Far or Very Far and succeeds on a Sneak roll (Difficulty 2), they may break the chase entirely without reaching Escaped — they simply vanish into the environment.
+* *Hiding:* If the fleeing party is at Widening and succeeds on a Sneak roll (Difficulty 2), they may break the chase entirely without reaching Escaped — they simply vanish into the environment.
 
 ---
 

--- a/docs/chapters/10-equipment.adoc
+++ b/docs/chapters/10-equipment.adoc
@@ -273,8 +273,8 @@ The *pursuing vehicle* wins by moving to or holding position 1–2.
 
 Each round of a chase, both drivers make a roll:
 
-* *Tech (WIT):* The primary chase skill. Represents reading traffic, anticipating routes, and making calculated maneuvers with vehicles under pressure.
-* *Evasion (AGI):* Used when attempting sudden unpredictable movement — cutting through a building site, reversing against traffic, going off-road. Higher risk, higher reward.
+* *Tech (WIT):* The primary chase skill. Represents reading traffic, anticipating routes, and making calculated maneuvers with vehicles under pressure. Use this for all standard chase rolls.
+* *Tech (AGI):* Used when attempting sudden unpredictable movement — cutting through a building site, reversing against traffic, going off-road. Higher risk, higher reward. The DA may call for AGI + Tech instead of WIT + Tech when a maneuver is more reflexive than tactical.
 
 Both sides roll simultaneously. The side with more successes moves the Contact Track one position in their favor. Ties: no position change.
 

--- a/docs/chapters/16-travel.adoc
+++ b/docs/chapters/16-travel.adoc
@@ -157,9 +157,11 @@ Once a tail is confirmed, the driver can attempt to lose it. This is a *Chase se
 
 Three options, each requiring one skill roll:
 
-. *Outrun:* AGI (on foot) or WIT (driving). Difficulty 2. Success = tail loses visual. Failure = they stay on you, and the leg's Road Event is escalated by one (worsening conditions, additional exposure).
+. *Outrun:* WIT + Tech (driving away) or AGI + Endure (on foot). Difficulty 2. Success = tail loses visual. Failure = they stay on you, and the leg's Road Event is escalated by one (worsening conditions, additional exposure).
 . *Blend In:* AGI (Sneak) or WIT (Investigate, to find a crowd). Difficulty 2. Success = tail loses the vehicle or person in ambient traffic. Requires stopping or drastically altering route.
 . *Double Back / Trap:* WIT (Investigate). Difficulty 3. Success = not only is the tail lost, but the team may identify *who* is following them (a glimpse, a plate, a voice on a radio). This is valuable intelligence.
+
+> *Abbreviated vs. full chase:* The three options above are a streamlined resolution for travel-context tails. For a tactical vehicle chase during a Case File scene or combat, use the full Vehicle Chase Rules (xref:chapters/10-equipment.adoc#_vehicle_conflict_actions_and_chase_rules[Equipment → Vehicle Chase Rules]). The primary skill for vehicle chases is always *WIT + Tech*.
 
 *On failure:* The tail remains. The team may try again next shift if the route continues. If the tail stays through arrival, the followers learn where the team is going.
 


### PR DESCRIPTION
## Summary

Resolves inconsistencies in vehicle chase rules across three chapters.

## Changes

- **Ch 5:** Changed vehicle chase roll from AGI+Tech to **WIT+Tech**; updated track names to Contact/Following/Closing/Widening/Escaped; removed '(#21 forthcoming)' placeholder note; fixed Hiding rule to use new track name (Widening, not Far/Very Far); added cross-ref to Ch 10 for full vehicle chase procedure.
- **Ch 10:** Replaced invented 'Evasion (AGI)' skill with **Tech (AGI)** for reflexive maneuvers — consistent with the Tech skill that already covers vehicles.
- **Ch 16:** Changed 'WIT (driving)' to **WIT + Tech**; added note clarifying this is abbreviated travel resolution; cross-ref to Ch 10 for full tactical chase.

## Design Decision

Ch 10 (Equipment) is the authoritative vehicle chase system. Ch 5 and Ch 16 defer to it. Single skill: **Tech**. Primary attribute: WIT (tactical). AGI + Tech permitted when DA calls for reflexive maneuver.

Closes #706