### PR TITLE
fix(#736): replace I9 custody lineage content with Appetite containment truth

### DIFF
--- a/docs/case-files/spear-that-went-dark/information-cards.html
+++ b/docs/case-files/spear-that-went-dark/information-cards.html
@@ -220,7 +220,7 @@
   <div class="card card-front">
     <div class="card-header-row"><div class="card-id truth">I9</div><div class="card-label">Information Card</div></div>
     <div class="card-type-label">&#9670; Containment Truth</div>
-    <div class="content-area">The Ferreyra family were never the owners of the Spear. They were temporary lay custodians under a postwar arrangement with ecclesiastical authorities &mdash; an arrangement never publicly regularized.</div>
+    <div class="content-area">The Spear is drawn to wound trauma, ideological certainty, righteous violence, and the proximity of anyone who believes themselves chosen. It does not merely react to these conditions &mdash; it seeks them out, intensifying conflict and conviction in its vicinity until a bearer emerges.</div>
     <div class="card-footer">Neon Relic &bull; The Verdant Covenant</div>
   </div>
 
@@ -303,10 +303,10 @@
     <div class="back-header"><div class="back-title">DA Reference</div><div class="back-stamp">DA Eyes Only</div></div>
     <div class="back-id truth">I9</div>
     <div class="type-row"><span class="type-option"><span class="checkbox checked"></span> Containment Truth</span><span class="type-option"><span class="checkbox"></span> Supporting Intel</span></div>
-    <div><span class="field-label">Found At (L#)</span><div class="field-value">L1 (Estate), L3 (Church Archive)</div></div>
-    <div><span class="field-label">Known By (NPC)</span><div class="field-value">Lucia Ferreyra, Father Vale, Sister In&eacute;s</div></div>
+    <div><span class="field-label">Found At (L#)</span><div class="field-value">L1 (Estate), L5 (La Boca Clinic)</div></div>
+    <div><span class="field-label">Known By (NPC)</span><div class="field-value">Lucia Ferreyra (observed effects), Dr. Maro (wound bloom pattern)</div></div>
     <div><span class="field-label">HQ Fallback (Day)</span><div class="field-value">Day 2</div></div>
-    <div><span class="field-label">Notes</span><div class="field-value med">Custodians Not Owners &mdash; establishes real custody lineage and Church claim.</div></div>
+    <div><span class="field-label">Notes</span><div class="field-value med">Appetite Pattern &mdash; what the relic feeds on and is drawn toward. Essential for containment planning: remove these conditions from the recovery environment.</div></div>
   </div>
 
   <!-- I12 Back -->


### PR DESCRIPTION
Closes #736

## Problem

The Relic Sheet Containment Truth Checklist correctly labels I9 as the **Appetite** truth (wound trauma, ideological certainty, righteous violence, chosen-bearer proximity), but the actual I9 Information Card contained custody lineage content about the Ferreyra family — which is already covered by I10 (Supporting Intel).

## Resolution

Ch 15 defines exactly three required Containment Truths: Trigger, Appetite, and Quiescence. The Relic Sheet checklist is authoritative — I9 IS the Appetite truth and its card content needed to match.

### Changes to information-cards.html

**I9 Front (player-facing):**
Old: Ferreyra custody lineage (temporary lay custodians under postwar arrangement)
New: Appetite description — the Spear is drawn to wound trauma, ideological certainty, righteous violence, and chosen-bearer proximity

**I9 Back (DA Reference):**
- Found At: L1 (Estate), L3 (Church Archive) → L1 (Estate), L5 (La Boca Clinic)
- Known By: Lucia Ferreyra, Father Vale, Sister Ines → Lucia Ferreyra (observed effects), Dr. Maro (wound bloom pattern)
- Notes: 'Custodians Not Owners' → 'Appetite Pattern — what the relic feeds on'

The old I9 custody lineage content is redundant with I10, which already describes the postwar custody arrangement. Starter-kit copies also updated locally (gitignored).