### PR TITLE
docs: update short-session wording in Defining Session

### DIFF
--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -5,7 +5,7 @@ The foundation of Project Neon Relic relies on the classic *dice-pool variant* o
 
 === Defining "Session"
 
-Throughout this book, "once per session" means once per continuous play session at your table — typically 3 to 4 hours. If your group plays significantly shorter sessions (under 2 hours), the DA may allow once-per-session abilities to carry over to the next session if unused. If your group plays extended sessions (6+ hours), the DA may reset once-per-session abilities at a natural midpoint (a significant scene break, shift change, or return to HQ). The intent is that agents recover at a rate of roughly once per 3–4 hours of play, regardless of how your group structures its calendar.
+Throughout this book, "once per session" means once per continuous play session at your table — typically 3 to 4 hours. If your group plays significantly shorter sessions (under 2 hours), the DA may consider once-per-session abilities to span across two or more sessions. If your group plays extended sessions (6+ hours), the DA may reset once-per-session abilities at a natural midpoint (a significant scene break, shift change, or return to HQ). The intent is that agents recover at a rate of roughly once per 3–4 hours of play, regardless of how your group structures its calendar.
 
 == The Anatomy of the Dice Pool
 


### PR DESCRIPTION
## Summary
- update the "Defining Session" paragraph to match the requested wording for short sessions
- keep the surrounding session-guidance text unchanged

## Validation
- git diff --check
- asciidoctor-pdf not available in this runner, so I could not regenerate the book PDF locally

Closes #758