### PR TITLE
fix(#738): assign unique form number VC-20 to Organization Reference

### DIFF
--- a/assets/organization-reference.html
+++ b/assets/organization-reference.html
@@ -251,7 +251,7 @@
     </div>
     <div class="header-right">
       <div class="classification">DA EYES ONLY</div>
-      <div>Form VC-18 &bull; Rev. 1987</div>
+      <div>Form VC-20 &bull; Rev. 1987</div>
       <div style="margin-top:3px; display:flex; align-items:baseline; gap:5px; justify-content:flex-end;">
         <span>Case ID:</span>
         <span style="border-bottom:1px solid var(--rule); display:inline-block; min-width:130px; height:14px;"></span>
@@ -393,7 +393,7 @@
 
   <!-- FOOTER -->
   <div class="footer">
-    <span>VC-18 &bull; The Verdant Covenant &bull; DA Use Only</span>
+    <span>VC-20 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
     <span>Organization Reference</span>
   </div>

--- a/docs/case-files/spear-that-went-dark/organization-reference.html
+++ b/docs/case-files/spear-that-went-dark/organization-reference.html
@@ -57,7 +57,7 @@
     </div>
     <div class="header-right">
       <div class="classification">DA EYES ONLY</div>
-      <div>Form VC-18 &bull; Rev. 1987</div>
+      <div>Form VC-20 &bull; Rev. 1987</div>
       <div style="margin-top:3px; display:flex; align-items:baseline; gap:5px; justify-content:flex-end;">
         <span>Case ID:</span>
         <span style="border-bottom:1px solid var(--rule); display:inline-block; min-width:130px; height:14px;">VC-AR-87-041</span>
@@ -198,7 +198,7 @@
   </div>
 
   <div class="footer">
-    <span>VC-18 &bull; The Verdant Covenant &bull; DA Use Only</span>
+    <span>VC-20 &bull; The Verdant Covenant &bull; DA Use Only</span>
     <span>Neon Relic &copy; 2025</span>
     <span>Organization Reference &mdash; The Spear That Went Dark</span>
   </div>


### PR DESCRIPTION
Closes #738

Organization Reference was using form number VC-18, duplicating the Player Case Brief. Changed to VC-20 in both:
- `assets/organization-reference.html` (blank template)
- `docs/case-files/spear-that-went-dark/organization-reference.html` (filled-in sample)

Updated Form Number Registry:
| Form | Number |
|---|---|
| Character Sheet | VC-7 |
| Location Page | VC-14 |
| NPC Card | VC-15 |
| Relic Sheet | VC-16 |
| Case Brief — DA | VC-17 |
| Case Brief — Player | VC-18 |
| Operations Board | VC-19 |
| Organization Reference | VC-20 |