### PR TITLE
fix(#711): Death Check +2 → +1 (d6+2 min=3 made death impossible)

### DIFF
--- a/docs/chapters/07-health-damage-armor.adoc
+++ b/docs/chapters/07-health-damage-armor.adoc
@@ -74,7 +74,7 @@ A *Death Check* is a single d6 roll. It is required whenever a Critical Injury i
 * *1–2:* The character dies.
 * *3–6:* The character survives — the Critical Injury still applies and must be treated, but they cling to life.
 
-*Medical Training Talent (Keep):* An ally with Medical Training may spend a Slow Action to make a *Heal (WIT) roll (Difficulty 2)* before the Death Check is rolled. On success: the dying character rolls d6+2 instead of d6 (death only on 1, and only if the Heal roll succeeded). On failure: no change; Death Check proceeds normally.
+*Medical Training Talent (Keep):* An ally with Medical Training may spend a Slow Action to make a *Heal (WIT) roll (Difficulty 2)* before the Death Check is rolled. On success: the dying character rolls d6+1 instead of d6 (death only on a natural 1 — result 2 on the table). On failure: no change; Death Check proceeds normally.
 
 === The Stabilization Window
 


### PR DESCRIPTION
## Summary

The Death Check modifier for successful Medical Training stabilization was +2, making death mathematically impossible: d6+2 minimum result is 3, which is a survival result. The text claimed 'death only on 1' but that could never occur.

## Fix

Changed modifier from +2 to +1.

**With d6+1:** minimum result = 2. Death range is 1–2 per the Death Check table, so a natural 1 (result = 2) remains in the death range. Death probability with Medical Training: 1/6 = 16.7% (vs. 33% without).

This preserves the intent: stabilization meaningfully reduces death risk but does not eliminate it.

Closes #711