### PR TITLE
fix(#734): change Tier 4 artifact references to Tier 3 (Catastrophic)

### DIFF
--- a/docs/case-files/spear-that-went-dark/case-brief-da.html
+++ b/docs/case-files/spear-that-went-dark/case-brief-da.html
@@ -69,14 +69,14 @@
 
   <div class="id-block-row" style="grid-template-columns: 2fr 0.8fr 0.8fr;">
     <div class="id-cell"><span class="id-label">Case Name</span><span class="id-value">The Spear That Went Dark</span></div>
-    <div class="id-cell"><span class="id-label">Relic Tier</span><span class="id-value">4</span></div>
+    <div class="id-cell"><span class="id-label">Relic Tier</span><span class="id-value">3</span></div>
     <div class="id-cell"><span class="id-label">Region</span><span class="id-value">Buenos Aires, Argentina</span></div>
   </div>
 
   <div class="section-title red">I &mdash; Mystery Statement</div>
   <div>
     <span class="field-label">Summarize the entire case in one sentence.</span>
-    <div class="field-value med">A Tier 4 sovereignty relic has surfaced in Buenos Aires after a professional theft crew funded by Vantablack Compact cutouts breached a private custody chamber. If left uncontained, the Spear will select a bearer and trigger a public mandate event. Meanwhile the Compact, the Church, local police, and foreign buyers are all moving on the same broken chain of custody. The agents need the old containment protocol before they can recover it safely.</div>
+    <div class="field-value med">A Tier 3 sovereignty relic has surfaced in Buenos Aires after a professional theft crew funded by Vantablack Compact cutouts breached a private custody chamber. If left uncontained, the Spear will select a bearer and trigger a public mandate event. Meanwhile the Compact, the Church, local police, and foreign buyers are all moving on the same broken chain of custody. The agents need the old containment protocol before they can recover it safely.</div>
   </div>
 
   <div class="section-title">II &mdash; The Real Situation</div>

--- a/docs/case-files/spear-that-went-dark/relic-sheet.html
+++ b/docs/case-files/spear-that-went-dark/relic-sheet.html
@@ -79,7 +79,7 @@
   <!-- RELIC IDENTITY -->
   <div class="id-block-row" style="grid-template-columns: 2fr 0.5fr 1fr 0.8fr;">
     <div class="id-cell"><span class="id-label">Relic Name</span><span class="id-value">The Spear of Destiny (Longinus-class lance relic)</span></div>
-    <div class="id-cell"><span class="id-label">Tier</span><span class="id-value">4</span></div>
+    <div class="id-cell"><span class="id-label">Tier</span><span class="id-value">3</span></div>
     <div class="id-cell"><span class="id-label">Category</span><span class="id-value">Relic / Instrument / War Crown Surrogate</span></div>
     <div class="id-cell"><span class="id-label">Risk Tag</span><span class="id-value">Catastrophic</span></div>
   </div>


### PR DESCRIPTION
Closes #734

Ch 11 defines only Tiers 1-3. The Spear's Corruption Cost is +3, which corresponds to Tier 3 (Catastrophic). Changed all Tier 4 references to Tier 3.

### Changes

**docs/case-files/spear-that-went-dark/case-brief-da.html:**
- Relic Tier field: 4 -> 3
- Mystery Statement: 'A Tier 4 sovereignty relic' -> 'A Tier 3 sovereignty relic'

**docs/case-files/spear-that-went-dark/relic-sheet.html:**
- Tier field: 4 -> 3

The Ch 15 Relic Sheet description ('Tier 1 to Tier 4') was already corrected in #735.
Starter-kit copies also updated locally (gitignored).