### PR TITLE
docs: update quick response teams wording

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -90,10 +90,8 @@ Within the Covenant there are *three Divisions*, each responsible for a differen
 
 === Quick Response Teams
 
-Under normal operations, the Covenant's three Divisions work sequentially: Wayfinders locate, Recovery retrieves, the Keep contains.
+Under standard operations, the Covenant's three Divisions work sequentially: Wayfinders locate, Recovery retrieves, the Keep contains.
 This process is methodical, documented, and safe — when time permits.
-
-Time rarely permits.
 
 When an artifact surfaces under hostile conditions — rival factions converging, civilian exposure escalating, or containment failures cascading beyond a single Division's capability — the Covenant activates a *Quick Response Team*.
 QRTs are ad-hoc field units assembled from available agents across all three Divisions, deployed to handle situations that require the full locate-retrieve-contain cycle in compressed, dangerous timeframes.


### PR DESCRIPTION
Closes #755

## Summary
Changes Quick Response Teams to use `standard` instead of `normal` and removes the `Time rarely permits.` sentence as requested.

## Changes
- Updated the opening Quick Response Teams paragraph in `docs/chapters/01-introduction.adoc`.

## Validation
- `git diff --check`