### PR TITLE
fix(#716): standardize XP award timing (per session)

### DIFF
--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -79,7 +79,7 @@ Use this list only if the character belongs to *The Keep* and selected *Stack (L
 ---
 == Advancement
 
-Experience Points (XP) are the game's *only* advancement currency. They are awarded at the end of each Case File through a structured debriefing. The DA asks the group a series of questions — for every "yes," each player receives *1 XP* (maximum *5 XP per session*):
+Experience Points (XP) are the game's *only* advancement currency. They are awarded at the end of each *session* through a structured debriefing. The DA asks the group a series of questions — for every "yes," each player receives *1 XP* (maximum *5 XP per session*):
 
 [%header,cols="^1,5"]
 |===
@@ -139,7 +139,7 @@ The following shows a typical post-session debrief for *Agent Yusuf Demi*, a Kee
 
 *Yusuf's player spends XP:*
 
-* *6 XP → Requisition Authority talent (CL 2 → CL 3).* The Watch Commander issued a formal written commendation during the case closure review, explicitly noting the intact transport as mission-critical. Yusuf's Covenant Standing is 10, which meets the CL 3 prerequisite (Standing 9+). The DA agrees this is a valid fiction trigger and approves the purchase.
+* *6 XP → Requisition Authority talent (CL 2 → CL 3).* The Watch Commander issued a formal written commendation during the case closure review, explicitly noting the intact transport as mission-critical. The DA agrees this is a valid fiction trigger and approves the purchase.
 * *6 XP remain* for future sessions.
 
 > *DA note:* Requisition Authority purchases should be supported by a fiction trigger — a commendation, a formal reassignment, or a documented mission assessment that the Covenant acknowledges. If the trigger hasn't been established in play, ask the player to name one before approving. The increase marks institutional recognition, not just personal growth.

--- a/docs/chapters/19-bestiary.adoc
+++ b/docs/chapters/19-bestiary.adoc
@@ -498,7 +498,7 @@ at their final level. The DA chooses which skill based on the dead agent's
 profile (e.g., a dead Firearms 3 agent becomes a Wraith with Firearms 3).
 ----
 
-*Broken State:* Release. The Wraith dissolves in a cascade of static images — faces, file documents, artifact photographs — before going silent. Characters who witness the dissolution gain +1 XP (the vision is painful but clarifying). The corruption spike that created the Wraith is fully discharged; the location is safe from this specific entity.
+*Broken State:* Release. The Wraith dissolves in a cascade of static images — faces, file documents, artifact photographs — before going silent. Characters who witness the dissolution gain +1 XP at the end of the session (the vision is painful but clarifying; this XP is not awarded immediately and cannot be spent mid-scene). The corruption spike that created the Wraith is fully discharged; the location is safe from this specific entity.
 
 *Motivation:* The Fracture Wraith is not the dead agent. It is the *moment of death* given form. It seeks to replicate the conditions of its creation — drawing living agents toward high-corruption situations, artifact activation, and the threshold of corruption. It doesn't know it's doing this. It believes it's trying to warn them.
 


### PR DESCRIPTION
Standardize all XP award language to 'per session' (YZE convention). Remove 'per Case File' from Ch 13 intro. Fracture Wraith +1 XP in Ch 19 clarified as end-of-session, cannot be spent mid-scene. Also removed obsolete Standing prerequisite reference from Ch 13 Yusuf example (prerequisite was removed by #715).

Closes #716