### PR TITLE
docs: remove flawlessly from analog aesthetic

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -38,7 +38,7 @@ The technological environment is characterized by analog limitations, forcing a 
 
 The juxtaposition of high-tech, neon-lit urban sprawl against the ancient, rotting, cosmic horror of the artifacts creates a stark, atmospheric dichotomy. Audio aesthetics play a major role -- underground clubs pulse with aggressive synthwave beats, while secretive government laboratories hum with the low, oppressive frequencies of massive server mainframes.
 
-The tactile, error-prone nature of 1980s technology maps flawlessly to the engine's attrition mechanics. Batteries die at the worst moment. Magnetic tapes corrupt. CRT screens flicker and distort in the presence of the anomalous.
+The tactile, error-prone nature of 1980s technology maps to the engine's attrition mechanics. Batteries die at the worst moment. Magnetic tapes corrupt. CRT screens flicker and distort in the presence of the anomalous.
 
 ---
 


### PR DESCRIPTION
Closes #754

## Summary
Removes the extra adverb from the Analog Aesthetic paragraph without changing the surrounding meaning.

## Changes
- Updated `docs/chapters/01-introduction.adoc` so the 1980s technology sentence now reads `maps to the engine's attrition mechanics`.

## Validation
- `git diff --check`