### PR TITLE
fix(#715): differentiate CL Standing rewards from Requisition Authority talent

### DIFF
--- a/docs/chapters/12-headquarters.adoc
+++ b/docs/chapters/12-headquarters.adoc
@@ -301,10 +301,10 @@ cannot be purchased with Development Points alone.
 | Reward | Min. Standing | Effect
 
 | *Tier 2 HQ Upgrades Unlocked*       | 5  | Cell may begin purchasing Tier 2 facilities (see <<hq-upgrade-tree>>). DP cost unchanged.
-| *CL 3 Requisition Access*           | 5  | Standard CL 3 gear is available without special authorization.
+| *CL 3 Requisition Access*           | 5  | During Equipping Phase, the *entire cell* may requisition items up to CL 3 — even agents whose personal CL is still 2. This does not change individual agents' personal CL score.
 | *Keep Reinforcements*               | 10 | Once per arc, request a second Covenant cell for 1 session of operational support. They arrive equipped; they do not share Standing.
 | *Tier 3 HQ Upgrades Unlocked*       | 10 | Cell may begin purchasing Tier 3 facilities. DP cost unchanged.
-| *CL 4 Requisition Access*           | 10 | High-tier equipment (specialized surveillance, artifact containment casings, prototype weapons) available via formal request.
+| *CL 4 Requisition Access*           | 10 | During Equipping Phase, the entire cell may requisition items up to CL 4 regardless of personal CL. High-tier equipment available via formal request. Does not change individual agents' personal CL scores.
 | *Classified Archive Access*         | 15 | Wayfinder Division shares files on cold cases and artifact history normally restricted to senior analysts. +2 dice on Lore and Investigate rolls during pre-departure research.
 | *Covenant Asset Call-In*            | 15 | Once per campaign arc, the Covenant deploys a named asset — insider at a government agency, black-market arms contact, demolitions specialist — to assist directly.
 | *Legacy Standing Bonus*             | 20 | When a cell member retires or dies, their Keeper (xp replacement PC) begins play with 3 Standing already gained toward the cell total.

--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -167,7 +167,7 @@ This is the *canonical General Talents list* used at character creation and duri
 | *Iron Will* _(Healing)_ | Land the killing blow or banish a supernatural threat? The rush of victory heals 1 Corruption.
 | *Brawler* | Unarmed strikes inflict base damage of 2 instead of 1.
 | *Flee the Scene* | Gain +2 bonus dice to Agility when rolling explicitly to escape a conflict.
-| *Requisition Authority* _(Repeatable)_ | Increase your Clearance Level by 1 (maximum CL 5). May be purchased multiple times. _Prerequisite:_ Covenant Standing must equal or exceed the target CL × 3 (CL 3 requires Standing 9+, CL 4 requires Standing 12+, CL 5 requires Standing 15+).
+| *Requisition Authority* _(Repeatable)_ | Increase your *personal* Clearance Level by 1 (maximum CL 5). May be purchased multiple times. No Standing prerequisite — this talent represents individual institutional recognition, useful for agents who want personal CL access before the team's Standing catches up to that tier. Purchasing this talent does not count toward or substitute the team's Standing-based access rewards.
 |===
 
 ---


### PR DESCRIPTION
## Summary

Ch 12 Standing Rewards and Ch 13 Requisition Authority talent were redundant — both granted CL increases, making the 6 XP talent worthless.

## Decision

Option 3 (differentiate): Standing grants team-wide requisition access; Requisition Authority grants individual personal CL with no Standing prerequisite.

## Changes

**Ch 12 Standing Rewards:**
- CL 3 at Standing 5: Now explicitly 'entire cell may requisition CL 3 items — does not change individual personal CL'
- CL 4 at Standing 10: Same clarification

**Ch 13 Requisition Authority:**
- Removed Standing prerequisite (no longer required)
- Now says 'personal CL' to distinguish from team-wide Standing access
- Noted as useful for individual agents who want personal CL ahead of the team's Standing reaching that tier

## Result

Standing = team gear pool access. Requisition Authority = early/individual personal CL authority. Both systems remain valuable and non-redundant.

Closes #715