### PR TITLE
fix(#709): reconcile ammo Resource Dice across Ch 5/10

### DIFF
--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -229,17 +229,21 @@ A character *in cover* benefits from partial physical shielding.
 
 === Ammunition
 
-Ammunition is tracked using a *Resource Die*. When you acquire a weapon or reload, set its ammo die:
+Ammunition is tracked using a *Resource Die*. When you acquire a weapon or reload, set its ammo die based on the weapon type and current magazine state:
 
 [%header,cols="2,1,2"]
 |===
 | Ammo State | Die | Notes
 
-| *Full magazine* | d8 | Fresh load; most pistols and rifles
-| *Half loaded* | d6 | Partially used
-| *Low / scrounged* | d4 | Found ammo, emergency reload
-| *Drum / extended mag* | d10 | Special acquisition (CL 4)
+| *Pistol — full magazine* | d10 | 9mm, .38, .45; standard load
+| *Shotgun — full load* | d8 | Pump or semi-auto shotgun
+| *Rifle — full magazine* | d8 | Assault rifle, battle rifle, .308
+| *Half loaded (any)* | d6 | Partially used magazine
+| *Low / scrounged (any)* | d4 | Found ammo, emergency reload
+| *Drum / extended mag* | d12 | Special acquisition (CL 4)
 |===
+
+> *Two-track ammo system:* This table governs *in-combat per-shot tracking* — roll when you push a Firearms roll, fire full auto, or the DA calls for it. Between scenes, use the *Supply-level Resource Dice* in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment] to track how much ammo the team has on hand. When you reload in the field, roll the supply die; then reset the weapon's combat ammo die to its 'full' value from this table.
 
 *When do you roll the ammo die?*
 


### PR DESCRIPTION
## Summary

Resolves pistol d8/d10 and rifle d10/d8 mismatches between Ch 5 and Ch 10.

## Decision

Option 3 (explicit two-track system): Ch 10 is authoritative for starting die sizes. Ch 5 updated to match.

## Changes

- **Ch 5:** Updated ammo die table — pistol full mag = d10, shotgun = d8, rifle = d8, drum/extended = d12. Split 'full magazine' into weapon-type rows for clarity. Added callout box explaining the two-track ammo system (in-combat per-shot vs. scene-level supply).
- **Ch 10:** No changes needed — already has a note that Ch 5 overrides for in-combat rolls.

## Design Decision

The two systems track different things: Ch 5 = current loaded magazine during a fight; Ch 10 = total ammo supply between scenes. Both are intentional. Making the 'full magazine' die equal to the Ch 10 starting die ensures reloading from supply sets the combat die consistently.

Closes #709