### PR TITLE
docs: clarify disposition shifts are DA-driven

### DIFF
--- a/docs/chapters/06-social-conflict.adoc
+++ b/docs/chapters/06-social-conflict.adoc
@@ -37,7 +37,7 @@ The DA sets starting Disposition based on the NPC's relationship to the agents a
 
 == Shifting Disposition
 
-Disposition shifts up (toward Open) or down (toward Closed) based on agent actions, NPC reveals, and roll outcomes.
+Disposition shifts up (toward Open) or down (toward Closed) based on agent actions, NPC reveals, and roll outcomes. All disposition shifts are done at the DA's discretion and may vary depending on the situation.
 
 === Actions that Shift Disposition Up (+1)
 


### PR DESCRIPTION
## Summary
- append the requested note that disposition shifts happen at the DA's discretion
- keep the existing social-conflict structure unchanged

## Validation
- git diff --check
- asciidoctor-pdf not available in this runner, so I could not regenerate the book PDF locally

Closes #768