### PR TITLE
fix(#735): consolidate case file package from 9 to 8 documents

### DIFF
--- a/docs/case-file-instructions.adoc
+++ b/docs/case-file-instructions.adoc
@@ -200,8 +200,7 @@ Gather everything you have created:
 | Document | Status
 
 | Case Brief — DA | Mystery statement, real situation, containment truths, relic milestones, resolution notes, DA pacing guidance.
-| Case Brief — Player | Covenant briefing — only what the agents would know walking in.
-| Case File Form | In-world mission document for players.
+| Case Brief — Player | Covenant agent briefing — case name, region, objectives, known organizations, NPC dossiers, starting leads, operational parameters, regional contacts.
 | Operations Board | Shift row with relic milestones, organization rows with starting values and milestone squares.
 | Organization Reference | All organizations, each with O#M# milestone descriptions and cross-link consequences.
 | Relic Sheet | Full artifact profile, fracture table, containment truth checklist.

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -488,53 +488,48 @@ The board serves as the table's coordination surface. Players can look at it and
 [[case-file-package]]
 == The Case File Package
 
-A complete Case File consists of *nine documents*. Together they form the *case file package* — everything a DA needs to run the case and everything the players need to engage with it.
+A complete Case File consists of *eight documents*. Together they form the *case file package* — everything a DA needs to run the case and everything the players need to engage with it.
 
 [cols="1,3,1,4", options="header"]
 |===
 | # | Document | Audience | Purpose
 
 | 1
-| *Case File* (mission brief)
-| Players
-| An in-world document from the Covenant. Contains only what the organization would share with field agents: the relic's surface description, region, timeline pressure, known organizations, starting NPC dossiers, and regional contacts. No secrets, no Containment Truths, no milestone details.
-
-| 2
 | *Case Brief — DA* (mystery statement + DA notes)
 | DA only
 | The real story. What is actually happening, who is really involved, and how the case resolves. The DA's anchor document — every question about "what is going on?" starts here.
 
-| 3
-| *Case Brief — Player* (player-facing summary)
+| 2
+| *Case Brief — Player* (agent briefing / mission brief)
 | Players
-| A briefing document containing the case name, region, objectives, known actors, initial leads, and operational parameters. What the agents know walking in.
+| An in-world briefing document from the Covenant containing the case name, region, objectives, known organizations, starting NPC dossiers, initial leads, operational parameters, and regional contacts. Only what the Covenant would share with field agents — no secrets, no Containment Truths, no milestone details.
 
-| 4
+| 3
 | *Operations Board*
 | DA (visible to players)
 | Shift row plus organization countdown rows. The single tracking surface for the case.
 
-| 5
+| 4
 | *Organization Reference*
 | DA only
 | All case organizations listed with their O#M# milestone descriptions and cross-link instructions. The DA scans this when crossing out milestone squares on the board.
 
-| 6
+| 5
 | *Relic Sheet*
 | DA only
-| Full artifact profile: *Tier* (a measure of the artifact's lethality, containment difficulty, and the Corruption exposure it generates — Tier 1 to Tier 4, defined in xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts]), activation condition, mechanical effects, fracture table, containment profile, and Containment Truth checklist.
+| Full artifact profile: *Tier* (a measure of the artifact's lethality, containment difficulty, and the Corruption exposure it generates — Tier 1 to Tier 3, defined in xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts]), activation condition, mechanical effects, fracture table, containment profile, and Containment Truth checklist.
 
-| 7
+| 6
 | *Location Pages* (one per Location)
 | DA only
 | The documents in front of the DA when the players arrive at a Location. Each page matches the Location form described above.
 
-| 8
+| 7
 | *NPC Cards* (playing-card size)
 | DA only
 | One per NPC. The DA pulls relevant cards and places them next to the active Location page.
 
-| 9
+| 8
 | *Information Cards* (playing-card size, double-sided)
 | DA -> Players
 | Front (player-facing): what the agents learn. Back (DA reference): source Locations, source NPCs, HQ fallback day, type. Players physically receive cards when information is discovered.
@@ -553,7 +548,7 @@ For a single-session case with five or six Locations and six to eight NPCs, the 
 * *xref:chapters/13-advancement.adoc#chapter-advancement[Ch 13 — Advancement]* — XP Debrief procedure (Aftermath Phase), downtime phase healing rules, Dark Secret development
 * *xref:chapters/16-travel.adoc#chapter-travel[Ch 16 — Travel and Journey Rules]* — Travel as a shift type, cost in shifts, vehicle options
 * *xref:chapters/17-rival-factions.adoc#chapter-rival-factions[Ch 17 — Rival Factions]* — Organization behavior and agendas for the Operations Board (Compact, MJ-12, Church, and others)
-* *xref:chapters/20-sample-case-file.adoc#chapter-sample-case-file[Ch 20 — Sample Case File]* — Worked example of all nine case file package documents in use
+* *xref:chapters/20-sample-case-file.adoc#chapter-sample-case-file[Ch 20 — Sample Case File]* — Worked example of all eight case file package documents in use
 
 ---
 

--- a/docs/chapters/20-sample-case-file.adoc
+++ b/docs/chapters/20-sample-case-file.adoc
@@ -1,7 +1,7 @@
 [#chapter-sample-case-file]
 = Sample Case File: The Spear That Went Dark
 
-This chapter presents a complete, ready-to-run Neon Relic case file. *The Spear That Went Dark* is the introductory sample that ships with the game. It demonstrates every system working together: the Operations Board, the nine-document case package, Containment Truths, Organizations, NPC Cards, Location Pages, and Information Cards. Run it as written for your first session, or read through it to understand how the pieces fit before building your own.
+This chapter presents a complete, ready-to-run Neon Relic case file. *The Spear That Went Dark* is the introductory sample that ships with the game. It demonstrates every system working together: the Operations Board, the eight-document case package, Containment Truths, Organizations, NPC Cards, Location Pages, and Information Cards. Run it as written for your first session, or read through it to understand how the pieces fit before building your own.
 
 The full document package — all filled-in forms — lives in the starter kit under `sample-case-file/`. This chapter provides the narrative architecture the DA needs to run the case, plus the handout images and NPC portraits for use at the table.
 
@@ -56,15 +56,14 @@ Once you have run or read through *The Spear That Went Dark*, you are ready to b
 [#sample-case-packet]
 == The Case Packet
 
-The complete case data is organized into the nine-document case file package defined in xref:chapters/15-case-file.adoc#case-file-package[The Case File Package]. All filled-in forms are located in the starter kit under `sample-case-file/`:
+The complete case data is organized into the eight-document case file package defined in xref:chapters/15-case-file.adoc#case-file-package[The Case File Package]. All filled-in forms are located in the starter kit under `sample-case-file/`:
 
 [%header,cols="2,3"]
 |===
 | Document | File
 
-| Case File (Mission Brief — Player-Facing) | `case-file-mission-brief.html`
 | Case Brief — DA | `case-brief-da.html`
-| Case Brief — Player | `case-brief-player.html`
+| Case Brief — Player (Agent Briefing) | `case-brief-player.html`
 | Relic Sheet | `relic-sheet.html`
 | Operations Board | `operations-board.html`
 | Organization Reference | `organization-reference.html`
@@ -90,7 +89,7 @@ The object is simultaneously sacred relic, imperial mandate, and weaponizable as
 
 == Cross-References
 
-* *xref:chapters/15-case-file.adoc#chapter-case-file[Ch 15 — Case File]* — Full case file package structure (nine documents), scene resolution mechanics, Organizations Board, Containment Truths, Information Cards
+* *xref:chapters/15-case-file.adoc#chapter-case-file[Ch 15 — Case File]* — Full case file package structure (eight documents), scene resolution mechanics, Organizations Board, Containment Truths, Information Cards
 * *xref:chapters/11-artifacts.adoc#chapter-artifacts[Ch 11 — Artifacts]* — Tier 2+ relic behavior, Containment Profile structure (Trigger/Appetite/Quiescence), Containment Ritual procedure
 * *xref:chapters/14-da-guidance.adoc#chapter-da-guidance[Ch 14 — DA Guidance]* — Operations Board authoring, NPC Card design, entity web construction
 * *xref:chapters/17-rival-factions.adoc#chapter-rival-factions[Ch 17 — Rival Factions]* — Vantablack Compact operational behavior, MJ-12 surveillance profile, Church-adjacent faction dynamics


### PR DESCRIPTION
Closes #735

The Case Brief — Player (Agent Briefing) already contains everything described for the separate 'Case File (Mission Brief)' in Ch 15: situation summary, objectives, known organizations, NPC dossiers, starting leads, operational parameters, and regional contacts. They are the same document.

### Changes

**Ch 15 (15-case-file.adoc):**
- Changed 'nine documents' to 'eight documents'
- Consolidated entries 1 (Case File / Mission Brief) and 3 (Case Brief — Player) into a single entry
- Renumbered remaining entries
- Fixed Relic Sheet tier reference from 'Tier 1 to Tier 4' to 'Tier 1 to Tier 3' (related to #734)
- Updated cross-reference to Ch 20

**Ch 20 (20-sample-case-file.adoc):**
- Changed 'nine-document case package' to 'eight-document'
- Removed 'case-file-mission-brief.html' row from document table (file never existed)
- Updated cross-reference back to Ch 15

**case-file-instructions.adoc:**
- Removed 'Case File Form' row from Step 8 assembly table
- Enhanced Case Brief — Player description to cover mission brief content

**starter-kit/sample-case-file/ (gitignored, local only):**
- Copied case-brief-player.html from filled-in case file
- Updated README.md to include player brief in file table