### PR TITLE
docs: quote retired phrasing in introduction

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -11,7 +11,7 @@ Neon Relic's default protagonists are *competent but vulnerable containment spec
 
 * *Episodic investigation.* Each session follows a structured *Case File* -- a "artifact-of-the-week" mystery driven by artifact recovery, faction interference, and occult threats.
 * *Base management between missions.* The team maintains a *Headquarters* -- a Covenant facility they upgrade, staff, and defend over the course of a campaign.
-* *Psychological attrition.* The real threat is not the monsters. It is the toll the work takes on the agents. Corruption accumulates from pushing rolls, using supernatural abilities, and confronting the unnatural. It does not go away easily. Characters who cross the threshold are permanently retired.
+* *Psychological attrition.* The real threat is not the monsters. It is the toll the work takes on the agents. Corruption accumulates from pushing rolls, using supernatural abilities, and confronting the unnatural. It does not go away easily. Characters who cross the threshold are "permanently retired."
 * *Analog procedural thriller.* No internet. No GPS. No cell phones. Investigations require physical legwork, face-to-face conversations, and fragile 1980s technology that degrades under use.
 * *Professional tradecraft under cost.* Agents have real tools, protocols, and institutional support, but those tools create access, leverage, and temporary control -- not effortless victories.
 


### PR DESCRIPTION
Closes #753

## Summary
Wraps the final phrase in Introduction §1.1 bullet 3 in quotation marks to match the requested wording.

## Changes
- Updated the psychological attrition bullet in `docs/chapters/01-introduction.adoc` to use `"permanently retired."`.

## Validation
- `git diff --check`