### PR TITLE
docs: rename exhaustion damage in character creation

### DIFF
--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -80,7 +80,7 @@ Distribute your *Attribute Points* across your four core attributes. Each attrib
 > Your four attributes serve a dual purpose: they define your dice pools *and* they are your health. When your agent takes damage, the relevant attribute is reduced:
 >
 > * *Physical damage* (bullets, blunt trauma, falls) → reduces *Strength*
-> * *Exhaustion damage* (sprint, forced march, exertion) → reduces *Agility*
+> * *Hobbling damage* (sprint, forced march, exertion) → reduces *Agility*
 > * *Mental horror* (supernatural imagery, occult overload) → reduces *Wits*
 > * *Emotional trauma* (witnessing atrocity, corruption of bonds) → reduces *Empathy*
 >


### PR DESCRIPTION
Closes #756

## Summary
Renames the Agility damage example in Step 3 from `Exhaustion damage` to `Hobbling damage`.

## Changes
- Updated the attribute damage bullet list in `docs/chapters/02-character-creation.adoc`.

## Validation
- `git diff --check`