### PR TITLE
Batch 2: Close 18 design issues

### DIFF
--- a/docs/chapters/01-introduction.adoc
+++ b/docs/chapters/01-introduction.adoc
@@ -19,7 +19,7 @@ Neon Relic's default protagonists are *competent but vulnerable containment spec
 
 * Not a step-dice system. Neon Relic uses d6 dice pools, not the step-dice variant from _Twilight: 2000_ or _Blade Runner RPG_.
 * Not high fantasy or superhero action. Powers are rare, dangerous, and always come at a cost.
-* Not a dungeon crawl. There are no experience points for killing monsters. Advancement comes from completing missions, surviving trauma, and confronting your Dark Secret.
+* Not a dungeon crawl. There are no experience points for killing monsters. Advancement comes from completing missions and surviving trauma.
 * Not a game where Division gear or Talents replace investigation. The Covenant equips you to enter the problem, not to bypass it.
 
 ---
@@ -151,3 +151,59 @@ This rulebook is organized into six parts:
 * *Part VI: Glossary* -- Quick reference for all game terms.
 
 If you are a player, start with Character Creation and Core Mechanics. If you are the DA (the *Director*), read everything -- but especially the Director section and the Corruption chapter.
+
+---
+
+== How Play Works
+
+A typical Neon Relic session follows a structured rhythm: the team spends *shifts* investigating locations, interviewing NPCs, and gathering information while external pressure mounts on the *Operations Board*. Understanding shifts, shift actions, and Covenant packets is essential for every player — not just the DA.
+
+=== Shifts
+
+Each in-game day is divided into four *shifts*:
+
+[%header,cols="1,2"]
+|===
+| Shift | Approximate Time
+
+| *Morning* | 6:00 AM – 12:00 PM
+| *Day* | 12:00 PM – 6:00 PM
+| *Evening* | 6:00 PM – 12:00 AM
+| *Night* | 12:00 AM – 6:00 AM
+|===
+
+During each shift, the team undertakes *one primary action* as a group. The DA advances the Operations Board by one square after each shift, regardless of what the team does. Time is always running.
+
+=== Shift Actions
+
+The team chooses one action per shift:
+
+[%header,cols="2,4"]
+|===
+| Action | What It Does
+
+| *Scene* | Go to a Location, interact with NPCs, gather information, or attempt an objective. This is the core investigative action.
+| *Travel* | Move between cities or distant locations. Short urban travel is free; long-distance travel costs a full shift.
+| *Surveillance* | Stake out a Location or NPC. Requires a full shift; reveals activity patterns, arrivals, or organization movements.
+| *Research* | Spend time in archives, libraries, or the Covenant's records. May reveal historical context, artifact precedent, or NPC backgrounds.
+| *Preparation* | Plan an approach, acquire equipment, set up a safe house, or coordinate with Covenant contacts.
+| *Recovery* | Rest, heal, or decompress. Required for Anchor Scenes and Safe Scene recovery (see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing]).
+|===
+
+=== Covenant Packets
+
+The team can send *one packet* to Covenant HQ per shift — a request for information, analysis, equipment, or authorization. Packets are not instant:
+
+* *Minimum response time:* 2 shifts. The request goes out, HQ processes it, and the response arrives no sooner than two shifts later.
+* *Requests must be specific.* "Tell us everything about the artifact" gets nothing. "Run the serial number on this pocket watch against Keep intake records from 1920–1930" gets results.
+* *HQ responses may be incomplete, delayed, or intercepted.* The DA controls what comes back and when.
+
+The packet system means the team cannot pause the investigation to wait for HQ to solve their problems. They have to keep moving with incomplete information — and when the packet arrives, it either confirms what they've already been acting on or redirects them at a cost of time already spent.
+
+=== Time Pressure
+
+A standard case runs up to *fourteen days* — 56 shifts total. The Operations Board tracks every shift spent. While the team investigates, rival factions advance on their own timelines. An organization that reaches its crisis milestone before containment means the case is lost on their terms.
+
+The clock is the game's central tension. Every shift spent on recovery, travel, or a dead lead is a shift the artifact spends getting worse and rival factions spend getting closer.
+
+For full DA-facing rules on the Operations Board, Locations, NPC Cards, Information Cards, and case construction, see xref:chapters/15-case-file.adoc#chapter-case-file[Ch 15 — The Case File].

--- a/docs/chapters/01b-opening-fiction.adoc
+++ b/docs/chapters/01b-opening-fiction.adoc
@@ -1,0 +1,87 @@
+[#opening-fiction]
+= Field Report: The Holbrook Frequency
+
+[.center]
+_Covenant Case File #CF-1987-0419 — REDACTED EXTRACT_ +
+_Classification: Restricted (Operational Personnel Only)_ +
+_Filed by: Agent Elena Vasquez, Recovery Division_
+
+---
+
+The payphone on Seventh smelled like rain and cigarettes. I fed it two quarters and dialed the dead drop number. Three rings. Click. The recording played — Covenant shorthand for "packet received, processing, minimum two shifts." Two shifts. We didn't have two shifts.
+
+Behind me, Kowalski was sitting in the van with the engine running, pretending to read a newspaper he'd already memorized twice. The surveillance van across the street — the one with the fake plumber's logo — had been there since Tuesday. MJ-12, probably. They'd made the shop yesterday morning. Same time we did.
+
+It was Thursday. Day 9.
+
+---
+
+The morning shift had started with Yusuf pulling the Operations Board out of his field case and laying it across the motel room's credenza. Fourteen columns, four rows each. Nine days of crossed-out squares stared back at us. The relic row was worse — the artifact had advanced twice since the church incident, and we still didn't have the third Containment Truth.
+
+"The Compact moved overnight," Yusuf said, marking their organization row with a red pen. "O_M2. Their fixer met with the appraiser at the harbor. If they hit M3 before we contain, they'll have the watch on a boat by Sunday."
+
+Chen was at the desk, cross-referencing the county records we'd pulled yesterday with Professor Harlan's research notes. Two Information Cards pinned to the wall: I3 — the 1923 estate sale connecting the watch to St. Anne's Parish — and I5 — Harlan's description of the activation trigger. Sustained skin contact. That explained the previous owner's death.
+
+We needed I6. The quiescence condition. The parish priest at St. Anne's knew it — we were almost certain — but the church had been locked since the incident on Day 6, and the priest wasn't answering his phone.
+
+"We have two options," Chen said, not looking up from the notes. "I go back to the university library and try the restricted collection. Or someone talks to the priest."
+
+"The priest is spooked," Kowalski said from the doorway. "He saw what happened in the nave. He's not opening that door for a badge."
+
+"He might open it for a confession."
+
+Silence. Kowalski looked at me. I looked at the Board. Five days left. The Compact was three squares from crisis. And the relic was doing something to the neighborhood — the motel clerk had complained about the clocks running slow, and I'd noticed the light in the parking lot had a quality I didn't like. A thickness.
+
+"I'll take the church," I said. "Chen, try the library — if Harlan left anything else in the restricted stacks, we need it. Kowalski, stay on the van. If the plumber's truck moves, I want to know."
+
+Yusuf pulled three cards from his field case and sorted them on the table — the NPC cards for the parish priest, the appraiser, and the Compact fixer. Standard practice. Know who you're dealing with before you walk in.
+
+I picked up my jacket. In the inside pocket, I felt the weight of the cassette tape — Los Lobos, _By the Light of the Moon_. Marco's handwriting on the label. I didn't take it out. Not yet. Not until the shift was over and we were somewhere safe and I could sit with it for five minutes without the world pressing in.
+
+The morning shift had started. The clock was running.
+
+---
+
+I reached St. Anne's by 10:15. The church was dark, but the side door was unlocked — the priest hadn't sealed it properly after the incident. The nave smelled wrong. Cold stone and something else. Ozone, maybe, or the way the air tastes before a thunderstorm that never comes.
+
+Father Malone was in the sacristy, sitting in the dark with his hands on the table. He didn't look surprised to see me. He looked like a man who had stopped being surprised by anything.
+
+"You're with them," he said. Not a question.
+
+"I'm with the people who can make it stop."
+
+He told me what I needed. The original Latin invocation — the one the parish had used in 1923 to seal the watch after three parishioners died holding it. He recited it from memory, slowly, while I wrote it down on a Covenant field form. His hands didn't shake. His voice did.
+
+I6. Containment Truth number three. The quiescence condition.
+
+I was back at the motel by noon. Chen had struck out at the library — the restricted collection had been pulled by someone with federal credentials two days ago. MJ-12, again. But it didn't matter. We had what we needed.
+
+Yusuf laid the three Containment Truth cards on the table:
+
+* *I3:* Provenance — 1923 estate, St. Anne's Parish.
+* *I5:* Trigger — sustained skin contact.
+* *I6:* Quiescence — the Latin invocation.
+
+"Full containment profile," he said. He was already reaching for the Warden's Bracer on his left forearm.
+
+The evening shift would be the containment attempt. The watch was in evidence lockup at the county sheriff's office — which meant either a formal Covenant requisition through proper channels (two shifts we didn't have) or an unofficial extraction that would burn our cover with local law enforcement.
+
+Kowalski cracked his knuckles. "I'll get the watch."
+
+I didn't ask how. Recovery Division.
+
+That night, in the motel parking lot, with Yusuf's Bracer dampening the emissions and Chen reading the invocation from my field notes, we sealed the watch in a lead-lined containment case. The containment held. The clocks in the motel started running at the right speed again. The thickness in the light went away.
+
+Day 10. We'd beaten the Compact by four days. MJ-12 would find an empty evidence locker and a confused sheriff. The parish priest would sleep through the night for the first time in a week.
+
+I sat on the motel room bed after the others had gone to their rooms. I took out the cassette tape. Marco's handwriting. I didn't play it — the Walkman's rewind button was still broken. I just held it. Five minutes of quiet. The memory of a birthday before any of this. Before the Covenant, before the artifacts, before the things I'd seen in the Tucson raid that I still can't describe without my hands shaking.
+
+I felt it work. The tightness behind my eyes loosened. The cold static that had been building since the church receded. Not gone — never gone — but manageable. Enough to sleep. Enough to do it again tomorrow.
+
+I put the tape back in my pocket and turned off the light.
+
+---
+
+[.center]
+_End of extract. Full operational details available to CL 3+ personnel._ +
+_Case status: Contained. Artifact transferred to Keep Vault 7, Bay 14._

--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -7,15 +7,15 @@ Every player in Neon Relic portrays a sworn agent of *The Verdant Covenant* — 
 
 == Step 1: Choose Your Division
 
-Your *Division* is your character class. It defines your role within the Covenant, your key attributes, your starting skills, and your access to supernatural Division Talents. Your Division tells the group what kind of pressure you are trained to handle -- not that you can solve scenes cleanly on your own. There are three Divisions:
+Your *Division* is your character class. It defines your role within the Covenant, your primary attribute, your starting skills, and your access to supernatural Division Talents. Your Division tells the group what kind of pressure you are trained to handle -- not that you can solve scenes cleanly on your own. There are three Divisions:
 
 [%header,cols="1,2,1,2"]
 |===
-| Division | Role | CL | Key Attributes
+| Division | Role | CL | Primary Attribute
 
-| *Wayfinder* | Research and intelligence. You find what others don't know exists. | 3 | Wits, Empathy
-| *Recovery* | Field retrieval. You go in and bring the artifact out. | 2 | Strength, Agility
-| *The Keep* | Vault security, custody, and logistics. You guard what has been won — and equip those who win it. | 3 | Empathy, Wits
+| *Wayfinder* | Research and intelligence. You find what others don't know exists. | 3 | Wits
+| *Recovery* | Field retrieval. You go in and bring the artifact out. | 2 | Agility
+| *The Keep* | Vault security, custody, and logistics. You guard what has been won — and equip those who win it. | 3 | Empathy
 |===
 
 [NOTE]
@@ -151,7 +151,7 @@ Most Division Talents cost *+1 Corruption* to activate. One talent per list is a
 
 Talents and Division items are meant to create *leverage*: a clue path, a brief edge, a safer handling window, a cleaner extraction. They should not change the game's default expectation that agents must still investigate, improvise, and pay a price for certainty.
 
-> *Talent Advancement:* Additional General, Division, or Wing/Paradigm/Department talents can be purchased during play using XP. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+> *Talent Advancement:* Additional General, Division, or Wing/Paradigm/Department talents can be purchased during play using XP. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 
 ---
 
@@ -177,7 +177,7 @@ Once attributes are set, note the following:
 >
 > As threshold approaches, your options narrow: lower Empathy reduces social dice pools, reduces your passive resistance to emotional trauma, and leaves no buffer for emergencies. The game's Corruption economy is deliberately asymmetric — Corruption is easier to gain than to lose.
 >
-> Manage your Empathy carefully at creation. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing] for the full economy.
+> Manage your Empathy carefully at creation. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing] for the full economy.
 
 > *Maximum Corruption Threshold* is the number at which your character's mind permanently fractures, resulting in catatonia and character retirement. This is the most important number on your sheet — protect it.
 
@@ -241,41 +241,20 @@ Each agent begins with a Division-appropriate kit. Gear beyond this standard kit
 
 == Step 9: Choose Your Anchor
 
-Every agent carries an *Anchor* — a tangible, physical object tied to a core humanizing memory from before the Covenant. It connects you to the ordinary world you are fighting to protect, and it is your most reliable tool for healing Corruption.
+Every agent has an *Anchor* — a personal source of solace that grounds them against the psychological toll of Covenant work. An Anchor is not a physical object; it is the practice, habit, or connection where the character finds peace. It connects you to who you are outside the mission.
 
 Choose one of the following options:
 
-* *Roll d66* on the Anchor Table in the Healing chapter and accept the result as written.
-* *Invent your own:* name a specific object and the memory attached to it. Run it by your DA.
+* *Roll d66* on the Anchor Sources table in the Healing chapter and accept the result as written.
+* *Invent your own:* name the source of solace and describe how the character engages with it. Run it by your DA.
 
-Record your Anchor's name and the memory it represents on your character sheet.
+Record your Anchor on your character sheet.
 
-> *Mechanic:* Once per session, dedicate a scene to your Anchor — a quiet moment where you handle the object and let the memory surface. Heal *1d4 Corruption*. Full rules in the Healing chapter.
-
----
-
-== Step 10: Choose Your Dark Secret
-
-Every Covenant agent harbors a *Dark Secret* — something from their past that the Covenant knows, or should know, about them. It must be specific enough that the DA can use it as a story hook when the investigation points in the right direction.
-
-> **What makes a good Dark Secret?**
->
-> * *Specific, not vague.* "I used to drink too much" is not a Dark Secret. "I destroyed evidence that would have exposed my supervisor's corruption, and the Covenant has the original file" is.
-> * *Actionable.* The DA should be able to make it appear in play — it should have a name, a face, or a faction that could show up in a case.
-> * *Morally complicated.* The best secrets involve something your character did, chose, or failed to prevent — not just embarrassment.
->
-> **Examples:**
->
-> * _Loyalty:_ Your former handler is now working for the Vantablack Compact. You haven't reported this to the Covenant.
-> * _Cover-up:_ You falsified your field report after a containment failure. Someone died who didn't have to.
-> * _Double identity:_ The government agency that employed you before still believes you're their operative. You haven't corrected them.
-> * _Forbidden contact:_ You are in quiet communication with a known Ember Accord operative. You tell yourself it isn't a problem.
-
-Choose one from your Division's example list in the Advancement chapter, or write your own. The XP question at session end — *"Did your Dark Secret complicate the mission?"* — is the mechanical payoff. Full rules and Division-specific examples are in xref:chapters/13-advancement.adoc#_dark_secrets[Dark Secrets].
+> *Mechanic:* Once per session, dedicate a scene to your Anchor — a quiet moment where you actively engage with your source of solace. Heal *1d4 Corruption*. Full rules in the Healing chapter.
 
 ---
 
-== Step 11: Name, Country of Origin, and Biography
+== Step 10: Name, Country of Origin, and Biography
 
 Choose a name appropriate for your campaign's 1980s setting. Record your *Country of Origin*. Then write 2–3 sentences of biography: who were you before the Covenant? What incident drew their attention? What can you not bring yourself to talk about?
 
@@ -305,8 +284,7 @@ After completing all steps, your sheet should record:
 | *Starting Gear* | Division kit (department variant if applicable) ± optional items
 | *Corruption* | Starts at 0
 | *Max Corruption Threshold* | 10 + Empathy
-| *Dark Secret* | Chosen from Division list or custom (see Advancement chapter)
-| *Anchor* | Object name + memory (see Healing chapter)
+| *Anchor* | Source of solace (see Healing chapter)
 |===
 
 ---
@@ -328,7 +306,7 @@ Petra's six years in DEA field operations put her at age 34 — she selects *Exp
 | Attribute | Score | Reasoning
 
 | Strength | 4 | Ex-agency physical conditioning
-| Agility | 4 | Trained for fast entries; Recovery Key Attribute
+| Agility | 4 | Trained for fast entries; Recovery Primary Attribute
 | Wits | 3 | Sharp but not an analyst
 | Empathy | 2 | Gets by on presence, not charm; lower threshold is a real risk
 |===
@@ -376,13 +354,9 @@ Petra records the *Verdant Satchel* automatically. From the Recovery Kit she tak
 
 === Step 9: Anchor
 
-> *Anchor:* A cassette tape — Los Lobos, _By the Light of the Moon_, 1987. Her brother Marco made it for her birthday. She keeps it in the inside pocket of her field jacket and hasn't listened to it since the Tucson raid.
+> *Anchor:* Memory / Nostalgia — a cassette tape her brother Marco made for her birthday. She keeps it in the inside pocket of her field jacket. She doesn't listen to it — the Walkman's rewind button is broken — but holding it and remembering that birthday is enough.
 
-=== Step 10: Dark Secret
-
-> *Dark Secret:* Petra's former DEA supervisor is now working for *The Vantablack Compact*. She has not reported this.
-
-=== Step 11: Name, Country of Origin, and Biography
+=== Step 10: Name, Country of Origin, and Biography
 
 * *Name:* Petra Vasquez
 * *Country of Origin:* United States (California)

--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -34,7 +34,7 @@ Each *6* rolled counts as *one success*.
 
 * *Standard roll:* You succeed if your total successes meet or exceed the Difficulty.
 * *Opposed roll:* Both sides roll, then compare total successes; the higher total wins. Ties are resolved in favor of the player character.
-* *Special binary roll:* A few subsystems, especially *Fear checks*, define their own pass/fail rule instead of using Difficulty.
+* *Special binary roll:* A few subsystems, especially *Corruption Burst checks*, define their own pass/fail rule instead of using Difficulty.
 
 Successes beyond what was needed are *extra successes*. If the roll supports stunts, each extra success becomes *1 Stunt Point*.
 
@@ -72,7 +72,7 @@ However, pushing represents the character exerting maximum physical, mental, or 
 
 * You immediately gain *+1 Corruption*.
 
-> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing] for the full rules.
+> *Design note:* Corruption is the only push cost. There is no separate "Stress" track, no optional complication table. The Corruption system handles all forms of mental and supernatural pressure through a single unified resource — see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing] for the full rules.
 
 ****
 *What happens when you push?*

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -109,7 +109,7 @@ The following stunts are available *only* when rolling the listed skill. They re
 | Cost | Stunt | Effect
 
 | 1 | *Controlled Break* | You force open the door/lock/container without damaging the contents or triggering adjacent mechanisms. Finesse in violence.
-| 1 | *Intimidating Display* | Your feat of strength is visibly dramatic. One NPC present must make a *Fear Check* (Fear Rating 1) or immediately comply with your next simple demand. See xref:chapters/08-corruption-fear-healing.adoc#fear-checks[Fear Checks].
+| 1 | *Intimidating Display* | Your feat of strength is visibly dramatic. One NPC present must make a *Corruption Burst* (Burst Rating 1) or immediately comply with your next simple demand. See xref:chapters/08-corruption-fear-healing.adoc#corruption-burst-procedure[Corruption Burst].
 | 2 | *Clear the Room* | A shove, flip, or sweep clears all loose objects from the zone simultaneously (useful for destroying a cultist's ritual setup, or just making a scene).
 |===
 
@@ -169,7 +169,7 @@ The following stunts are available *only* when rolling the listed skill. They re
 
 | 1 | *Aimed Shot* | The shot hits exactly the intended location (specific limb, lock, cable, tire). DA treats the result as precision even at range.
 | 1 | *Suppression* | Target is pinned behind cover until start of your next turn. They cannot move zones or fire back without losing their cover bonus.
-| 2 | *Warning Shot* | You visibly miss by design, close enough to be terrifying. The target must make a *Fear Check* (Fear Rating 2) or drop to the ground and remain there for 1 round. No ammo die roll required for this shot. See xref:chapters/08-corruption-fear-healing.adoc#fear-checks[Fear Checks].
+| 2 | *Warning Shot* | You visibly miss by design, close enough to be terrifying. The target must make a *Corruption Burst* (Burst Rating 2) or drop to the ground and remain there for 1 round. No ammo die roll required for this shot. See xref:chapters/08-corruption-fear-healing.adoc#corruption-burst-procedure[Corruption Burst].
 |===
 
 ---
@@ -250,7 +250,7 @@ The following stunts are available *only* when rolling the listed skill. They re
 
 == General Talents
 
-General Talents are not defined in this chapter. The canonical advancement rules and full General Talents catalog live in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+General Talents are not defined in this chapter. The canonical advancement rules and full General Talents catalog live in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 
 At character creation, an agent may choose one General Talent in place of their starting Division Talent, as described in xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
 

--- a/docs/chapters/05-combat.adoc
+++ b/docs/chapters/05-combat.adoc
@@ -256,42 +256,7 @@ A character *in cover* benefits from partial physical shielding.
 
 === Ammunition
 
-Ammunition is tracked using a *Resource Die*. When you acquire a weapon or reload, set its ammo die based on the weapon type and current magazine state:
-
-[%header,cols="2,1,2"]
-|===
-| Ammo State | Die | Notes
-
-| *Pistol — full magazine* | d10 | 9mm, .38, .45; standard load
-| *Shotgun — full load* | d8 | Pump or semi-auto shotgun
-| *Rifle — full magazine* | d8 | Assault rifle, battle rifle, .308
-| *Half loaded (any)* | d6 | Partially used magazine
-| *Low / scrounged (any)* | d4 | Found ammo, emergency reload
-| *Drum / extended mag* | d12 | Special acquisition (CL 4)
-|===
-
-> *Two-track ammo system:* This table governs *in-combat per-shot tracking* — roll when you push a Firearms roll, fire full auto, or the DA calls for it. Between scenes, use the *Supply-level Resource Dice* in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment] to track how much ammo the team has on hand. When you reload in the field, roll the supply die; then reset the weapon's combat ammo die to its 'full' value from this table.
-
-*When do you roll the ammo die?*
-
-* After *every turn in which you fire* (standard fire — the die represents the resource pressure of sustained combat).
-* After *pushing a Firearms roll* — roll an additional time (you burned through extra rounds).
-* After a *full auto burst* — roll *twice* (see Full Auto below).
-* At the DA's discretion when dramatically appropriate (ambush, very long firefight).
-
-*Rolling the ammo die:*
-
-* Roll the current die. On a *1 or 2*, step the die down one size (d8→d6→d4→empty).
-* On *empty* (die was d4 and rolled 1–2): weapon is dry. Reload costs a Slow Action.
-
-=== Full Auto
-
-Weapons capable of fully automatic fire (noted in the Equipment tables) may fire a *full auto burst* on a Slow Action instead of a standard shot.
-
-* *Effect:* Make *two separate attack rolls* against the same target (or split between two targets in the same zone). Resolve each roll independently — each can hit, miss, or generate stunt points.
-* *Ammo:* Roll the ammo die *twice* after a full auto burst (once per attack).
-* *Penalty:* After firing full auto, the firing character suffers −1 die on all Firearms rolls until the start of their next turn (recoil and muzzle rise).
-* *When in doubt:* If the Equipment tables do not specify a weapon as full auto, it fires semi-auto only.
+Ammunition is tracked using a *Resource Die* that steps down as you fire. Full ammunition tracking rules — including the ammo die table, when to roll, and full automatic fire — are in xref:chapters/appendix-combat.adoc#ammunition-tracking[Appendix: Advanced Combat → Ammunition Tracking].
 
 ---
 
@@ -327,7 +292,7 @@ Extra successes (6s beyond the attack's required Difficulty, usually 1) are *Stu
 | 1 | *Disarm* | Target drops their held weapon at Engaged range (without a full Disarm maneuver roll). The weapon lands at Engaged range from the target — either party could pick it up.
 | 1 | *Target Limb* | Attack hits a specific limb. DA applies a situational penalty (hobbled, one-armed, etc.) until treated.
 | 1 | *Push Back* | Target is forced one zone away.
-| 1 | *Scare* | Target must immediately make a *Fear Check* (Fear Rating 1) even if no supernatural trigger is present — the violence itself is the threat. See xref:chapters/08-corruption-fear-healing.adoc#fear-checks[Fear Checks].
+| 1 | *Scare* | Target must immediately make a *Corruption Burst* (Burst Rating 1) even if no supernatural trigger is present — the violence itself is the threat. See xref:chapters/08-corruption-fear-healing.adoc#corruption-burst-procedure[Corruption Burst].
 | 2 | *Double Damage* | Deal the weapon's Damage value twice instead of once.
 | 2 | *Suppressive Fire* | Target is pinned — they cannot move zones until the start of your next turn unless they succeed on a Wits roll (Difficulty 2).
 | 2 | *Destroy Cover* | Target's cover is destroyed or invalidated after this attack.
@@ -336,61 +301,14 @@ Extra successes (6s beyond the attack's required Difficulty, usually 1) are *Stu
 
 ---
 
-== Chase and Pursuit
+== Advanced Combat Rules
 
-When one side is fleeing and the other is pursuing, use the following chase rules.
+The following situational combat systems are detailed in xref:chapters/appendix-combat.adoc#appendix-combat[Appendix: Advanced Combat Rules]:
 
-=== Chase Structure
-
-A chase is divided into *chase rounds*. Each round, both the fleeing and pursuing party roll their relevant attribute + skill:
-
-* *On foot:* Agility + Sneak (for stealth flight) or Agility + Endure (for pure sprint)
-* *By vehicle:* Wits + Tech (see xref:chapters/10-equipment.adoc#_vehicle_conflict_actions_and_chase_rules[Vehicle Chase Rules] for full vehicle chase procedure, speed modifiers, and maneuvers)
-
-> **DA discretion on skill choice:** These are default options. The DA may call for other skills when the context demands it — a chase through a crowded market could use Manipulate (EMP) to slip through a crowd; a chase through a building's maintenance passages could use Investigate (WIT). The DA should always tell the players which skill they're calling before the roll.
-
-=== Chase Outcome Per Round
-
-* Compare successes. The side with more successes *gains distance* (fleeing) or *closes distance* (pursuing).
-* Track relative distance on a 5-step track: *Contact → Following → Closing → Widening → Escaped*.
-* Start at Contact. Fleeing party wins a round → move one step toward Escaped. Pursuing party wins → move one step toward Contact.
-
-=== Escape and Recapture
-
-* The fleeing party *escapes* when they reach the Escaped position.
-* During a chase, characters may still attack (at whatever range the current position represents) but do so at *−1 die* (distraction of movement).
-* If the pursuing party reaches Contact: normal combat resumes. Draw initiative cards immediately; the pursuit party does not get a free round unless they successfully set up an ambush (see Surprise and Ambush).
-* *Hiding attempt:* If the fleeing party is at Widening, they may attempt to break the chase entirely — succeed on a Sneak roll (Difficulty 2) to vanish into the environment. This attempt may be made *once per chase*; if it fails, the hiding window has passed and the fleeing party must reach Escaped normally.
-
----
-
-== Combat Around Vehicles
-
-Not every vehicle encounter is a chase. When combat occurs at or near stationary vehicles — roadblock shootouts, parking lot ambushes, or attacks on a parked convoy — use standard combat rules with the following guidance:
-
-* *Vehicles as cover:* A vehicle provides cover equal to its Armor Rating. Agents behind a vehicle add the vehicle's Armor Rating to their defense as if it were personal armor (Gear Dice, 6s absorb damage). Unlike personal armor, vehicle cover does not degrade from 1s — the vehicle absorbs Wear instead (1 Wear per combat scene in which it provides cover).
-* *Attacking vehicles:* Targeting a vehicle (to disable it, breach it, or destroy it) uses Force (melee) or Firearms (ranged) at Difficulty 1 — no special maneuver is needed, just a successful hit. Each point of damage that exceeds the vehicle's Armor Rating reduces the vehicle by 1 Wear. At 5 Wear, the vehicle is disabled. Typical vehicle Armor Ratings are listed in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment].
-* *Targeting occupants:* Attacking someone inside a vehicle requires a called shot (1 stunt point) or the vehicle's windows/doors to be open. Closed vehicles provide full Armor Rating to occupants. Open vehicles (windows down, convertibles) provide half Armor Rating (round down).
-
-For moving vehicle encounters, use the Chase and Pursuit rules above. If a chase transitions into a stationary firefight (e.g., vehicles crash and combatants exit), switch to standard combat using the guidance in this section.
-
-> **Wear** is the vehicle damage track. It runs from 0 (undamaged) to 5 (disabled). At Wear 5, the vehicle cannot move, its systems are failing, and it may be on fire — DA determines consequences. Repairing Wear requires tools, time, and a successful Tech (WIT) roll. Full vehicle Wear and repair rules are in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment].
-
----
-
-== Group Combat (Multiple NPCs)
-
-When 3 or more combatants on the NPC side share a common purpose and act together, they may be treated as a *mob*.
-
-=== Mob Rules
-
-* A mob draws *one Initiative card* and acts as a single entity on that card.
-* A mob has a shared Strength pool equal to *3 per member* (e.g., a 4-person mob has Strength 12). Maximum mob Strength is 15 regardless of size.
-* A mob attacks as one unit: roll dice pool equal to the *best individual's dice pool* plus bonus dice equal to the number of additional members (beyond the first), *maximum +3 bonus dice total*.
-* *Damage to a mob:* Any attack that deals Strength damage reduces the mob's shared pool. When the mob Strength pool reaches 0, the mob is broken — all members are Broken or fleeing. The DA may narrate intermediate casualties at thresholds (e.g., one member falls at Strength 6, another at Strength 3).
-* *Splitting a mob:* Area effects (full auto burst, explosive, fire) or AoE-capable stunts can split a mob into two smaller groups. The DA distributes remaining Strength between them.
-
-> Mobs represent low-tier hostiles (cultist grunts, security guards, Compact foot soldiers). Named or significant NPCs always act individually with their own initiative and stat blocks.
+* *Chase and Pursuit* — foot chase structure, escape/recapture rules.
+* *Combat Around Vehicles* — vehicles as cover, attacking vehicles and occupants.
+* *Vehicle Conflict* — Contact Track, chase rolls, speed modifiers, vehicle maneuvers (Ram, PIT, Gunfire, Off-Road Break, Blending In), vehicle damage and breakdown.
+* *Group Combat (Mob Rules)* — treating multiple NPCs as a single mob with shared Strength.
 
 ---
 
@@ -427,6 +345,8 @@ When any PC attribute reaches 0, they are *Broken*:
 * They must roll on the appropriate *Critical Injury table* (see xref:chapters/07-health-damage-armor.adoc#_critical_injuries[Critical Injuries]).
 * They are out of the fight unless stabilized by an ally (Heal roll, costs a Slow Action, requires a First Aid Kit).
 * An unstabilized Broken PC *dies at the end of the scene* — defined as when the immediate danger has passed and the group can act freely, not at the end of the round in which they fell. This means teammates have a window during the fight to stabilize them. If combat ends and the PC has not been stabilized, they die.
+
+> *DA Guidance — When does the scene end?* The scene ends when the DA declares it over — typically when the last hostile threat is neutralized, has fled, or has been contained. If all enemies are down and the team's only remaining action is stabilizing a downed ally, the scene is *not over yet* — the agents are still acting under combat urgency. The DA should not call scene end while a teammate is actively bleeding out and allies are attempting to reach them. The scene ends when the group transitions from combat urgency to free action: looting the room, securing the perimeter, calling for extraction. If in doubt, give the team one more round to act before calling it.
 
 > *Capture over kill:* The Covenant defaults to capturing hostile humans for interrogation. NPCs with relevant information are more valuable alive. DAs should give players narrative opportunities to take prisoners rather than mandating lethality.
 

--- a/docs/chapters/06-social-conflict.adoc
+++ b/docs/chapters/06-social-conflict.adoc
@@ -178,16 +178,16 @@ When a social scene ends badly (Disposition reaches 1, or the agents leave havin
 
 ---
 
-== Social Pressure and Fear
+== Social Pressure and Corruption Burst
 
-Social encounters with entities, artifacts, or cult members may cross into supernatural territory. When the content of a conversation triggers a Fear check:
+Social encounters with entities, artifacts, or cult members may cross into supernatural territory. When the content of a conversation triggers a Corruption Burst:
 
-* *Direct supernatural revelation during a Manipulate scene* (the NPC says something that cannot be explained naturally): Fear check, Fear Rating 1 or 2.
-* *Psychoanalyze roll on a contaminated NPC* (someone who has long-term artifact exposure): Roll Psychoanalyze as normal. On any failure, the agent picks up a psychic echo — immediate Fear check, Fear Rating 2. On success, the agent gets the information but gains +1 Corruption.
+* *Direct supernatural revelation during a Manipulate scene* (the NPC says something that cannot be explained naturally): Corruption Burst, Burst Rating 1 or 2.
+* *Psychoanalyze roll on a contaminated NPC* (someone who has long-term artifact exposure): Roll Psychoanalyze as normal. On any failure, the agent picks up a psychic echo — immediate Corruption Burst, Burst Rating 2. On success, the agent gets the information but gains +1 Corruption.
 
-> *Exception:* This is the only roll in Neon Relic where a *success* costs Corruption. Reading a contaminated mind means absorbing a fragment of what contaminated it. The information is accurate — but the contact is inherently dangerous. This cannot be mitigated by skill or luck. See also the cross-reference in xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+> *Exception:* This is the only roll in Neon Relic where a *success* costs Corruption. Reading a contaminated mind means absorbing a fragment of what contaminated it. The information is accurate — but the contact is inherently dangerous. This cannot be mitigated by skill or luck. See also the cross-reference in xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing].
 
-See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing] for full Fear check rules.
+See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing] for full Corruption Burst rules.
 
 ---
 

--- a/docs/chapters/07-health-damage-armor.adoc
+++ b/docs/chapters/07-health-damage-armor.adoc
@@ -12,7 +12,7 @@ Every source of damage specifies its type and target attribute. The attack defin
 | Damage Type | Target | Sources
 
 | *Physical* | *Strength* (violence, toxins, falls) or *Agility* (exhaustion, prolonged exertion) | Weapons, environmental hazards, physical traps, mundane combat
-| *Mental* | *Wits* (terror, confusion, psychic assault) or *Empathy* (grief, guilt, emotional manipulation) | Failed Fear checks (Wits only), supernatural abilities, psychological attacks, social betrayal
+| *Mental* | *Wits* (terror, confusion, psychic assault) or *Empathy* (grief, guilt, emotional manipulation) | Supernatural abilities, psychological attacks, social betrayal
 | *Corruption* | *Corruption track* directly | Pushing rolls, activating Division Talents, occult exposure, artifact activation/feedback, specific creature attacks
 |===
 
@@ -24,7 +24,7 @@ Every source of damage specifies its type and target attribute. The attack defin
 . *Creature stat blocks* list damage per attack. Example: _Shadow Tendril — Damage 2, Mental (WIT) + 1 Corruption_.
 . *Broken state* triggers when any attribute reaches 0, as before. Physical Broken (STR/AGI = 0) → Physical Critical Injury table. Mental Broken (WIT/EMP = 0) → Mental Critical Injury table.
 
-> *Note on Corruption:* Corruption is listed above for completeness, but it functions differently from Physical and Mental damage. Physical and Mental damage reduce Attribute pools. Corruption adds to a separate Corruption track — it cannot be absorbed by armor, and its healing follows different rules (see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing]). When an attack deals both Physical damage and Corruption, resolve each type independently.
+> *Note on Corruption:* Corruption is listed above for completeness, but it functions differently from Physical and Mental damage. Physical and Mental damage reduce Attribute pools. Corruption adds to a separate Corruption track — it cannot be absorbed by armor, and its healing follows different rules (see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing]). When an attack deals both Physical damage and Corruption, resolve each type independently.
 
 === What Determines STR vs AGI / WIT vs EMP
 
@@ -52,7 +52,7 @@ When multiple end-states trigger from a single sequence of events, resolve them 
 
 . *Physical damage resolves first.* Apply all damage, check for Broken state, roll Critical Injury if applicable.
 . *Death Check resolves second.* If the Critical Injury requires a Death Check (†), resolve it immediately. If the character dies, they are dead — no further checks apply.
-. *Corruption threshold resolves third.* After all physical injury effects are complete, check whether any Corruption gained during the sequence (from Critical Injury results, Fear Checks from witnessing an ally's Critical Injury — see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing] for witness Fear Check rules — or other sources) has pushed the character over their Corruption threshold. If so, the character enters catatonia.
+. *Corruption threshold resolves third.* After all physical injury effects are complete, check whether any Corruption gained during the sequence (from Critical Injury results, Corruption Bursts from witnessing an ally's Critical Injury — see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing] for Burst rules — or other sources) has pushed the character over their Corruption threshold. If so, the character enters catatonia.
 
 > *Corruption timing:* Corruption gained from Mental Critical Injury results (the +1 base and any additional listed amounts) is accumulated but *not* checked against the Corruption threshold until Step 3. Accumulate all Corruption from the entire sequence, then check the threshold once at the end.
 
@@ -119,7 +119,6 @@ When a character dies:
 
 . *Gear returns to Stack.* Division equipment, the Division Signature Item (Verdant Codex, Warden's Bracer, etc.), and all Covenant-issued gear are logged and returned at the end of the Case File.
 . *Covenant notification.* The character is officially listed as *Fallen in the Line of Duty*. The circumstances are filed — truthfully or not, at the surviving team's discretion.
-. *Dark Secrets.* A dead character's Dark Secrets may surface posthumously. If an NPC knew the secret, the DA may still play that complication forward with remaining PCs (the secret outlives the character).
 . *Character replacement.* A new character enters play at the start of the next Case File. They begin with the same XP total as the lowest-XP surviving member of the team (minimum: the character creation baseline values as defined in xref:chapters/02-character-creation.adoc#chapter-creation[Character Creation]). If a character dies *mid-Case-File*, the DA may introduce the replacement at a narratively appropriate moment in the same mission — a Covenant backup team, a local contact activated as emergency support, or a specialist from HQ. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement] for XP totals and spending.
 . *Legacy.* The deceased character's player chooses one lasting effect: a significant item the new character carries (with DA permission), an NPC connection inherited, or a reputation within the Covenant that precedes them.
 
@@ -260,7 +259,7 @@ Roll when Broken by *Wits or Empathy* damage. Mental criticals always gain Corru
 | 35 | *Dissociative Identity Trigger* | +1 Corruption (additional). DA introduces an alternate behavioral state — twice per session, at dramatic moments, rolls a d6: 1–2 = alternate state this scene. | Psychoanalyze campaign (3 downtime phases, Difficulty 3).
 | 36 | *Rage Episodes* | When Empathy falls below 2, character must succeed on Wits roll (Difficulty 2) or attack nearest person (ally or foe). | Psychoanalyze campaign (2 downtime phases, Difficulty 3).
 | 41 | *Artifact Corruption (Insight)* | +2 Corruption (additional). Permanent: *+1 die on all artifact interaction rolls* (you opened a channel). Permanent: −1 Empathy. | Cannot be recovered — this is the artifact's mark.
-| 42 | *Phobia* | New phobia defined (DA and player): when triggered, automatic Fear check at Fear Rating 3. | Psychoanalyze campaign (3 downtime phases, Difficulty 3) reduces to Fear Rating 1.
+| 42 | *Phobia* | New phobia defined (DA and player): when triggered, automatic Corruption Burst at Burst Rating 3. | Psychoanalyze campaign (3 downtime phases, Difficulty 3) reduces to Burst Rating 1.
 | 43 | *Waking Hallucinations* | Wits reduced by 1 permanently. Once per session, character perceives a supernatural intrusion that may or may not be real (DA only knows). | Keep's Empathy specialist can reduce severity; Wits loss is permanent.
 | 44 | *Emotional Bleed* | Permanently −1 Empathy. Character becomes emotionally numb — all social skill rolls suffer −1 die for the remainder of the campaign. | Cannot be healed.
 | 45 | *Fracture Point* | Corruption threshold reduced by 2 (permanently). Max Corruption = `8 + Empathy` instead of `10 + Empathy`. The exposure has cracked something fundamental. | Cannot be reversed.
@@ -301,7 +300,7 @@ Several Mental Critical Injuries require a *Psychoanalyze campaign* — a struct
 
 == Attribute Recovery
 
-Attributes damaged during play (by physical or mental damage) recover over time. The process is separate from Corruption healing (see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing]).
+Attributes damaged during play (by physical or mental damage) recover over time. The process is separate from Corruption healing (see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing]).
 
 === Standard Recovery
 

--- a/docs/chapters/08-corruption-fear-healing.adoc
+++ b/docs/chapters/08-corruption-fear-healing.adoc
@@ -1,5 +1,5 @@
 [#chapter-corruption]
-= Corruption, Fear, and Healing
+= Corruption and Healing
 
 *Corruption* is Neon Relic's signature mechanic — a single ascending number that tracks the cumulative psychic toll of occult exposure, supernatural exertion, and sheer human desperation. It functions as an "inverse hit points" system: every push, every artifact activation, every encounter with the unnatural ratchets the number higher, and there is no coming back from the top.
 
@@ -17,7 +17,7 @@ When a character's Corruption *exceeds* their threshold, their mind permanently 
 * *Fracture Point* Critical Injury (Result 45): −2 to threshold permanently (effective threshold = `8 + Empathy`).
 * Both modifiers apply simultaneously if relevant.
 
-*Retroactive threshold drop:* If permanent Empathy loss (Critical Injury or other source) drops your Corruption Threshold below your current Corruption score, you must immediately attempt a Fear Check. On failure, catatonia triggers at once. On success, you remain active but must reduce your Corruption below the new threshold by the end of the next session or face catatonia automatically.
+*Retroactive threshold drop:* If permanent Empathy loss (Critical Injury or other source) drops your Corruption Threshold below your current Corruption score, you must immediately attempt a Corruption Burst check. On failure, catatonia triggers at once. On success, you remain active but must reduce your Corruption below the new threshold by the end of the next session or face catatonia automatically.
 
 > When Corruption threshold is breached simultaneously with a physical Broken state, see the Simultaneous Injury Resolution rule in xref:chapters/07-health-damage-armor.adoc#chapter-health[Chapter 7: Health, Damage & Armor].
 
@@ -31,8 +31,8 @@ When a character's Corruption *exceeds* their threshold, their mind permanently 
 | *Activating a Division Talent* | +1 (or free) | Most talents that tap the supernatural exact a cost. Talents marked *—* in their Corruption Cost column are free to activate — healing and passive-support talents carry no Corruption. See each talent's entry in xref:chapters/09-talents.adoc#chapter-talents[Talents].
 | *Occult Exposure* | +1 to +3 | Witnessing entities, reading forbidden tomes, or being targeted by anomalous phenomena. DA sets severity.
 | *Artifact Activation* | +1 to +3 | Utilizing an artifact's supernatural properties. Cost varies by artifact tier.
-| *Fear Check (any 1s rolled)* | +1 | The mind cracks trying to process the unprocessable. See Fear rules below.
-| *Failed Fear Check* | +1 | On top of any 1s penalty. See Fear rules below.
+| *Corruption Burst (any 1s rolled)* | +1 | The mind cracks trying to process the unprocessable. See Corruption Burst rules below.
+| *Failed Corruption Burst* | +Burst Rating | On top of any 1s penalty. See Corruption Burst rules below.
 | *Successful Psychoanalyze on contaminated NPC* | +1 | Reading a corrupted mind transfers a fragment. Unique: the only roll where *success* costs Corruption. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict].
 | *Other sources* | Varies | Artifact emissions (passive auras, pulses, Corruption Cascade), creature passive Corruption, Mental Critical Injury results, ritual backlash, and specific supernatural interactions. See xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts], xref:chapters/07-health-damage-armor.adoc#chapter-health[Health & Damage], and xref:chapters/19-bestiary.adoc#chapter-bestiary[Bestiary] for details.
 |===
@@ -62,15 +62,15 @@ Because Corruption naturally builds toward lethal levels, characters must active
 |===
 | Method | Effect | Requirements
 
-| *Anchor Scene* | Heal *1d4 Corruption* | Once per session. Physically hold or interact with your Anchor in a safe, unhurried moment. Player describes the interaction. See detailed rules below.
-| *Safe Scene Recovery* | Heal *1 Corruption* | Once per session. Dedicate a quiet scene to personal decompression — sleep, a meal, a walk, listening to music, a phone call with family. The scene must be *safe* (no active threats, no time pressure). Must be a *different scene* than the one used for an Anchor activation — the two recovery methods cannot share the same moment. No object or specific memory required; just the absence of pressure.
+| *Anchor Scene* | Heal *1d4 Corruption* | Once per session. Engage with your Anchor — a personal source of solace — in a safe, unhurried moment. Player describes the interaction. See detailed rules below.
+| *Safe Scene Recovery* | Heal *1 Corruption* | Once per session. Dedicate a quiet scene to personal decompression — sleep, a meal, a walk, listening to music, a phone call with family. The scene must be *safe* (no active threats, no time pressure). Must be a *different scene* than the one used for an Anchor activation — the two recovery methods cannot share the same moment. No specific Anchor required; just the absence of pressure.
 | *Full Rest (24 hours)* | Heal Corruption equal to *Empathy score* | Full 24-hour cycle resting in a secure, non-anomalous location (defined as: no active artifact emissions, no supernatural entities, no uncontained occult material in the building). Covenant HQ with an active Faraday Cage qualifies. A hotel room or safe house qualifies. Full Rest is typically available only *between Case Files* or during extended downtime within a case (at DA discretion); it cannot be taken during an active shift. **Faraday Cage stacking:** Full Rest and the Faraday Cage (xref:chapters/12-headquarters.adoc#chapter-headquarters[Headquarters]) stack — a character who takes Full Rest at HQ with access to the Cage recovers Empathy score + up to 4 additional Corruption.
 | *Healing Talents* | Varies by talent | See Division Talents and General Talents marked with _(Healing)_.
 |===
 
 > **Anchor Scene vs. Safe Scene — what's the difference?**
 >
-> An *Anchor Scene* requires a specific object, a specific memory, and active player engagement with that memory in fiction. It heals more (1d4, potentially 2–4 Corruption) because it's doing psychological work — confronting the thing that grounds you to the world before the Covenant.
+> An *Anchor Scene* requires the character to actively engage with their personal source of solace — their Anchor. This might mean praying, running laps around the parking lot, playing guitar in the motel room, or calling a loved one. It heals more (1d4, potentially 2–4 Corruption) because it's doing psychological work — confronting the thing that grounds the agent to who they are outside the Covenant.
 >
 > A *Safe Scene* requires only the *absence of threat and pressure* — no supernatural contact, no mission urgency. A character can share a meal, sit quietly, or simply sleep. It heals less (1 Corruption, flat) because it's passive recovery, not active processing.
 >
@@ -84,56 +84,52 @@ Because Corruption naturally builds toward lethal levels, characters must active
 
 === Anchors
 
-Every character begins with an *Anchor* — a tangible, physical object linked to a core humanizing memory (e.g., a cassette tape recording of a lost spouse's voice). In a moment of quiet downtime, a character can dedicate a scene to interacting with their Anchor. This grounded roleplay provides powerful mechanical healing.
+Every character begins with an *Anchor* — a personal source of solace that grounds the agent against the psychological toll of Covenant work. An Anchor is not a physical object; it is the *practice, habit, or connection* where the character finds peace. In a moment of quiet downtime, a character can dedicate a scene to engaging with their Anchor. This grounded roleplay provides powerful mechanical healing.
 
 *Anchor Scene Requirements:*
 
-* The character must *physically hold or interact with* their Anchor.
+* The character must *actively engage with their Anchor* — not just mention it. Pray, meditate, run, call a loved one, play an instrument, write in a journal.
 * The scene must be *safe* — no active threats, no time pressure, no combat.
 * The player should *describe the interaction* (at least a sentence or two of roleplay).
 * Anchor scenes *can occur during a Case File* if the team has a genuine moment of safety (a secured safe house, a quiet vehicle, a defended position at the DA's discretion).
-* *If the Anchor is lost or destroyed:* The character cannot use this recovery method until they create a new Anchor during a downtime phase — a meaningful roleplay scene with the DA. The new Anchor must be tied to a genuine memory. Acquiring a new Anchor is a narrative milestone, not a mechanical transaction.
-* *One Anchor at a time.* A character cannot carry backup Anchors to cycle through.
+* *If the Anchor becomes inaccessible:* If circumstances deny the character access to their source of solace (e.g., a loved one dies, a faith is shaken by supernatural revelation, the character is isolated from all human contact), they cannot use this recovery method until they *establish a new Anchor* during a downtime phase — a meaningful roleplay scene with the DA. The new Anchor must feel earned, not transactional.
+* *One Anchor at a time.* A character cannot maintain multiple Anchors.
 
-=== Random 1980s Anchor Table (Roll d66)
+=== Anchor Sources (Roll d66 or choose)
 
-> *Occult properties:* Several Anchor entries hint at subtle supernatural properties (a compass that points toward entities, a lighter with a blue flame). These are *narrative flavor* — the DA may describe them reacting to supernatural phenomena, but they do not provide reliable detection or mechanical advantage. An Anchor is a psychological comfort object, not a tool. Players cannot use Anchor properties as a substitute for proper detection equipment.
-
-[%header,cols="^1,4,^1,4"]
+[%header,cols="^1,2,4"]
 |===
-| Roll | Anchor | Roll | Anchor
+| Roll | Category | Example Anchors
 
-| 11 | A severely chewed, red Bic pen belonging to a missing sibling. | 41 | A blood-stained matchbook from a notorious neon-lit nightclub.
-| 12 | A Polaroid photograph of a figure that no one else remembers. | 42 | A high school varsity jacket smelling faintly of cheap cologne and ozone.
-| 13 | A mixtape cassette labeled "Do Not Play" in your mother's handwriting. | 43 | A digital Casio watch with an alarm set for a time that doesn't exist.
-| 14 | A heavily worn silver Saint Christopher medal on a broken chain. | 44 | A half-empty bottle of expensive 1970s scotch saved for a special occasion.
-| 15 | A dog-eared paperback copy of a pulp sci-fi novel with cryptic margin notes. | 45 | A pocket-sized, battery-operated arcade game that occasionally glitches.
-| 16 | A tarnished Zippo lighter that sparks with an unnatural blue flame. | 46 | An unmarked VHS tape containing 15 seconds of deeply unsettling footage.
-| 21 | A collection of arcade tokens from a venue that mysteriously burned down. | 51 | A pair of aviator sunglasses with one cracked lens.
-| 22 | A ticket stub from a 1984 rock concert you attended with a dead friend. | 52 | A Rubik's Cube that you nervously solve and scramble to calm your nerves.
-| 23 | A dented police badge belonging to a disgraced former partner. | 53 | A Walkman with a broken rewind button and a single classical music tape.
-| 24 | A crumpled handwritten letter promising a reunion that never happened. | 54 | A military dog tag from the Vietnam War belonging to your father.
-| 25 | A plastic action figure missing its left arm. | 55 | A crumpled receipt for a pawned wedding ring.
-| 26 | A heavy set of brass keys to a property you have never been able to locate. | 56 | A faded newspaper clipping detailing a tragic "accident."
-| 31 | A leather-bound diary with the last fifty pages violently torn out. | 61 | A cracked makeup compact with a mirror that reflects a younger you.
-| 32 | A heavy, gold-plated class ring from a prestigious ivy-league university. | 62 | A brass compass that occasionally points towards the nearest anomalous entity.
-| 33 | A 35mm film canister containing undeveloped negatives you are afraid to process. | 63 | A faded "Dungeons & Dragons" character sheet from a childhood friend.
-| 34 | A switchblade knife with an intricately carved bone handle. | 64 | A heavy iron coin depicting a two-faced Roman emperor.
-| 35 | A woven friendship bracelet that has survived a decade of wear and tear. | 65 | A battered tin flask containing ash instead of liquor.
-| 36 | A cracked pager that occasionally receives numerical codes from unknown numbers. | 66 | A pristine, sealed action figure in its original 1980s blister pack.
+| 11–16 | *Faith / Spirituality* | Prayer (any tradition). Lighting a candle for the dead. Reading scripture. Meditation with rosary beads. Visiting a church, mosque, or temple. A private ritual from a tradition nobody else at the table needs to understand.
+| 21–22 | *Physical Exertion* | Running laps. Push-ups until the shaking stops. Boxing a heavy bag. Swimming. The point is exhaustion — the body takes over when the mind won't stop.
+| 23–24 | *Music / Art* | Playing guitar in the motel room. Sketching in a field journal. Singing — badly, alone, in the car. Listening to a specific album that means something.
+| 25–26 | *A Person* | Calling your mother. Writing a letter to your daughter that you'll never send. Sitting with a teammate who doesn't need to talk. The person doesn't have to be alive — visiting a grave counts.
+| 31–32 | *Routine / Ritual* | Cleaning and maintaining your weapon. Cooking a specific meal. Ironing your shirt. The ritual matters because it's the same every time — the world is chaos, but this one thing is yours.
+| 33–34 | *Logic / Rationalization* | Writing out what happened in clinical language. Diagramming cause-and-effect until it makes sense. Convincing yourself it's all explainable. It isn't, but the exercise helps.
+| 35–36 | *Substance* | A drink. A cigarette. Something stronger. It works in the short term. The DA may eventually ask what happens when it stops working.
+| 41–42 | *Nature / Solitude* | Sitting outside at 3 AM. Watching the sunrise. Finding a park, a river, a patch of sky with no buildings. Silence and distance from anything human-made.
+| 43–44 | *Animals* | A stray cat that lives behind the motel. A dog you kept from a case that went wrong. Feeding pigeons in a plaza. Animals don't know what you've seen, and they don't care.
+| 45–46 | *Writing / Journaling* | A private journal. Poetry nobody reads. Letters to someone who won't write back. The act of putting it into words — even bad words — externalizes what's rattling inside.
+| 51–52 | *Games / Puzzles* | A Rubik's Cube. Crosswords. Chess by mail. Solitaire with a real deck. Something with rules and solutions — a closed system where effort produces results.
+| 53–54 | *Memory / Nostalgia* | Looking at photographs. Holding a keepsake. Replaying a specific moment — a birthday, a last good day, a conversation you keep returning to. The memory is the Anchor, not the object.
+| 55–56 | *Humor / Connection* | Telling jokes — bad ones, dark ones. Making someone laugh. Being around people who don't know what you do. Pretending, for an hour, that the world is normal.
+| 61–62 | *Service / Helping* | Fixing something for a stranger. Volunteering. Doing something kind that has nothing to do with the Covenant. Proof that you're still capable of ordinary good.
+| 63–64 | *Professional Craft* | Working with your hands — carpentry, electronics, mechanics. Building or repairing something that exists in the real world and stays fixed.
+| 65–66 | *Denial / Compartmentalization* | Refusing to think about it. Going to a bar and watching the game. Acting as though nothing happened. Not healthy, but functional. For now.
 |===
 
 ---
 
-== Fear Mechanics
+== Corruption Burst
 
-The Corruption track governs the long arc of psychological decay. *Fear* governs the acute, in-the-moment terror of direct supernatural confrontation — the thing that happens to your body and your mind in the next thirty seconds when the entity looks at you.
+The Corruption track governs the long arc of psychological decay. A *Corruption Burst* governs the acute, in-the-moment shock of direct supernatural confrontation — what happens to your body and your mind in the next thirty seconds when reality breaks in front of you.
 
-Fear and Corruption are directly linked: Fear checks that produce 1s on the dice generate Corruption, and failed Fear checks generate additional Corruption plus a panic response. A single terrifying encounter can spike Corruption in a way that takes days of rest to undo.
+A Burst is not always fear. It might manifest as a wave of dread, static electricity crawling across skin, a cold mist rolling in, a nosebleed, a migraine spike, or a momentary sensory distortion where the room feels wrong in a way you can't articulate. The flavor varies by artifact and entity, but the mechanic is unified under Corruption.
 
-=== What Triggers a Fear Check
+=== What Triggers a Corruption Burst
 
-The DA calls for a Fear check when a character directly confronts a source of genuine supernatural horror. Not everything unusual triggers one — strange sounds, unusual smells, or reading an old text do not. A Fear check requires *direct sensory confrontation* with something that violates the natural order.
+The DA calls for a Corruption Burst when a character directly confronts a source of genuine supernatural phenomena. Not everything unusual triggers one — strange sounds, unusual smells, or reading an old text do not. A Burst requires *direct sensory confrontation* with something that violates the natural order.
 
 [%header,cols="2,4"]
 |===
@@ -144,26 +140,27 @@ The DA calls for a Fear check when a character directly confronts a source of ge
 | *Witnessing violent supernatural death* | An ally or bystander is killed or consumed by occult means in front of the character
 | *Occult revelation* | Irrefutable proof of something the human mind cannot accommodate — a genuine miracle, an impossible geometry, a speaking dead
 | *Sustained entity presence* | For each *additional round* a character remains within Engaged range of an active, hostile entity (after the initial check)
-| *Contact with contaminated minds* | Attempting Psychoanalyze on an NPC with artifact exposure or long-term occult contamination. Fear Rating per DA (typically 1–2). See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict] for Psychoanalyze procedure.
+| *Contact with contaminated minds* | Attempting Psychoanalyze on an NPC with artifact exposure or long-term occult contamination. Burst Rating per DA (typically 1–2). See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict] for Psychoanalyze procedure.
 |===
 
-> *One check per trigger:* If the same entity is already known to the character from a prior session and has been observed before, no new Fear check is required merely for seeing it again — only for new escalations (it doing something new, getting closer, attacking, or *changing in a way that increases its threat* such as revealing a new form or escalating its Fear Rating).
+> *One check per trigger:* If the same entity is already known to the character from a prior session and has been observed before, no new Burst is required merely for seeing it again — only for new escalations (it doing something new, getting closer, attacking, or *changing in a way that increases its threat* such as revealing a new form or escalating its Burst Rating).
 
-> *Edge cases:* A character who is Broken, unconscious, or in a Fugue panic state does *not* make Fear checks. A character who failed a Fear check and is currently suffering a Panic result does not make additional Fear checks until the Panic result ends. Sustained presence checks (each additional round) apply even to characters who succeeded on their initial check.
+> *Edge cases:* A character who is Broken, unconscious, or in a Fugue panic state does *not* roll for Corruption Bursts. A character who failed a Burst check and is currently suffering a Panic result does not make additional checks until the Panic result ends. Sustained presence checks (each additional round) apply even to characters who succeeded on their initial check.
 
-=== The Fear Check Procedure
+[[corruption-burst-procedure]]
+=== The Corruption Burst Procedure
 
-Fear checks are a *special binary roll*. They do *not* use the standard Difficulty system from xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
+Corruption Bursts are a *special binary roll*. They do *not* use the standard Difficulty system from xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 
-. The DA calls for a Fear check when a character directly confronts supernatural horror.
-. Roll dice equal to your current *Wits* attribute (no skill modifier — Fear is instinctual, not trained).
+. The DA calls for a Corruption Burst when a character directly confronts supernatural phenomena.
+. Roll dice equal to your current *Wits* attribute (no skill modifier — the mind's response to the impossible is instinctual, not trained).
 . *One or more 6s = success.* You hold it together.
 . *Any 1s rolled (one or more) = +1 Corruption.* Only one Corruption regardless of how many 1s. This applies whether the check succeeded or failed.
-. *No 6s = failure.* Suffer *1 Mental (Wits) damage*, gain +1 Corruption, AND roll d6 on the *Panic Table*. This is mental injury — it represents the mind cracking under the weight of the unprocessable.
+. *No 6s = failure.* Gain Corruption equal to the *Burst Rating* of the source AND roll d6 on the *Panic Table*.
 
-Fear checks *cannot be pushed* and *cannot receive helping dice*.
+Corruption Bursts *cannot be pushed* and *cannot receive helping dice*.
 
-Fear is involuntary — there is no "trying harder" against the absolute horror of the unnatural. Pushing assumes deliberate effort and expenditure of personal resources; that option does not exist when the primal response has already engaged. Similarly, no ally can steady your nerves against something that violates the physical laws of the universe. Presence helps; coaching doesn't. The Psychoanalyze skill and certain Talents can address the *aftermath* of a failed Fear Check (see Panic Table and Healing Talents) — but they cannot intervene in the moment between seeing the entity and the mind's reaction to it.
+The supernatural overwhelms the rational mind — there is no "trying harder" against something that violates physical law. Pushing assumes deliberate effort; that option does not exist when the primal response has already engaged. Similarly, no ally can steady your mind against a direct encounter with the impossible. The Psychoanalyze skill and certain Talents address the *aftermath* of a failed Burst (see Panic Table and Healing Talents) — but they cannot intervene in the moment between perception and reaction.
 
 ==== Four Outcomes
 
@@ -173,25 +170,25 @@ Fear is involuntary — there is no "trying harder" against the absolute horror 
 
 | Yes | No | Clean pass. No consequence.
 | Yes | Yes | Pass, but +1 Corruption. The exposure marks you.
-| No | No | Fail. 1 Mental (WIT) damage + +1 Corruption + Panic Table.
-| No | Yes | Worst case. 1 Mental (WIT) damage + +1 Corruption (from 1s) + +1 Corruption (from failure) = *+2 Corruption* + Panic Table.
+| No | No | Fail. +Burst Rating Corruption + Panic Table.
+| No | Yes | Worst case. +1 Corruption (from 1s) + Burst Rating Corruption (from failure) + Panic Table.
 |===
 
-> *Why higher Wits means more Corruption on success:* Rolling more dice increases both the chance of a 6 (success) and the chance of a 1 (Corruption). A Wits-5 character who succeeds on a Fear check has a ~60% chance of still gaining +1 Corruption from the 1s rider. This is intentional — sharper minds process more of what they saw, and that awareness has a cost. Fear is never free. The consolation is that Wits 5 characters almost never fail the check entirely.
+> *Why higher Wits means more Corruption on success:* Rolling more dice increases both the chance of a 6 (success) and the chance of a 1 (Corruption). A Wits-5 character who succeeds on a Burst check has a ~60% chance of still gaining +1 Corruption from the 1s rider. This is intentional — sharper minds process more of what they saw, and that awareness has a cost. Supernatural exposure is never free. The consolation is that Wits 5 characters almost never fail the check entirely.
 
-> *Why Wits?* Fear strikes the rational, pattern-recognizing mind first. The brain tries to *explain* what the eyes are seeing — and fails. Empathy governs emotional horror (grief, bargaining, despair); that comes later, through the Corruption track.
+> *Why Wits?* The Burst strikes the rational, pattern-recognizing mind first. The brain tries to *explain* what the eyes are seeing — and fails. Empathy governs emotional processing (grief, bargaining, despair); that comes later, through the Corruption track's long-term effects.
 
 ****
-*Why can't I push or help on a Fear Check?*
+*Why can't I push or get help on a Corruption Burst?*
 
-Fear Checks deliberately break the standard resolution pattern. Every other roll lets you apply training and experience — that's what skills are for. Fear is different. No training prepares the human mind for direct sensory confrontation with something that violates natural law. The Wits-only roll represents your rational mind, stripped of professional scaffolding, trying to hold itself together. Skills can't help. Other people can't help.
+Corruption Bursts deliberately break the standard resolution pattern. Every other roll lets you apply training and experience — that's what skills are for. The Burst is different. No training prepares the human mind for direct sensory confrontation with something that violates natural law. The Wits-only roll represents your rational mind, stripped of professional scaffolding, trying to hold itself together. Skills can't help. Other people can't help.
 
-What can help is recovery: Psychoanalyze and Healing Talents address the aftermath of panic, not the moment of terror. Presence, preparation, and swift containment reduce the number of Fear Checks you're forced to make — the best answer to Fear is never being in a position to need the roll.
+What can help is recovery: Psychoanalyze and Healing Talents address the aftermath of panic, not the moment of confrontation. Presence, preparation, and swift containment reduce the number of Bursts you're forced to face — the best defense is never being in a position to need the roll.
 ****
 
 === The Panic Table
 
-On a failed Fear check (no 6s), roll *d6*:
+On a failed Corruption Burst (no 6s), roll *d6*:
 
 [%header,cols="^1,2,4"]
 |===
@@ -199,7 +196,7 @@ On a failed Fear check (no 6s), roll *d6*:
 
 | *1* | *Fight* | Attack nearest creature (ally or foe) with bare hands. Cannot use weapons. Resolve as a single Brawl attack: *Agility + Brawl skill dice* (no Gear Dice — bare hands only, unarmed damage = 1). Ends automatically after the single strike.
 | *2* | *Flight* | Run at maximum speed (2 zones per round) away from the source for *1d6 rounds*, or until reaching a dead end. Drop held items when the panic begins. An ally may physically restrain the fleeing character (opposed Brawl/Force roll, spending a Slow Action).
-| *3* | *Freeze* | Paralyzed. Cannot move, speak, or act. Allies can move the character (Slow Action). *Exit:* An ally spends a Slow Action and makes a Psychoanalyze (EMP) roll (Difficulty 1) to snap them out, OR the Fear source is no longer visible.
+| *3* | *Freeze* | Paralyzed. Cannot move, speak, or act. Allies can move the character (Slow Action). *Exit:* An ally spends a Slow Action and makes a Psychoanalyze (EMP) roll (Difficulty 1) to snap them out, OR the source is no longer visible.
 | *4* | *Denial* | Treat the supernatural as mundane for rest of scene. Cannot acknowledge entity as real. *Early exit:* An ally may attempt Psychoanalyze (Difficulty 2) to break denial. On success, character acknowledges the entity but is Shaken (−1 die on all rolls for the remainder of the scene).
 | *5* | *Compulsion* | Locked in repetitive behavior. Cannot take meaningful action until ally Psychoanalyze (Difficulty 2) frees them.
 | *6* | *Fugue* | DA takes character sheet. DA narrates character for rest of scene. Player regains control next scene. *Early exit:* An ally may attempt Psychoanalyze (Difficulty 3) to recover the character mid-scene. On success, the player regains control but is disoriented (−2 dice on all rolls for the remainder of the scene).
@@ -215,19 +212,20 @@ After the single attack resolves (hit or miss), the panic breaks and the agent r
 If the attack Breaks the target, proceed with normal Broken/Critical Injury rules.
 The panicked agent gains +1 Corruption from the guilt of harming an ally.
 
-=== Fear Ratings
+[[burst-ratings]]
+=== Burst Ratings
 
-Fear Rating is how the DA classifies how terrifying a creature or event is on a 1–5 scale. It appears in Bestiary stat blocks.
+Burst Rating is how the DA classifies the supernatural intensity of a creature or event on a 1–5 scale. It appears in Bestiary stat blocks and determines how much Corruption a failed Burst check inflicts.
 
-*What Fear Rating does mechanically:*
+*What Burst Rating does mechanically:*
 
-* *Fear Rating 0* = this entity or event does *not* trigger a Fear Check. No check is called.
-* *Fear Rating 1–5* = this entity or event triggers a Fear Check when a character first directly confronts it. The DA calls the check.
-* Fear Rating does *not* modify the dice pool, success threshold, or outcome of the Fear Check itself — the roll is always Wits dice, binary success, regardless of how horrifying the source is.
+* *Burst Rating 0* = this entity or event does *not* trigger a Corruption Burst. No check is called.
+* *Burst Rating 1–5* = this entity or event triggers a Corruption Burst when a character first directly confronts it. On failure, the agent gains Corruption *equal to the Burst Rating*.
+* Burst Rating does *not* modify the dice pool or success threshold — the roll is always Wits dice, binary success. The Rating determines the *consequences* of failure.
 
-*Escalation:* Some creatures have a Fear Rating that increases during an encounter (e.g., "Fear Rating 2 initially; 4 once its nature is understood"). An escalation is a *new trigger* per the rule above — it calls for a new Fear Check even if the character has already made one this scene. An escalation includes: the entity doing something new, getting closer, attacking, revealing a new form, or *increasing its Fear Rating*.
+*Escalation:* Some creatures have a Burst Rating that increases during an encounter (e.g., "Burst Rating 2 initially; 4 once its nature is understood"). An escalation is a *new trigger* per the rule above — it calls for a new check even if the character has already made one this scene. An escalation includes: the entity doing something new, getting closer, attacking, revealing a new form, or *increasing its Burst Rating*.
 
-> *DA Frequency Guidance:* Fear Rating 1–2 — call for one check on first direct confrontation per scene. Fear Rating 3–4 — call for a check each time the entity acts directly against a character (not just passive presence). Fear Rating 5 — call for a check every round the entity is within sight. These are guidelines, not hard rules; the DA adjusts for pacing.
+> *DA Frequency Guidance:* Burst Rating 1–2 — call for one check on first direct confrontation per scene. Burst Rating 3–4 — call for a check each time the entity acts directly against a character (not just passive presence). Burst Rating 5 — call for a check every round the entity is within sight. These are guidelines, not hard rules; the DA adjusts for pacing.
 
 [%header,cols="1,1,4"]
 |===
@@ -240,7 +238,7 @@ Fear Rating is how the DA classifies how terrifying a creature or event is on a 
 | *5* | Annihilating | A Class-5 entity. A tear in physical space. Direct contact with whatever the artifacts are *for*.
 |===
 
-Fear Ratings are a property of supernatural *entities* and *events*, not of individual characters. Add the Fear Rating stat to entity stat blocks in the Bestiary (xref:chapters/19-bestiary.adoc#chapter-bestiary[Bestiary]).
+Burst Ratings are a property of supernatural *entities* and *events*, not of individual characters. Add the Burst Rating stat to entity stat blocks in the Bestiary (xref:chapters/19-bestiary.adoc#chapter-bestiary[Bestiary]).
 
 ---
 

--- a/docs/chapters/09-divisions.adoc
+++ b/docs/chapters/09-divisions.adoc
@@ -5,9 +5,9 @@ In Project Neon Relic, players are sworn members of *The Verdant Covenant*. Beca
 
 Within that Division, players select a *Department* background. At character creation, agents choose *three* starting talents:
 
-* *One Division Talent* — chosen from the Division's talent list in this chapter — *or one General Talent* from xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+* *One Division Talent* — chosen from the Division's talent list in this chapter — *or one General Talent* from xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 * *One Wing, Paradigm, or Department Talent* — chosen from the talent list of the specific Wing, Paradigm, or Department the agent belongs to in this chapter.
-* *One Background Talent* — chosen from the Background Talents list in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+* *One Background Talent* — chosen from the Background Talents list in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 
 Most Division and sub-unit Talents cost *+1 Corruption* to activate, feeding directly into the game's risk-reward loop. Each talent list includes one *Healing* talent usable freely once per session.
 
@@ -16,6 +16,113 @@ Most Division and sub-unit Talents cost *+1 Corruption* to activate, feeding dir
 Unless a Talent explicitly says otherwise, read these abilities as *scene-shaping leverage*, not complete scene resolution. They should reveal a lead, buy time, create access, or improve odds under pressure rather than trivialize artifacts, rivals, or core investigation procedures.
 
 > **Design note — healing talent triggers:** Each Division and sub-unit has one _(Healing)_ talent. Trigger conditions vary intentionally: some require a completed field action (covert objective, combat win), others spend a Shift in deliberate recovery activity. The principle is that the trigger should match each sub-unit's operational philosophy — a Wayfinder heals through learning, a Recovery agent heals through action, a Keeper heals through duty. If a specific session's circumstances make a healing trigger unreachable, the DA may rule a comparable equivalent (e.g., a Warden who performed emergency vault security during active combat may count that as a completed "guard mission").
+
+---
+
+=== Covenant Organizational Structure
+
+....
+                          The Verdant Covenant
+              ┌───────────────────┼───────────────────┐
+              │                   │                   │
+        ┌─────▼─────┐      ┌─────▼─────┐      ┌──────▼─────┐
+        │ WAYFINDER  │      │ RECOVERY   │      │ THE KEEP   │
+        │ (Research  │      │ (Field     │      │ (Vault     │
+        │  & Intel)  │      │  Retrieval)│      │  Security  │
+        └─────┬──────┘      └─────┬──────┘      │ & Logistics│
+              │                   │              └──────┬─────┘
+        ┌─────┴─────┐      ┌─────┴──────────┐   ┌──────┴─────────────┐
+        │           │      │        │        │   │      │      │      │
+   ┌────▼───┐ ┌─────▼──┐ ┌▼───────┐│┌───────▼┐ ┌▼─────┐│┌─────▼┐┌───▼──┐
+   │Research│ │Counter-│ │Ex-Agency│││Acquisi-│ │Cata- │││War-  ││Stack │
+   │Wing    │ │intel   │ │Operative│││tion    │ │logers│││dens  ││(Logi-│
+   │        │ │Wing    │ │         │││Special-│ │      │││      ││stics)│
+   └───┬────┘ └───┬────┘ └───┬─────┘││ist     │ └──┬───┘││└──┬───┘└──┬───┘
+       │          │          │      ││└───┬───┘    │    ││   │       │
+  Desk │     Desk │     Handler    ││ Infiltrator  │  Int│CI │   Quarter-
+  Analyst    Analyst   Breacher    ││ Grifter   Intake  ││Counter- master
+  Field      Field     Ghost   Heavy│ Wheelman  Archivist│Exposure Field
+  Analyst    Analyst          Hitter│           Contain-  │Analyst  Tech
+  Liaison    Technical        │     │           ment      │Infiltr. Inventor
+             Analyst      Enforcer  │           Architect │Investi-
+                          Close Prot│                     │gator
+                          Wrecker   │                     │Vetting
+                                    │                     │Officer
+                            Vault Guardian
+                            Escort Warden
+                            Field Warden
+....
+
+---
+
+=== Global Structure
+
+The Verdant Covenant operates across *five continents* through a cellular structure designed to maintain operational secrecy. No single member — not even the most senior leadership — knows the full scope of the organization.
+
+[%header,cols="2,3,^1"]
+|===
+| Tier | Description | Approximate Count
+
+| *Central Council*
+| The governing body. Location unknown to field agents. Communicates only through intermediaries. Sets strategic priorities, arbitrates inter-division disputes, and authorizes Tier 3 artifact operations.
+| 7–12 members
+
+| *Regional Hubs*
+| Continental coordination centers managing cells within a geographic zone. Each hub has a *Regional Director* (one per Division) who handles assignment routing, resource allocation, and inter-cell mediation. Hubs are not permanent buildings — they rotate locations every 18–24 months.
+| 6 hubs (Americas, Europe, Africa/Middle East, Central Asia, East Asia/Pacific, Oceania)
+
+| *Field Cells*
+| The operational units. Each cell is assigned a home city and operates semi-autonomously within its region. Cells do not know each other's locations unless leadership authorizes contact.
+| ~80–120 active cells globally
+
+| *Extended Network*
+| Civilian contacts, academic consultants, sympathetic law enforcement, and retired agents who provide intelligence and logistical support without being sworn members. They know pieces of the truth — never the whole picture.
+| ~400–600 individuals
+|===
+
+> *Total active personnel:* Approximately 500–700 sworn members globally, plus the extended network. For an organization protecting the world from supernatural threats, this is a skeleton crew — and that's the point. The Covenant cannot afford to be large. Every new member is a potential leak, a potential compromise, a potential vessel for Corruption. Growth is slow, vetting is brutal, and attrition is constant.
+
+> *Secrecy at scale:* The Covenant survives because of three structural safeguards: (1) *cellular isolation* — cells cannot contact each other without hub authorization; (2) *cover diversity* — the organization has no unified public identity, no logo, no letterhead; and (3) *plausible deniability* — the extended network believes they're helping a private research foundation, a government intelligence subcontractor, or an eccentric philanthropist. The truth is compartmentalized so thoroughly that even a captured and interrogated agent can only compromise their own cell and their regional hub contact.
+
+---
+
+=== Inter-Division Dynamics
+
+The three Divisions are not a harmonious machine. They are three departments within a clandestine organization under constant pressure, and they behave accordingly.
+
+==== Why Divisions Sometimes Pursue the Same Artifact
+
+It happens more often than leadership would like:
+
+* *Competing intelligence.* A Wayfinder Research Wing identifies an artifact through historical records. Simultaneously, a Counterintelligence Wing detects a rival faction moving on the same artifact through signals intelligence. Both routes generate a case — and both routes reach different regional hubs before anyone cross-references.
+* *Different threat assessments.* The Keep classifies an artifact as contained (stable, in a museum, not actively dangerous). A Wayfinder analysis disagrees — the artifact is dormant, not contained, and will wake up. Both assessments are valid. Both generate operational responses.
+* *Bureaucratic friction.* A Recovery cell recovers an artifact and begins transport. A Keep team arrives claiming they have transfer authority. Both have legitimate paperwork. The regional hub issued contradictory orders because two Directors signed off on different operational plans.
+
+This is not a bug in the Covenant's structure — it's an unavoidable consequence of compartmentalization. The same secrecy that protects the organization from external threats creates internal blind spots.
+
+==== When Competition Helps
+
+* *Redundancy.* If one cell fails, the other is already in position. The Covenant loses fewer artifacts to single points of failure.
+* *Accountability.* Cells that know another team is watching perform better. Sloppy containment gets reported.
+* *Fresh perspective.* A Wayfinder team and a Recovery team approach the same problem differently. Sometimes the answer requires both approaches.
+
+==== When Competition Hurts
+
+* *Friendly fire.* Two cells operating on the same target without knowing each other's identities can and do interfere with each other's operations. In extreme cases, they've fought.
+* *Resource waste.* Two cells burning DP, contacts, and cover identities on the same artifact is expensive for an organization that can't afford waste.
+* *Standing games.* Cells competing for the same artifact are also competing for Standing. The temptation to sabotage a rival cell's operation — even subtly, even passively — is real.
+
+==== How Leadership Mediates
+
+When overlapping operations are discovered:
+
+. The *Regional Director* for the affected zone contacts both cells and issues a priority ruling — one cell takes point, the other supports or withdraws.
+. If the cells are in different regions, the *Central Council* arbitrates. This takes time. The artifact doesn't wait.
+. In practice, the cell that's closest to containment usually wins priority. The other cell is reassigned with +1 DP as compensation for operational disruption.
+
+> *Design note for DAs:* Inter-division tension is a rich source of Case File complications. A rival Covenant cell showing up mid-operation — are they here to help or to take over? — creates drama that doesn't require supernatural threats. Use it sparingly (once per arc at most) but don't avoid it.
+
+---
 
 == Division 1: The Wayfinder
 
@@ -27,9 +134,7 @@ The Wayfinder Division serves as the primary investigative arm of the Covenant. 
 
 [cols="1,2"]
 |===
-| *Key Attributes* | Wits, Empathy
 | *Primary Attribute* | Wits _(guidance, not a rule — see note below)_
-| *Key Skills* | Investigate, Lore, Tech, Psychoanalyze
 | *Key Skill (Cap 4 at creation)* | Lore
 | *Starting Clearance Level* | 3
 |===
@@ -37,6 +142,8 @@ The Wayfinder Division serves as the primary investigative arm of the Covenant. 
 [NOTE]
 ====
 *Primary Attribute:* "Primary Attribute" in the Key Stats tables is a design recommendation, not a mechanical rule. It describes the attribute most central to a Division's playstyle and is intended as guidance for players deciding where to invest Attribute points — it does not grant any inherent bonus.
+
+*Key Skill:* Each Division has one Key Skill that may be raised to 4 during character creation (the normal cap is 3). This represents the Division's signature competency.
 ====
 
 === The Verdant Codex (Division Item)
@@ -148,9 +255,7 @@ Unlike other Divisions, the Recovery Division has *no internal departments*. Eve
 
 [cols="1,2"]
 |===
-| *Key Attributes* | Strength, Agility
 | *Primary Attribute* | Agility _(guidance, not a rule — see note in Wayfinder Key Stats)_
-| *Key Skills* | Force, Brawl, Firearms, Sneak
 | *Key Skill (Cap 4 at creation)* | Firearms
 | *Starting Clearance Level* | 2
 |===
@@ -243,7 +348,7 @@ Expert in bypassing security, stealing valuable objects, and getting in and out 
 |===
 | Talent | Cost | Effect
 
-| *Ghost Entry* | +1 Corruption | Bypass a single ordinary locked door, security system, or physical barrier without a roll. Against hardened or anomalous protection, gain +3 bonus dice instead. Leave no trace of entry.
+| *Ghost Entry* | +1 Corruption | Bypass a single ordinary locked door, security system, or physical barrier without a roll. Against hardened or anomalous protection, you may spend additional Corruption (1 per required success) to bypass it instead of rolling. Leave no trace of entry.
 | *The Long Con* | +1 Corruption | After at least one scene spent building rapport with an NPC, gain +3 bonus dice on a Manipulate roll to extract one specific piece of information or gain one specific favor.
 | *Clean Getaway* _(Healing)_ | — | Once per session, after successfully completing a theft, infiltration, or escape without triggering an alarm, heal 1 Corruption.
 |===
@@ -274,9 +379,7 @@ Members of the Keep are entrusted with the stewardship of the Covenant's most se
 
 [cols="1,2"]
 |===
-| *Key Attributes* | Empathy, Wits
 | *Primary Attribute* | Empathy _(guidance, not a rule — see note in Wayfinder Key Stats)_
-| *Key Skills* | Lore, Command, Endure, Heal
 | *Key Skill (Cap 4 at creation)* | Command
 | *Starting Clearance Level* | 3
 |===
@@ -436,5 +539,5 @@ Stack agents design, modify, and distribute the tools used by Covenant agents �
 | *The Inquisitor's Gaze* | +1 Corruption | While conversing with someone, instantly know their current Corruption score and whether they are *possessed* (defined as: under active supernatural domination by an entity — their will is overridden, not merely influenced). This does not detect high-Corruption individuals who are acting of their own will, only those actively controlled. The target does not know you used this talent.
 | *Medical Training* | — | Spend a Slow Action and make a *Heal (WIT) roll at Difficulty 2* before an ally rolls their Death Check. On success, the ally rolls d6+1 instead of d6 (death only on a natural 1). On failure, no change. Does not apply to DOA (Result 66) intervention rolls — those are separate emergency Heal actions.
 | *Sanctuary Master* | — | When inside Covenant HQ, automatically succeed on any Lore (WIT) roll regarding the history of a *registered* artifact in the Covenant's inventory. This only applies to artifacts formally catalogued by the Catalogers — unknown or newly recovered artifacts require a normal Lore roll.
-| *The Confessor* _(Healing)_ | — | Spend a quiet moment outside combat listening to one ally share their *Dark Secret* or confess a fear or failing. Both you and the ally heal *1d4 Corruption*. *Limit:* once per target per scene. The same ally may not confess again to receive Corruption healing until at least one scene has passed — partial confessions or trivial admissions don't count.
+| *The Confessor* _(Healing)_ | — | Spend a quiet moment outside combat listening to one ally share a fear, a failing, or a burden they have been carrying. Both you and the ally heal *1d4 Corruption*. *Limit:* once per target per scene. The same ally may not confess again to receive Corruption healing until at least one scene has passed — partial confessions or trivial admissions don't count.
 |===

--- a/docs/chapters/10-equipment.adoc
+++ b/docs/chapters/10-equipment.adoc
@@ -101,7 +101,7 @@ Supplies can be restocked:
 
 * During the *Equipping Phase* at the start of each Case File: any supply can be restocked to its starting die size at no cost (subject to CL restrictions).
 * During a *Case File*, at a credible source: a hospital supply room, a hardware store, an abandoned military cache. The DA determines availability; resupply takes time and may require a Tech or Deft Hands roll (Difficulty 1–2) to access without authorization.
-* HQ *Underground Field Medic* (Personnel): once per Case File, restocks any medical supply to d8 automatically.
+* Cell *Underground Field Medic* (Personnel): once per Case File, restocks any medical supply to d8 automatically.
 
 === Supply Categories
 
@@ -253,91 +253,9 @@ For long-distance intercontinental rapid response only. Requires a licensed pilo
 Coastal/river access. Cannot be followed by road vehicles. Night operations: −1 die on all navigation rolls without instruments.
 |===
 
-=== Vehicle Conflict — Actions and Chase Rules
+=== Vehicle Conflict, Damage, and Breakdown
 
-Vehicle conflict follows the same chase structure as foot chases (xref:chapters/05-combat.adoc#chapter-combat[Combat]), with vehicle-specific modifications.
-
-==== Chase Structure
-
-Vehicle conflict follows the same procedural structure as foot chases (xref:chapters/05-combat.adoc#chapter-combat[Combat]), but uses vehicle-specific position names. *Note:* Foot chases use the combat zone scale (Engaged/Near/Short/Long/Distant). Vehicle chases use the following 5-position *Contact Track* — both measure closing/opening distance but at a scale appropriate to vehicles.
-
-A vehicle chase uses a *Contact Track* — a 5-step range:
-
-[%header,cols="^1,3"]
-|===
-| Position | State
-
-| 1 | *Rammed / Contact* — vehicles are adjacent; ramming and boarding are possible.
-| 2 | *Following* — pursuing vehicle is directly behind; gunfire from rear positions is possible.
-| 3 | *Closing* — pursuit is active; the gap is narrowing or holding.
-| 4 | *Widening* — the pursued vehicle has gained distance; gunfire at Long range only.
-| 5 | *Escaped* — the pursuer has lost visual contact. Chase ends.
-|===
-
-The *pursued vehicle* wins by moving to position 5.
-The *pursuing vehicle* wins by moving to or holding position 1–2.
-
-==== Chase Roll
-
-Each round of a chase, both drivers make a roll:
-
-* *Tech (WIT):* The primary chase skill. Represents reading traffic, anticipating routes, and making calculated maneuvers with vehicles under pressure. Use this for all standard chase rolls.
-* *Tech (AGI):* Used when attempting sudden unpredictable movement — cutting through a building site, reversing against traffic, going off-road. Higher risk, higher reward. The DA may call for AGI + Tech instead of WIT + Tech when a maneuver is more reflexive than tactical.
-
-Both sides roll simultaneously. The side with more successes moves the Contact Track one position in their favor. Ties: no position change.
-
-*Speed modifiers:*
-
-* Each speed tier above the opponent's: +1 die on the chase roll.
-* Each speed tier below the opponent's: −1 die on the chase roll.
-* Handling bonus/penalty applies directly to the roll.
-
-*Pushing a chase roll:* +1 Corruption as normal. The vehicle also takes 1 Wear immediately (the driver is wringing everything out of it).
-
-==== Vehicle Maneuvers
-
-Declare before rolling. No cost unless noted.
-
-[%header,cols="1,2,3"]
-|===
-| Maneuver | Skill | Effect
-
-| *Ram* | Force (STR) | Only available at Contact. Roll Force (STR) opposed by opponent's Tech (WIT). On success: both vehicles take 1–3 damage (equal to Force successes); Contact Track does not change; occupants of both vehicles take 1 Agility damage (thrown around). Cannot ram a vehicle more than two speed tiers faster.
-| *PIT Maneuver* | Tech (WIT) Difficulty 3 | Available at Contact only. On success: target vehicle spins — they lose their next action and the pursuer moves to Contact. On failure: the maneuvering driver's vehicle takes 1 Wear.
-| *Gunfire from Vehicle* | Firearms (standard roll) | Available at Following or closer. −1 die on all shooting rolls from a moving vehicle unless the shooter has the *Stable Platform* talent. A passenger shooting from a moving car is at −1 die; a driver shooting is at −2 dice.
-| *Off-Road Break* | Tech (AGI) Difficulty 2 | Drive off the paved route. On success: move one position on the Contact Track toward Escaped. On failure: vehicle takes 1 Wear and no position change. If in a vehicle with off-road penalty (Motorcycle in rain, Van, Helicopter equivalent): add +1 Difficulty.
-| *Blending In* | Sneak (WIT) Difficulty 2 | Abandon the direct chase and disappear into traffic or terrain. On success: move directly to Escaped (skip the track). On failure: no change and opponent moves one step toward Contact.
-|===
-
-=== Vehicle Damage
-
-When a vehicle takes damage (from ramming, gunfire, or environmental hazard):
-
-. Roll damage as normal. Subtract the vehicle's AR.
-. Remaining damage is applied as *Wear* (not as Strength damage to occupants, unless the damage is extraordinary).
-. At 5 Wear: vehicle stops. Characters inside may take 1 Agility damage from the sudden stop (Endure Difficulty 1 to avoid).
-. *Structural damage:* At DA discretion, a catastrophic hit (4+ damage after AR) may cause a specific system failure: blown tire (−2 die Handling), cracked windscreen (blindness penalties for driver), fuel leak (vehicle stops at end of scene unless repaired).
-
-*Repairing Wear:*
-
-* Tech roll (Difficulty 2) + 30 minutes + access to tools: clear 1 Wear.
-* Full garage repairs (overnight, proper tools): restore to starting Reliability.
-* Field repairs without tools: Tech Difficulty 4, clears 1 Wear, cannot reduce below 3.
-
-=== Vehicle Breakdown
-
-When Reliability reaches 5 Wear, the vehicle stops. Roll d6:
-
-[%header,cols="^1,4"]
-|===
-| Roll | Breakdown Type
-
-| 1–2 | *Total Failure.* Engine seized. Not repairable in the field. Needs a tow and a full day of garage work (restore to 2 Wear, 4 hours minimum).
-| 3–4 | *Serious Fault.* Driveable at Slow speed only. Tech (Difficulty 3) to clear in field; otherwise full garage repair.
-| 5–6 | *Inconvenient Failure.* Battery, tire, or small component. Tech (Difficulty 1) to address in 15 minutes. 1 Wear remains after fix.
-|===
-
-A breakdown during an active chase is resolved immediately: the broken-down vehicle is treated as *Contact* on the next round (the pursuer closes automatically).
+Full vehicle conflict rules — the Contact Track, chase rolls, speed modifiers, vehicle maneuvers (Ram, PIT, Gunfire, Off-Road Break, Blending In), vehicle damage, Wear, and breakdown — are in xref:chapters/appendix-combat.adoc#vehicle-chase-rules[Appendix: Advanced Combat → Vehicle Conflict].
 
 ---
 
@@ -404,7 +322,7 @@ Repairing gear requires **time**, **parts**, and a **Tech** roll.
 
 [NOTE]
 ====
-*Vehicle repair* uses a separate system — see <<vehicle-damage,Vehicle Damage and Repair>> earlier in this chapter (Tech roll Difficulty 2, 30 minutes per 1 Wear cleared). Do not use this table for vehicle Wear.
+*Vehicle repair* uses a separate system — see xref:chapters/appendix-combat.adoc#vehicle-damage[Appendix: Advanced Combat → Vehicle Damage] (Tech roll Difficulty 2, 30 minutes per 1 Wear cleared). Do not use this table for vehicle Wear.
 ====
 
 **Success:** Each success restores Gear Bonus by 1 (up to the item's maximum).
@@ -434,7 +352,7 @@ scavenged or on-hand parts). Roll the Junk Die after completing repairs:
 | Hardware Components    | d8  | Electronics, communications gear, vehicle parts
 | Medical Supplies       | d10 | See Resource Dice table in Consumables section
 | Specialized Parts      | d6  | High-tech, rare, or artifact-adjacent repairs only — not scavengeable
-| Covenant Cache Parts   | d12 | HQ-supplied; best quality; no acquisition roll needed
+| Covenant Cache Parts   | d12 | Covenant-supplied; best quality; no acquisition roll needed
 |===
 
 ---
@@ -552,12 +470,14 @@ These are *background advantages* intrinsic to Stack training — always active,
 | *Faster Repairs*      | Quick Repairs take 5 minutes instead of 15. Full Repairs take 2 hours instead of a full Shift.
 | *Parts Economy*       | Stack agents never step down a Junk Die on a successful repair — only failed repairs consume parts.
 | *Known Contacts*      | Once per case, a Stack agent can source **Hardware Components (d8)** without a Covenant requisition (a contact comes through).
-| *Workshop Access*     | At HQ, Stack agents may use the <<facility-covenant-armorer,Covenant Armorer>> facility at no additional cost, even before it is fully built. They improvise the bench themselves.
+| *Workshop Access*     | At a cell location, Stack agents may use the <<facility-covenant-armorer,Covenant Armorer>> capability at no additional cost, even before it is fully established. They improvise the bench themselves.
 |===
 
 [NOTE]
 ====
-*Simplified crafting option (DA guidance):* The full parts economy (Junk Die, Hardware Components, Specialized Parts, Covenant Cache Parts) can feel like a lot to track. DAs running lighter sessions may substitute a single *Parts Die (d8)* for all non-vehicle repairs. Roll it like any Resource Die after each repair — 1–2: step down; 3+: no change. Replenish it at HQ or during Equipping Phase. This is a deliberate simplification, not the default rule.
+*Default crafting rule:* All non-vehicle repairs use a single *Parts Die (d8)* as the parts tracker. Roll it like any Resource Die after each repair — 1–2: step down; 3+: no change. Replenish it at a cell location or during Equipping Phase. This keeps crafting simple and fast at the table.
+
+*Detailed crafting option (DA guidance):* For groups that want more granular resource tracking, the full parts economy (Junk Die, Hardware Components, Specialized Parts, Covenant Cache Parts) described earlier in this section provides deeper material management. Use it when your table enjoys logistical gameplay — but the Parts Die is the default rule.
 ====
 
 > **Cross-reference:** Stack Division full description, background options, and Talents

--- a/docs/chapters/11-artifacts.adoc
+++ b/docs/chapters/11-artifacts.adoc
@@ -3,7 +3,7 @@
 
 This chapter covers the game's treatment of *Occult Artifacts* — how they work, how they are used, and how they are contained. It includes the Artifact Die and Activation Procedure, the Corruption cost system, emission rules (Aura, Pulse, Burst), the Containment-First play principle, a starting catalog of period artifacts, DA guidelines for designing new artifacts, Containment Profiles, Containment Rituals, and the optional Artifact Decay rule.
 
-Artifact mechanics tie directly to the Corruption system in xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Ch 8 — Corruption, Fear & Healing]. Division Instrument interactions (Verdant Codex, Verdant Satchel, Warden's Bracer) are described in xref:chapters/09-divisions.adoc#chapter-divisions[Ch 9 — Divisions].
+Artifact mechanics tie directly to the Corruption system in xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Ch 8 — Corruption and Healing]. Division Instrument interactions (Verdant Codex, Verdant Satchel, Warden's Bracer) are described in xref:chapters/09-divisions.adoc#chapter-divisions[Ch 9 — Divisions].
 
 ---
 
@@ -217,7 +217,7 @@ Carrying an artifact that has been *activated at least once this Case File* impo
 
 [NOTE]
 ====
-This passive Corruption gain is an *additional Corruption source* not listed in the Ch 8 Corruption sources table. Add it as a situational entry: "Carrying an activated artifact (Encumbered by it) | +1 per scene" — see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Ch 8 — Corruption, Fear & Healing].
+This passive Corruption gain is an *additional Corruption source* not listed in the Ch 8 Corruption sources table. Add it as a situational entry: "Carrying an activated artifact (Encumbered by it) | +1 per scene" — see xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Ch 8 — Corruption and Healing].
 ====
 
 === Stacking Artifacts

--- a/docs/chapters/12-headquarters.adoc
+++ b/docs/chapters/12-headquarters.adoc
@@ -1,21 +1,29 @@
 [#chapter-headquarters]
 = Headquarters Management
 
-This chapter covers the Covenant Safehouse — your cell's persistent base of operations — and the two systems attached to it: the *HQ Upgrade Tree* (spending Development Points to expand facilities and capabilities) and *Covenant Standing* (the cell's reputation within the Covenant, which gates access to higher-tier resources and privileged information).
+This chapter covers the *City Network* — your cell's persistent base of operations spread across a single city — and the two systems attached to it: the *HQ Upgrade Tree* (spending Development Points to expand capabilities) and *Covenant Standing* (the cell's reputation within the Covenant, which gates access to higher-tier resources and privileged information).
 
-Facilities are permanent once built. They do not require ongoing maintenance or upkeep costs — the Covenant handles logistics. The cost is in Development Points and time, not recurring expenditure (#648).
+Capabilities are permanent once established. They do not require ongoing maintenance or upkeep costs — the Covenant handles logistics. The cost is in Development Points and time, not recurring expenditure (#648).
 
-In YZE games, a persistent base of operations is a fundamental pillar of long-term campaign play. In _Mutant: Year Zero_ it's the Ark; in _Forbidden Lands_, the Stronghold; in _Vaesen_, Castle Gyllencreutz. In Project Neon Relic, the *Headquarters* serves as a mechanical anchor, a psychological safe haven from Corruption, and an economic resource sink giving players ownership over the world.
+In YZE games, a persistent base of operations is a fundamental pillar of long-term campaign play. In _Mutant: Year Zero_ it's the Ark; in _Forbidden Lands_, the Stronghold; in _Vaesen_, Castle Gyllencreutz. In Project Neon Relic, the *City Network* serves as a mechanical anchor, a psychological safe haven from Corruption, and an economic resource sink giving players ownership over the world.
 
-== The Covenant Safehouse
+== The City Network
 
-At campaign onset, players acquire a default headquarters representing a localized branch of the Covenant. Thematically appropriate locations include:
+At campaign onset, the DA designates a *home city* for the cell. The Covenant does not issue a single fortified building — it gives the team a *network of capabilities* spread across the city: a rented lab here, a safe house there, a contact at the morgue, a storage locker behind a laundromat. Each capability is a separate location within the urban landscape.
 
-* An abandoned 1970s underground civil defense bunker
-* A defunct mall arcade operating as a front
-* A decommissioned subway maintenance station
+The number of agents in a cell varies by assignment:
 
-Initially, the space is entirely derelict. Access to deeper subterranean levels, sealed vaults, or secure storage rooms requires the expenditure of *Development Points (Dev Points / DP)*, awarded collectively for completing Case Files and securing artifacts.
+* *Major cities* (New York, London, Tokyo, Berlin) — 4–6 agents, full Covenant support infrastructure
+* *Mid-tier cities* (Portland, Lyon, Prague) — 3–4 agents, moderate support
+* *Remote outposts* (small towns, rural regions) — 2–3 agents, minimal support, longer response times for Covenant requests
+
+At campaign start, the cell has three baseline assets:
+
+* A *primary safe house* — an apartment, back-room office, or rented commercial space that serves as the team's meeting point and rest location
+* A *dead drop* — a pre-arranged location for receiving Covenant communications (coded messages left in a library book, a specific payphone number, a P.O. box under a cover identity)
+* A *cover identity package* — each agent has one set of fabricated credentials sufficient for routine law enforcement encounters
+
+Additional capabilities are acquired through the *HQ Upgrade Tree* using Development Points. Each upgrade represents a new asset established somewhere in the city — a facility, a contact, or a capability.
 
 === Earning Development Points
 
@@ -38,47 +46,63 @@ DP is spent immediately during downtime or banked for future Case Files. There i
 
 ---
 
+== Vault Storage Rules
+
+All recovered artifacts *must* be transferred to the Covenant's central vault — this is a non-negotiable Covenant regulation, not a suggestion. Field agents (Recovery, Wayfinder) do not have unsupervised access to vault facilities; artifact custody is the Keep's exclusive domain.
+
+=== Field Custody
+
+During a Case File, agents may temporarily hold artifacts in the field. This is expected and necessary — the vault is not in the next room. However:
+
+* *Artifacts must be in transit or in active containment at all times.* Storing an active artifact in the safe house overnight without proper containment (Occult Lab containment vessels or Corruption Dampening Vault) is a Covenant infraction: *−1 Standing* and a formal report filed by Internal CI.
+* *Transfer to vault must occur during the Aftermath phase.* The cell is expected to hand off recovered artifacts to a Keep transport team before beginning downtime. Failure to transfer is treated as unauthorized retention: *−2 Standing* and an Internal CI investigation (the DA decides consequences based on the cell's explanation).
+* *Gear requisition follows proper channels.* Taking Covenant equipment off-books — removing items from the Armory without logging them, borrowing from another cell's stores, or acquiring restricted items outside the Equipping Phase — risks *−1 Standing* per incident if discovered. The DA determines whether a given action qualifies.
+
+> *Design intent:* These rules exist to create tension, not to punish players. The interesting situations arise when circumstances prevent proper transfer — the Keep transport is compromised, the artifact can't be moved safely, or the cell needs to use a contained artifact to resolve a crisis. The Standing cost is the price of those decisions.
+
+---
+
 [[hq-upgrade-tree]]
 == HQ Upgrade Tree
 
-Upgrades are organized into three tiers. Higher-tier upgrades require specific lower-tier facilities to be built first.
+Upgrades are organized into three tiers. Higher-tier upgrades require specific lower-tier capabilities to be established first. Each upgrade represents a new asset within the city — a facility, a contact arrangement, or a capability the cell can draw on.
 
 === Tier 1 — Base Infrastructure
 
-*Tier 1 upgrades have no prerequisites.* Any can be built from the start of the campaign.
+*Tier 1 upgrades have no prerequisites.* Any can be established from the start of the campaign.
 
 [%header,cols="2,^1,3,3"]
 |===
-| Facility | DP Cost | Narrative | Mechanical Benefit
+| Capability | DP Cost | Narrative | Mechanical Benefit
 
 | *Secure Communications Room*
 | 2
-| Encrypted landline bank, reel-to-reel tape vault, scrambled HAM radio array. No one outside the Covenant can track calls to or from this room.
+| A rented back office with encrypted landline bank, reel-to-reel tape vault, and scrambled HAM radio array. No one outside the Covenant can track calls to or from this location.
 | +1 die on Command (EMP) rolls when coordinating with Covenant contacts between Case Files. One free contact call per downtime (no CL requirement).
 
 | *Basic Medical Bay*
 | 2
-| Field triage table, locked pharmaceutical cabinet, sterilized instruments. Not elegant, but it keeps people alive.
+| A discreet clinic arrangement — a struck-off doctor's back room, a veterinary practice after hours, or a university lab with a sympathetic researcher. Not elegant, but it keeps people alive.
 | During downtime, each character recovers *2 additional Attribute points of their choice* (beyond normal rest). One character may also attempt to clear a non-lethal Critical Injury (Heal (WIT) Difficulty 2; success removes the injury without Attribute loss).
 
 | *Safeguard Protocol*
 | 1
-| A reinforced back room, a false-wall escape hatch, and a single-use alarm linked to a trip-wire perimeter. Not a fortress — a head start.
-| If the HQ is attacked, the team gains *+1 die on the initiative roll* during the first round of any HQ defense scene. One random NPC contact (if any recruited) survives even if the HQ falls.
+| A tripwire perimeter on the primary safe house, a dead-drop early-warning system, and pre-planned extraction routes from every regular meeting point. Not a fortress — a head start.
+| If any cell location is attacked, the team gains *+1 die on the initiative roll* during the first round of any defense scene. One random NPC contact (if any recruited) survives even if the location falls.
 |===
 
 === Tier 2 — Operational Support
 
-*Tier 2 upgrades each require at least one Tier 1 facility to be built first.* Prerequisites listed per upgrade.
+*Tier 2 upgrades each require at least one Tier 1 capability to be established first.* Prerequisites listed per upgrade.
 
 [%header,cols="2,^1,2,3,2"]
 |===
-| Facility | DP Cost | Prerequisite | Narrative | Mechanical Benefit
+| Capability | DP Cost | Prerequisite | Narrative | Mechanical Benefit
 
 | *The Microfiche Archive*
 | 3
 | Secure Communications Room
-| Wall-to-wall collection of newspaper records, police reports, and occult journals on microfilm. A full-time archivist — never seen without reading glasses and cigarettes — maintains the stacks.
+| A rented storage unit converted into a wall-to-wall collection of newspaper records, police reports, and occult journals on microfilm. A full-time archivist — never seen without reading glasses and cigarettes — maintains the stacks.
 | Permanent *+2 Gear bonus* to Lore (WIT) rolls when researching prior to departure. Also grants access to one free Historical Contact per Case File (a scholar, librarian, or researcher who owes the Covenant a favor).
 
 > *Division interaction:* A Wayfinder agent using the Verdant Codex in the Archive gains both the Codex's +1 bonus die and the Archive's +2 Gear bonus on the same Lore (WIT) roll.
@@ -86,7 +110,7 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 | *The Occult Laboratory*
 | 3
 | Basic Medical Bay
-| Sterile environment with chemical analysis tools, EMF meters, and purpose-built containment vessels. Smells permanently of ozone and burnt copper.
+| A sterile environment in a university basement or condemned hospital wing — chemical analysis tools, EMF meters, and purpose-built containment vessels. Smells permanently of ozone and burnt copper.
 | Safely identify unknown artifact triggers without risking accidental activation. Lore (WIT) roll to identify artifact tier is Difficulty 1 here (instead of 2). Failed identification rolls do not trigger the artifact.
 
 > *Division interaction:* A Wayfinder agent using the Verdant Codex in the Lab gains +1 bonus die on the Lore (WIT) identification roll in addition to the Lab's reduced difficulty.
@@ -94,24 +118,24 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 | *The Black-Market Armory*
 | 3
 | Safeguard Protocol
-| Reinforced vault with analog combination locks, stocked through underground contacts the Covenant officially denies knowing. The manifest is updated by hand.
+| A reinforced storage unit or garage bay with analog combination locks, stocked through underground contacts the Covenant officially denies knowing. The manifest is updated by hand.
 | During the Equipping Phase, all agents may requisition items up to *CL 4* regardless of personal CL. This does not change the agent's CL for any other purpose. High-capacity weapons no longer consume an extra DP to requisition repeatedly.
 
 | *The Faraday Cage*
 | 4
 | Secure Communications Room
-| Lead-lined room sealed against electromagnetic and supernatural interference. No phones work inside. No spirits answer. Silence like the inside of a safe.
-| One character per downtime can heal up to *4 Corruption*. Requires a full day (one Case File downtime period) inside — the character is unavailable for other downtime activities that day. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Ch 8 — Corruption, Fear & Healing] for all Corruption healing rules; the Faraday Cage is an exception that applies only during downtime at HQ. +
+| A lead-lined room in a rented basement, sealed against electromagnetic and supernatural interference. No phones work inside. No spirits answer. Silence like the inside of a safe.
+| One character per downtime can heal up to *4 Corruption*. Requires a full day (one Case File downtime period) inside — the character is unavailable for other downtime activities that day. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Ch 8 — Corruption and Healing] for all Corruption healing rules; the Faraday Cage is an exception that applies only during downtime at a cell location. +
 *Division interaction:* A Keep agent whose Warden's Bracer provides passive Corruption absorption may still use both the Bracer's per-session absorption AND heal in the Faraday Cage — they do not conflict.
 |===
 
 === Tier 3 — Advanced Operations
 
-*Tier 3 upgrades require at least two Tier 2 facilities to be built.* Prerequisites listed per upgrade.
+*Tier 3 upgrades require at least two Tier 2 capabilities to be established.* Prerequisites listed per upgrade.
 
 [%header,cols="2,^1,2,3,2"]
 |===
-| Facility | DP Cost | Prerequisite | Narrative | Mechanical Benefit
+| Capability | DP Cost | Prerequisite | Narrative | Mechanical Benefit
 
 | *Field Intelligence Network*
 | 5
@@ -135,8 +159,8 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 | *Safe House Network*
 | 6
 | Secure Communications Room + Safeguard Protocol
-| A constellation of bolt-holes, friendly business fronts, and sympathetic innkeepers spread across the region — pre-loaded with emergency cash, clean IDs, and a contact pager (each safe house maintains a dedicated pager number registered to a cutout identity).
-| The team always has a fallback safe house available in any new investigation city, no setup required. Removes all "no safe place to rest" environmental penalties while away from HQ. On failure during the HQ Compromise event, one safe house absorbs the breach instead of HQ itself (one-time use; must rebuild, 3 DP).
+| A constellation of bolt-holes, friendly business fronts, and sympathetic contacts spread across the city and its neighboring region — pre-loaded with emergency cash, clean IDs, and a contact pager (each safe house maintains a dedicated pager number registered to a cutout identity).
+| The team always has a fallback safe house available in any investigation area, no setup required. Removes all "no safe place to rest" environmental penalties while in the field. On failure during a Compromise event, one safe house absorbs the breach instead of the compromised location (one-time use; must rebuild, 3 DP).
 |===
 
 ---
@@ -145,7 +169,7 @@ Upgrades are organized into three tiers. Higher-tier upgrades require specific l
 
 Beyond infrastructure, the team can recruit individual *contacts and specialists* using Development Points. Personnel provide passive benefits between Case Files and can be called upon during active missions at the DA's discretion.
 
-Personnel are not combatants. If the HQ is directly attacked, they flee or hide — they do not fight to defend the base.
+Personnel are not combatants. If a cell location is directly attacked, they flee or hide — they do not fight to defend it.
 
 *Activating Personnel:* Requesting a personnel benefit during a Case File requires only a narrative declaration ("I contact the Dispatcher") — no roll is required unless the DA determines the contact is under surveillance, compromised, or operating outside their stated capability. In those cases, use Command (EMP) Difficulty 2 to reach them. Personnel benefits listed as "once per Case File" reset at the start of each new Case File.
 
@@ -166,7 +190,7 @@ Personnel are not combatants. If the HQ is directly attacked, they flee or hide 
 | *Black-Market Fence*
 | 3
 | A procurement specialist with connections to military surplus, private security disposals, and the occasional Consortium dropout.
-| Once per Case File, requisition one *CL 4 item* without burning the team's CL. The request takes 48 hours in-game. Item arrives at HQ; no trail.
+| Once per Case File, requisition one *CL 4 item* without burning the team's CL. The request takes 48 hours in-game. Item arrives at a designated dead drop; no trail.
 
 | *Covenant Scholar*
 | 3
@@ -176,23 +200,23 @@ Personnel are not combatants. If the HQ is directly attacked, they flee or hide 
 | *Signals Technician*
 | 4
 | An ex-NSA field tech — burned, paranoid, and very good at making equipment do things it shouldn't.
-| Once per Case File, plant a real-time audio tap on a rival faction's communication line (Investigate (WIT) Difficulty 2; success = one scene of intercepted intel). Also: +1 die on all Tech (WIT) rolls within HQ.
+| Once per Case File, plant a real-time audio tap on a rival faction's communication line (Investigate (WIT) Difficulty 2; success = one scene of intercepted intel). Also: +1 die on all Tech (WIT) rolls at the Secure Communications Room.
 |===
 
 ---
 
-== HQ Compromise and Attack
+== Network Compromise and Attack
 
-The safehouse is not invulnerable. Rivals, government black-ops, and supernatural entities may target it directly.
+The city network is not invulnerable. Rivals, government black-ops, and supernatural entities may target individual locations or the network as a whole.
 
 === The Threat Meter
 
-The DA tracks a hidden *Threat Meter* ranging from 0 to 6. When it reaches 6, the safehouse is directly targeted.
+The DA tracks a hidden *Threat Meter* ranging from 0 to 6. When it reaches 6, part of the network is directly targeted.
 
 The Threat Meter increases by 1 when:
 
 * The team uses explosives or automatic weapons fire in a populated area
-* A rival faction agent escapes alive with knowledge of the team's base location
+* A rival faction agent escapes alive with knowledge of a cell location
 * The team fails to contain a corruption leak (*active artifact left overnight in open storage* — not inside the Corruption Dampening Vault or Occult Lab containment vessels)
 * A deceased agent's civilian identity is linked to the Covenant by law enforcement
 * The team's *case pressure escalates to crisis and breaks containment* — meaning an Organization reaches Escalation 3 on the Operations Board and the Case File ends without resolution
@@ -207,20 +231,20 @@ When the Threat Meter hits 6, the DA triggers a *Compromise Event* before the ne
 |===
 | Roll | Compromise Type
 
-| 1–2 | *Surveillance* — A rival team has a long lens on the safehouse. The HQ is not breached, but the Threat Meter resets to 4 (not 0). All Tier 2+ facilities are temporarily offline until the surveillance is identified and dealt with (a mini-investigation, 1 Case File).
-| 3–4 | *Break-In* — Evidence of entry, triggered sensors, one personnel contact goes missing. One facility is trashed — to determine which, number all built facilities in construction order and roll d6 (re-roll if the result exceeds your facility count). The trashed facility is unavailable until repaired at half DP cost. Threat Meter resets to 3.
-| 5 | *Direct Assault* — A hostile team hits the safehouse hard. Run a full HQ defense scene (see below). One facility destroyed on failure; none if the team holds. Threat Meter resets to 2.
-| 6 | *Burned* — The safehouse is fully compromised. No defense scene is run — the breach happens between Case Files. The team receives a single scene to extract critical equipment and personnel before the location is abandoned. Lose all Tier 1–2 facilities; Tier 3 facilities survive only if the Safe House Network is built (they relocate to the fallback address). Threat Meter resets to 0. All banked DP intact; rebuild begins at the new location on the next Case File's Aftermath.
+| 1–2 | *Surveillance* — A rival team has eyes on one of the cell's locations. The location is not breached, but the Threat Meter resets to 4 (not 0). All Tier 2+ capabilities associated with that location are temporarily offline until the surveillance is identified and dealt with (a mini-investigation, 1 Case File).
+| 3–4 | *Break-In* — Evidence of entry at one location, triggered sensors, one personnel contact goes missing. One capability is compromised — to determine which, number all established capabilities in acquisition order and roll d6 (re-roll if the result exceeds your capability count). The compromised capability is unavailable until re-established at half DP cost. Threat Meter resets to 3.
+| 5 | *Direct Assault* — A hostile team hits a cell location hard. Run a full defense scene (see below). One capability destroyed on failure; none if the team holds. Threat Meter resets to 2.
+| 6 | *Burned* — One or more locations are fully compromised. No defense scene is run — the breach happens between Case Files. The team receives a single scene to extract critical equipment and personnel before the locations are abandoned. Lose all Tier 1–2 capabilities at the affected locations; Tier 3 capabilities survive only if the Safe House Network is established (they relocate to fallback addresses). Threat Meter resets to 0. All banked DP intact; rebuilding begins on the next Case File's Aftermath.
 |===
 
-=== HQ Defense Scene
+=== Defense Scene
 
 If the compromise event results in a direct assault (roll 5 only — the *Burned* result on 6 does not use this procedure), run it as a structured conflict:
 
 * The DA establishes attacker strength (Grunt × team size or Elite × half team size from the Bestiary).
 * Safeguard Protocol gives +1 die on the team's first initiative roll.
-* Characters who are *Broken* during an HQ defense scene follow standard Broken rules (Critical Injury + out of fight; see xref:chapters/07-health-damage-armor.adoc#chapter-health[Ch 7 — Health, Damage & Armor]). Stabilization must occur before end of scene to prevent the Dying state.
-* If the attackers are driven off or destroyed: Threat Meter resets to 2; HQ is undamaged.
+* Characters who are *Broken* during a defense scene follow standard Broken rules (Critical Injury + out of fight; see xref:chapters/07-health-damage-armor.adoc#chapter-health[Ch 7 — Health, Damage & Armor]). Stabilization must occur before end of scene to prevent the Dying state.
+* If the attackers are driven off or destroyed: Threat Meter resets to 2; location is undamaged.
 * If the team retreats: roll on the Compromise Event table again (once) to determine collateral damage (re-roll results of 5 or 6).
 
 > *Optional — Named Threats:* If the Threat Meter has recently been driven up by a specific rival faction, the DA may assign a Named Threat as the assault leader. This escalates the scene but awards +2 DP if the Named Threat is captured or killed. An *arc* is a sequence of 3–5 Case Files centered on a shared antagonist or artifact thread; the DA determines arc boundaries.
@@ -250,7 +274,7 @@ It never applies to individual agents — the Covenant evaluates teams, not hero
 | Score | Rank | What It Means
 
 | 0–4   | *Unknown*           | The cell is new or unproven. Covenant resources are minimal; access is limited to Tier 1 upgrades and standard requisitions. *Information access:* Operational briefings only — the Case Brief as written, no supplementary Covenant archive material. Lore (WIT) rolls using Covenant research assets gain no bonus dice.
-| 5–9   | *Acknowledged*      | The cell has delivered results. Wayfinder and Keep division contacts treat the cell as credible. *Information access:* Standard archive access (Microfiche Archive if built); classified materials are redacted when sent. Lore (WIT) research rolls gain +1 die from Covenant channels (not from personal skill).
+| 5–9   | *Acknowledged*      | The cell has delivered results. Wayfinder and Keep division contacts treat the cell as credible. *Information access:* Standard archive access (Microfiche Archive if established); classified materials are redacted when sent. Lore (WIT) research rolls gain +1 die from Covenant channels (not from personal skill).
 | 10–14 | *Trusted*           | The cell handles significant cases. The Covenant routes priority case files through them. Keep reinforcements available. *Information access:* Full archive access; classified materials available with DA approval. Lore (WIT) research rolls gain +2 dice from Covenant channels. One additional pre-case clue per Case File (DA provides it with the Case Brief).
 | 15–19 | *Honored*           | The cell has operated at the highest levels. Named contacts within Covenant leadership. *Information access:* Unrestricted access including Covenant historical records and cold case files. Lore (WIT) research rolls gain +3 dice from Covenant channels. Cold case files provided on request (no roll required).
 | 20    | *Covenant Elite*    | Fewer than a dozen cells in history have reached this. The Covenant treats the cell as irreplaceable. No resource limits. Legacy recorded. *Information access:* Unrestricted; may request records from allied organizations. Lore (WIT) research rolls gain +3 dice plus one automatic success from Covenant channels.
@@ -267,7 +291,7 @@ All gains are cumulative — multiple criteria can apply in a single case.
 |===
 | Trigger | Standing Gain | Notes
 
-| Successful containment of primary artifact           | +2 | Artifact recovered and secure in transport or HQ
+| Successful containment of primary artifact           | +2 | Artifact recovered and secure in transport or Covenant vault
 | Zero civilian exposure (no witnesses, no media)      | +1 | Bonus on top of other gains; lost if any civilian knowledge confirmed
 | Rival faction neutralized (operative captured/fled)  | +2 | Does not apply if rival escaped with artifact
 | Tier 3 artifact recovered intact                     | +3 | Replaces standard containment +2 for Tier 3 cases
@@ -297,7 +321,7 @@ Covenant knows. It always knows.
 | Artifact lost to rival faction or enemy             | −3 | Lost in the field, stolen post-recovery, or destroyed improperly
 | Agent compromised, turned, or gone rogue            | −4 | Applies whether the agent is caught or simply disappears
 | Case abandoned mid-operation                        | −2 | Cell withdrew without artifact containment or Covenant approval
-| HQ location exposed to non-Covenant entities        | −4 | Does not require an attack; exposure alone is the failure
+| Cell location exposed to non-Covenant entities       | −4 | Does not require an attack; exposure alone is the failure
 | Cover story collapsed (public incident attributed to cell) | −3 | Any incident where the cell is publicly connected to supernatural events
 |===
 
@@ -318,30 +342,30 @@ cannot be purchased with Development Points alone.
 |===
 | Reward | Min. Standing | Effect
 
-| *Tier 2 HQ Upgrades Unlocked*       | 5  | Cell may begin purchasing Tier 2 facilities (see <<hq-upgrade-tree>>). DP cost unchanged.
+| *Tier 2 Upgrades Unlocked*           | 5  | Cell may begin establishing Tier 2 capabilities (see <<hq-upgrade-tree>>). DP cost unchanged.
 | *CL 3 Requisition Access*           | 5  | During Equipping Phase, the *entire cell* may requisition items up to CL 3 — even agents whose personal CL is still 2. This does not change individual agents' personal CL score; it raises the cell-wide equipping cap only.
 | *Keep Reinforcements*               | 10 | Once per arc (3–5 Case Files), request a second Covenant cell for 1 Case File of operational support. They arrive equipped; they do not share Standing.
-| *Tier 3 HQ Upgrades Unlocked*       | 10 | Cell may begin purchasing Tier 3 facilities. DP cost unchanged.
+| *Tier 3 Upgrades Unlocked*           | 10 | Cell may begin establishing Tier 3 capabilities. DP cost unchanged.
 | *CL 4 Requisition Access*           | 10 | During Equipping Phase, the entire cell may requisition items up to CL 4 regardless of personal CL. High-tier equipment available via formal request. Does not change individual agents' personal CL scores.
 | *Classified Archive Access*         | 15 | Wayfinder Division shares files on cold cases and artifact history normally restricted to senior analysts. +2 dice on Lore (WIT) and Investigate (WIT) rolls during pre-departure research.
 | *Covenant Asset Call-In*            | 15 | Once per campaign arc, the Covenant deploys a named asset — insider at a government agency, black-market arms contact, demolitions specialist — to assist directly.
 | *Legacy Standing Bonus*             | 20 | When a cell member retires or dies, their Keeper (xp replacement PC) begins play with 3 Standing already gained toward the cell total.
-| *Unrestricted HQ Upgrade*           | 20 | Once per arc, build any single HQ upgrade for 0 DP. The Covenant funds it directly.
+| *Unrestricted Upgrade*               | 20 | Once per arc, establish any single upgrade for 0 DP. The Covenant funds it directly.
 |===
 
 ---
 
-=== Standing and HQ Upgrade Gates
+=== Standing and Upgrade Gates
 
-Some HQ facilities already require specific prerequisites (DP investment and prior
-facilities in the upgrade tree). **Standing gates** apply *in addition to* those
-prerequisites for the most sensitive upgrades — meeting the DP and facility
-prerequisites is not sufficient alone. The facility cannot be built until both the
-DP/facility prerequisite AND the Standing threshold are met.
+Some capabilities already require specific prerequisites (DP investment and prior
+capabilities in the upgrade tree). **Standing gates** apply *in addition to* those
+prerequisites for the most sensitive upgrades — meeting the DP and capability
+prerequisites is not sufficient alone. The capability cannot be established until both the
+DP/capability prerequisite AND the Standing threshold are met.
 
 [%header,cols="3,1,1"]
 |===
-| Facility | DP Cost | Min. Standing
+| Capability | DP Cost | Min. Standing
 
 | *Microfiche Archive* (Tier 2)           | 3 DP | 5
 | *Occult Laboratory* (Tier 2)            | 3 DP | 5
@@ -351,12 +375,13 @@ DP/facility prerequisite AND the Standing threshold are met.
 | *Safe House Network* (Tier 3)           | 6 DP | 15
 | *Covenant Armorer* (Tier 3)             | 5 DP | 10
 |===
+|===
 
-> **Design Note:** Standing gates exist because Tier 2 and 3 facilities represent
+> **Design Note:** Standing gates exist because Tier 2 and 3 capabilities represent
 > the Covenant extending significant trust to a cell. An unproven cell does not get
 > access to the Occult Laboratory or the Corruption Dampening Vault. They have to
 > earn it. These gates are separate from the DP economy — you can bank enough DP
-> to build the Vault immediately at Standing 10; you cannot build it at Standing 9
+> to establish the Vault immediately at Standing 10; you cannot establish it at Standing 9
 > regardless of DP.
 
 ---
@@ -400,13 +425,13 @@ When the player cell and a rival cell intersect on the same Case File, resolve s
 
 === When to Advance the Threat Meter
 
-The Threat Meter should tick up *during play*, not as a between-Case-File bookkeeping exercise. Announce increases openly when they result from visible player actions (explosives, escaped witnesses). Only advance it silently when the cause is something the players genuinely wouldn't know about (a rival faction operative spotting the HQ, a deceased agent's ID surfacing). Keep the meter itself hidden — the dread of not knowing how close they are to a Compromise Event is the point.
+The Threat Meter should tick up *during play*, not as a between-Case-File bookkeeping exercise. Announce increases openly when they result from visible player actions (explosives, escaped witnesses). Only advance it silently when the cause is something the players genuinely wouldn't know about (a rival faction operative spotting a cell location, a deceased agent's ID surfacing). Keep the meter itself hidden — the dread of not knowing how close they are to a Compromise Event is the point.
 
 Run Compromise Events when the meter hits 6 — do not delay them into the next arc. They're not punishments; they're Case Files. Treat the Surveillance or Break-In results as seeds for a mini-investigation, not as flat negative outcomes.
 
-=== Pacing HQ Upgrades
+=== Pacing Upgrades
 
-A typical campaign arc (3–5 Case Files) should end with the cell completing one Tier 2 facility if they're playing clean. Don't accelerate this — the upgrade tree is meant to feel like tangible progress over a campaign, not an early session loadout. The DP triggers are calibrated so that a cell succeeding on every award earns roughly 7–9 DP per Case File; a Tier 2 facility costs 3–4 DP. Pace accordingly.
+A typical campaign arc (3–5 Case Files) should end with the cell establishing one Tier 2 capability if they're playing clean. Don't accelerate this — the upgrade tree is meant to feel like tangible progress over a campaign, not an early session loadout. The DP triggers are calibrated so that a cell succeeding on every award earns roughly 7–9 DP per Case File; a Tier 2 capability costs 3–4 DP. Pace accordingly.
 
 The Faraday Cage is the single most important upgrade in the tree. Don't introduce it until the cell has had at least one scene where Corruption was a genuine crisis. Unlocking the Cage should feel like survival, not optimization.
 

--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -1,94 +1,8 @@
 [#chapter-advancement]
-= Advancement, Talents, and Dark Secrets
+= Advancement and Talents
 
-This chapter covers three connected systems: *Dark Secrets* (character hooks that generate XP when they complicate the mission), *Advancement* (the per-session XP debrief and how XP is spent on skills and talents), and *Talents* (General, Division, and Background abilities). Each agent has one Dark Secret and one Background Talent from creation; additional General and Division Talents are purchased with XP during play.
+This chapter covers two connected systems: *Advancement* (the per-session XP debrief and how XP is spent on skills and talents) and *Talents* (General, Division, and Background abilities). Each agent has one Background Talent from creation; additional General and Division Talents are purchased with XP during play.
 
-== Dark Secrets
-
-A *Dark Secret* is a specific fact from your character's past — something true, hidden, and consequential. It is not a personality flaw or a general backstory. It names something: an event, a decision, a relationship that *someone wants to remain buried*.
-
-Dark Secrets serve two purposes in the game:
-
-. *Roleplay device.* They give the DA a hook. When the investigation points toward your secret — when the evidence room comes up, when the contact's name surfaces — things get complicated. That's the point.
-. *XP question.* At the end of each session, the DA asks: *"Did your Dark Secret complicate the mission?"* If yes: +1 XP. That is the entirety of the mechanical system.
-
-There are no rules for voluntary activation, mandatory exposure, or faction consequences. If your secret surfaces, play it. Whether it surfaced because you chose to bring it in or because the DA did, the XP question applies the same way. Everything else is fiction.
-
-=== Faction Consequences
-
-Some Dark Secrets name a connection to a rival faction or outside organization (*The Competing Employer*, *The Loyalty Debt*, etc.). When a secret of this type is exposed during play — to the team, to the Covenant, or to the faction itself — the DA uses the following as a default consequence framework:
-
-* *Exposed to the team:* No mechanical consequence. The team chooses how to respond in fiction. The XP trigger still applies.
-* *Exposed to the Covenant:* The cell loses *−1 Standing* immediately. If the agent is found to have actively aided a rival faction, the loss is *−3 Standing* and the agent is placed on formal review (one Case File of reduced Equipping Phase access: CL reduced by 1 for that Case File only).
-* *Exposed to the rival faction:* The faction gains a leverage hold on the agent. Once per arc, the DA may present the agent with a task from the faction (not a mandatory action — but refusal has narrative consequences the DA controls).
-
-These consequences apply only when the secret is actually exposed in play — not when the player mentions it at the table. If it never surfaces, it never triggers. The DA should use exposure sparingly and always in service of the narrative.
-
-> *Choosing a secret:* Pick one from your Division's example list below, or write your own. The only requirement: it must be specific enough that the DA can look at it and ask "what happens if the investigation goes *here*?"
-
----
-
-=== Wayfinder Dark Secrets
-
-[%header,cols="2,5"]
-|===
-| Secret | Details
-
-| *The Fabricated Report* | You submitted a field analysis that was false. You buried evidence linking a recovered artifact to a civilian casualty event. The truth is in a file somewhere. The file has a reference number. You know it.
-| *The Missing Informant* | You cultivated a civilian informant for three years — a librarian with a genuine gift for pattern recognition. When the case closed, they disappeared. You did not report them missing. You don't know what happened, but you fear you do.
-| *Unauthorized Correspondence* | You have been communicating with a researcher outside the Covenant — someone who reached out through channels that shouldn't exist. Their information has been accurate. You have told them more than authorized. You don't know who they work for.
-| *The Siphoned Archive* | You copied a restricted section of the Verdant Codex and hid the transcription in a dead drop you maintain. Your reason was professional — there were patterns in the restricted material that connected to an active case. Your superior has since died. Nobody else knows about the copy or the dead drop.
-| *The Wrong Conclusion* | Your analysis on the Alderman Acquisition (Case File #7 — or whatever year's equivalent the DA sets) directly caused the team to misidentify and release a contained artifact. What they released hurt three people. The official record says the release was accidental. You know it followed your recommendation.
-|===
-
----
-
-=== Recovery Dark Secrets
-
-[%header,cols="2,5"]
-|===
-| Secret | Details
-
-| *The One You Left* | You extracted a target from a hostile situation and got the artifact out clean. But you left someone behind who could have survived with ten more minutes. You made a judgment call. They did not make it out. They had a name. You remember it.
-| *The Side Deal* | You negotiated a private arrangement with a civilian who held an artifact: they handed it over, you gave them something in return. Not money — something Covenant. A name. A suppressed report. A real asset. The covenant doesn't know the trade terms.
-| *The Competing Employer* | Early in your career — before the Covenant — you did contract work for a private intelligence firm. You never fully severed the relationship. They knew about you when you were recruited. You have not told anyone. At least one person at the firm knows you are Covenant now.
-| *The Planted Evidence* | On a recovery that was politically complicated, you placed evidence at a scene to close a civilian case that was getting too close to the truth. An innocent person was charged. The case was closed. You closed it deliberately.
-| *The Kept Artifact* | You found a secondary artifact on a site — smaller, overlooked. You logged the primary. The secondary is in a fireproof box in your apartment. You tell yourself you're studying it. That has been true for sixteen months. You have not told anyone.
-|===
-
----
-
-=== Keep Dark Secrets
-
-[%header,cols="2,5"]
-|===
-| Secret | Details
-
-| *The Unauthorized Transfer* | You moved an artifact between vault cells without clearance — you believed its listed containment protocol was incorrect. You were probably right. But the transfer created a window during which something influenced three junior staff members. The behavioural anomalies are in the health records. You signed the transfer log as routine maintenance.
-| *The Suppressed Incident* | Fourteen months ago, containment in your section failed briefly. Nothing escaped. But a visitor was present — a civilian consultant who should never have been in that corridor. They survived. You suppressed the incident log entry. The consultant now returns your calls with a very specific kind of urgency.
-| *The Loyalty Debt* | You owe a significant personal debt to someone who is a member of *The Vantablack Compact*. The debt predates your Covenant service. You have not acted on it, but you have also not reported the contact. The debt is the kind that has a due date.
-| *The Copyist* | You maintain a personal archive — transcribed containment protocols, artifact property notes, Warden's Bracer readings — for a project you tell yourself is academic. The project is not approved. The archive exists on paper, in your handwriting, in your home. You know what happens if it's found.
-| *The Broken Warden* | A trainee under your supervision suffered a containment exposure event eighteen months ago. The official report says they resigned for personal reasons. They are alive, institutionalized under a false name you arranged, and the Covenant does not know they exist. You visit them every few weeks. They are getting worse.
-|===
-
----
-
-=== Stack Dark Secrets (Keep — Logistics Department)
-
-Use this list only if the character belongs to *The Keep* and selected *Stack (Logistics)* as their department during character creation. *Stack characters use this table instead of the general Keep Dark Secrets table* — not in addition to it. This table reflects the specific nature of logistics-channel secrets and is calibrated to the same narrative weight as the other three division tables.
-
-[%header,cols="2,5"]
-|===
-| Secret | Details
-
-| *The Off-Books Supply Chain* | You have a procurement network that the Covenant doesn't know about. It operates faster and quieter than official channels. You trust it because you built it. Two of your suppliers have connections you would struggle to explain cleanly.
-| *The Substitution* | When a mission-critical component was unavailable, you substituted something that looked right, worked in the moment, and was not what you logged it as. Nothing went wrong. But the mission notes, the equipment manifest, and the Covenant's records all describe gear that was not actually used.
-| *The Blackmail File* | You stumbled onto something about a senior Covenant official during a logistics audit. You photographed the document. You have not used it, have not shown it to anyone, have no plan to. But you kept the photograph. It is in a very safe place.
-| *The Freelance Job* | Before — or possibly overlapping with — your Covenant service, you completed contract work for private clients that was unambiguously not sanctioned. The work involved resources and knowledge that came from your Covenant position. You were careful. You do not think you were seen.
-| *The Faulty Log* | The inventory manifest for the last six months has an inconsistency — a recurring item that is always logged as consumed but which you know was not always needed. Someone above you in the logistics chain is running a parallel set of numbers. You have not reported it because you're not certain you are not also implicated.
-|===
-
----
 == Advancement
 
 Experience Points (XP) are the game's *only* advancement currency. They are awarded at the end of each *session* — not at the end of a Case File. A session corresponds to one real-world play period (typically 2–4 hours). XP is awarded through a structured *Debriefing* that the DA runs immediately at session end. The DA asks the group a series of questions — for every "yes," each player receives *1 XP* (maximum *5 XP per session*):
@@ -99,7 +13,7 @@ Experience Points (XP) are the game's *only* advancement currency. They are awar
 
 | 1 | Did you participate in the session? _(Automatic +1 XP — this is always yes.)_
 | 2 | Did you risk your life for a fellow Covenant member or an innocent civilian?
-| 3 | Did your Dark Secret complicate the mission, or did you heavily interact with your *Anchor*? _(An Anchor is a significant personal relationship or obligation from the character's life outside the Covenant — a family member, a close friend, a mentor. It is defined at character creation. See xref:chapters/03-character-creation.adoc#chapter-character-creation[Ch 3 — Character Creation].)_
+| 3 | Did you interact heavily with your *Anchor*, or did a personal connection complicate the mission? _(An Anchor is a personal solace — a ritual, a memory, a relationship — that grounds the agent against the toll of the work. It is defined at character creation. See xref:chapters/02-character-creation.adoc#chapter-character-creation[Ch 2 — Character Creation].)_
 | 4 | Did the team successfully secure or contain an Occult Artifact?
 | 5 | Did you learn something new and significant about the supernatural threat or rival factions?
 |===
@@ -134,8 +48,8 @@ The following shows a typical post-session debrief for *Agent Yusuf Demi*, a Kee
 | Yes — Yusuf entered the artifact room to pull Agent Skovgaard to safety when triple-layer containment cracked.
 | +1 XP
 
-| Did your Dark Secret complicate the mission, or did you interact heavily with your Anchor?
-| Yes — the mission contact recognised Yusuf from the unauthorised transfer incident; Yusuf had to manage that conversation while the team worked.
+| Did you interact heavily with your Anchor, or did a personal connection complicate the mission?
+| Yes — Yusuf spent a quiet evening shift writing a letter to his mother in Istanbul, a ritual that grounds him after containment work.
 | +1 XP
 
 | Did the team successfully secure or contain an Occult Artifact?
@@ -160,7 +74,7 @@ The following shows a typical post-session debrief for *Agent Yusuf Demi*, a Kee
 
 This is the *canonical General Talents list* used at character creation and during XP advancement. General Talents use the same concise format as the rest of the manuscript's talent lists: talent name plus effect text, with tags only when mechanically relevant.
 
-> *Healing Tag and Stacking:* Talents with the _(Healing)_ tag can heal Corruption. Each tagged talent's trigger is independent, but a character may heal a maximum of *3 Corruption per session* from Healing-tagged General Talents combined — regardless of how many they possess or how many triggers fire. This cap does not apply to Corruption healed by HQ facilities, the Warden's Bracer, or Division talents.
+> *Healing Tag and Stacking:* Talents with the _(Healing)_ tag can heal Corruption. Each tagged talent's trigger is independent, but a character may heal a maximum of *3 Corruption per session* from Healing-tagged General Talents combined — regardless of how many they possess or how many triggers fire. This cap does not apply to Corruption healed by city network capabilities, the Warden's Bracer, or Division talents.
 
 [%header,cols="2,4"]
 |===

--- a/docs/chapters/15-case-file.adoc
+++ b/docs/chapters/15-case-file.adoc
@@ -461,6 +461,43 @@ No safe containment is possible without all three. Containment Truths are always
 
 When the agents discover information during play, the DA physically hands them the player-facing side of the card. This makes progress tangible — the growing stack of Information Cards on the table is a visible measure of how much the team has pieced together.
 
+==== Example: A Simple Investigation Web
+
+The following shows how Locations, NPCs, and Information Cards connect for a small case. The artifact is a cursed pocket watch recovered from an antiques dealer. Three Containment Truths (CT) must be discovered before the team can safely contain it.
+
+....
+                        ┌──────────────────┐
+                        │  L1: Antiques     │
+                        │  Shop (crime scene)│
+                        │  NPC: N1 (owner)  │
+                        │  Info: I1, I2     │
+                        └────────┬─────────┘
+                                 │
+                   ┌─────────────┼─────────────┐
+                   │             │             │
+          ┌────────▼───────┐  ┌──▼──────────┐  ┌▼───────────────┐
+          │ L2: County     │  │ L3: Victim's│  │ L4: University │
+          │ Records Office │  │ Apartment   │  │ Library        │
+          │ NPC: N2 (clerk)│  │ NPC: N3     │  │ NPC: N4 (prof) │
+          │ Info: I3 [CT1] │  │ Info: I4    │  │ Info: I5 [CT2] │
+          └────────────────┘  └──────┬──────┘  └───────┬────────┘
+                                     │                 │
+                               ┌─────▼─────────────────▼──┐
+                               │ L5: St. Anne's Church     │
+                               │ NPC: N5 (parish priest)   │
+                               │ Info: I6 [CT3]            │
+                               └───────────────────────────┘
+....
+
+* *I1* — The watch was sold by a man matching the description of a known Compact fixer. _(Leads to L2.)_
+* *I2* — The previous owner died holding the watch; cause of death listed as "acute senescence." _(Leads to L3.)_
+* *I3 [CT1]* — County deed records show the watch was part of a 1923 estate sale from St. Anne's Parish. _(Containment Truth: provenance.)_
+* *I4* — The victim's journal mentions a recurring dream about a church bell. _(Leads to L4 and L5.)_
+* *I5 [CT2]* — Professor Harlan's research notes describe the watch's activation trigger: it responds to sustained skin contact. _(Containment Truth: trigger.)_
+* *I6 [CT3]* — The parish priest knows the original blessing that sealed the watch in 1923 — a specific Latin invocation. _(Containment Truth: quiescence.)_
+
+The web ensures that every Location leads to at least one other Location, every Containment Truth has a field source, and no single failure can block the investigation entirely. If the agents miss I3 at the records office, HQ can pull the deed history on Day 6 (HQ Fallback).
+
 [[hq-safety-valve]]
 === The HQ Safety Valve
 
@@ -558,14 +595,14 @@ Roll two d6s: the first die is the tens digit, the second is the units digit.
 | 11 | Cassette tape               | Recordings of events before they happen; playback causes hemorrhaging
 | 12 | Pocket watch                | Stops time in a 5-meter radius for d6 rounds; user ages accelerated
 | 13 | Hospital chart              | Accurate medical diagnosis of anyone named in it; reading causes symptoms
-| 14 | Photograph                  | Shows what the subject fears most; viewing drives Fear check
+| 14 | Photograph                  | Shows what the subject fears most; viewing drives Corruption Burst
 | 15 | Book (journal/diary)        | Compels reader to continue until finished; knowledge is real and dangerous
 | 16 | Vinyl record                | Music causes compliance in listeners within earshot; player is compelled too
 | 21 | Military dog tags           | Reveals the moment of death of anyone who held the tags
 | 22 | Children's toy              | Locates any child within a mile; toy speaks in the missing child's voice
 | 23 | Radio receiver              | Picks up transmissions from parallel timelines; maddening incoherence
 | 24 | Compass                     | Points toward the nearest supernatural entity regardless of direction
-| 25 | Mirror (compact or full)    | Shows true form of all entities reflected; cannot be looked away from
+| 25 | Mirror (compact or full)    | Shows true form of all entities reflected; compels the gaze of anyone who looks into it
 | 26 | Surgical instrument         | Wounds inflicted by it cannot be healed by normal medicine
 | 31 | Film reel                   | Footage shows crimes not yet committed; watching causes +1 Corruption
 | 32 | Blueprint or schematics     | Construction following these plans creates a corrupted space; builders don't survive
@@ -581,7 +618,7 @@ Roll two d6s: the first die is the tens digit, the second is the units digit.
 | 46 | Painting or portrait        | Subject watches through it; communicates, manipulates, hungers
 | 51 | Typewriter                  | Text typed on it becomes true; reality reconfigures to match
 | 52 | Map (hand-drawn)            | Accurate to a location that doesn't exist — yet
-| 53 | Clock (grandfather or wall) | Slows time in a building-sized area; those inside age normally
+| 53 | Clock (grandfather or wall) | Slows time in a building-sized area; those outside the zone age normally while those inside experience minutes as hours
 | 54 | Syringe / vial of fluid     | Injection grants a specific ability; dependency forms within 24 hours
 | 55 | Musical instrument          | Performance compels specific emotional response; player loses control
 | 56 | Weapon (pistol, knife)      | Kills what cannot be killed; user marked for retaliation by its kind
@@ -728,9 +765,9 @@ Resolve all pending healing — physical injuries requiring downtime phases, men
 
 A *downtime phase* is a discrete rest-and-recovery period lasting approximately one week of in-world time. It is the basic unit of between-case recovery. Physical Critical Injuries and Broken conditions clear at a rate of one phase per requirement, with each successful Heal roll advancing progress. The DA determines how many downtime phases are available based on the gap between cases — a rushed reassignment may allow only one phase, while an extended stand-down may allow three or four.
 
-A *Psychoanalyze campaign* is a sustained treatment track for mental injuries: Corruption-driven trauma, persistent fear responses, or Broken conditions rooted in occult exposure. It requires a willing agent, an accessible therapist or Covenant psychologist, and at least one downtime phase per treatment step. The number of steps depends on severity. A Psychoanalyze campaign may be interrupted by a new Case File assignment — incomplete treatment does not reset, but the condition does not improve until it resumes. The mechanics for Psychoanalyze are in xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+A *Psychoanalyze campaign* is a sustained treatment track for mental injuries: Corruption-driven trauma, persistent panic responses, or Broken conditions rooted in occult exposure. It requires a willing agent, an accessible therapist or Covenant psychologist, and at least one downtime phase per treatment step. The number of steps depends on severity. A Psychoanalyze campaign may be interrupted by a new Case File assignment — incomplete treatment does not reset, but the condition does not improve until it resumes. The mechanics for Psychoanalyze are in xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing].
 
-Corruption recovery via *Full Rest* requires a minimum of one downtime phase with no artifact exposure, no field work, and no significant stress. This reduces Corruption by 1. Multiple phases spent in genuine recovery can reduce Corruption further. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing] for all recovery methods.
+Corruption recovery via *Full Rest* requires a minimum of one downtime phase with no artifact exposure, no field work, and no significant stress. This reduces Corruption by 1. Multiple phases spent in genuine recovery can reduce Corruption further. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing] for all recovery methods.
 
 === 3. HQ Investment Phase
 
@@ -741,15 +778,32 @@ Spend accumulated Development Points on facility upgrades and personnel recruitm
 Each player answers one question about their agent's downtime:
 
 * *What did your agent do to decompress?* (Establishes or reinforces Anchor connections)
-* *Did anything about the last case follow you home?* (Seeds Dark Secret development or Corruption narrative)
+* *Did anything about the last case follow you home?* (Seeds Corruption narrative or personal complications)
 * *Did you reach out to anyone — or did anyone reach out to you?* (Develops NPC relationships and potential complications)
 
 The DA may use Personal Phase answers to seed hooks for the next Case File. Agents who skip the Personal Phase or describe isolation gain *+1 Corruption* — the Covenant's work consumes those who don't maintain human connections.
 
 === 5. Briefing
 
-The Covenant assigns the next Case File. Assignment quality reflects the cell's reputation:
+The Covenant assigns the next Case File. Understanding the *assignment pipeline* clarifies why some cells get better cases than others — and why "better" doesn't mean "easier."
 
-* *Standing 0–4 (Unknown):* The team receives whatever case nobody else wants.
-* *Standing 5–14 (Acknowledged / Trusted):* Cases matching the team's demonstrated competencies.
-* *Standing 15+ (Honored / Elite):* The team may request specific assignments or receive priority cases with advanced intel.
+==== The Assignment Pipeline
+
+Case Files originate from three sources:
+
+. *Wayfinder intelligence* — The Research or Counterintelligence Wing identifies an artifact through historical analysis, signals intercept, or field report. This generates a *Proactive Case* — the Covenant knows about the threat before it escalates.
+. *Incident response* — A civilian report, media story, or law enforcement anomaly triggers a Covenant alert. This generates a *Reactive Case* — the artifact is already active, and the clock is already ticking.
+. *Cold case reactivation* — A previously dormant artifact resurfaces, a containment failure is detected, or new evidence reopens a closed file. This generates a *Legacy Case* — old, complicated, and poorly documented.
+
+The *Regional Hub Director* for the cell's zone evaluates incoming cases against available cells and assigns based on three factors:
+
+* *Capability match* — Does the cell have the skills, equipment, and Standing to handle this case? A cell with no Occult Laboratory shouldn't be sent to identify a Tier 3 artifact.
+* *Proximity* — Is the cell close enough to respond within the case's time pressure? Reactive Cases demand fast deployment; Proactive Cases allow more flexibility.
+* *Standing* — Higher Standing doesn't mean easier cases. It means the Covenant trusts the cell with *more dangerous and sensitive* ones. A Standing 15 cell receives priority Tier 3 cases, Named Threat operations, and cross-regional assignments — the missions where failure has catastrophic consequences.
+
+==== Assignment Quality by Standing
+
+* *Standing 0–4 (Unknown):* The cell receives whatever case nobody else wants — cold cases with bad documentation, low-tier artifacts in inconvenient locations, cleanup after another cell's failure.
+* *Standing 5–9 (Acknowledged):* Cases matching the cell's demonstrated competencies. The regional hub routes cases that play to the cell's strengths.
+* *Standing 10–14 (Trusted):* The cell receives advance briefing material (one additional pre-case clue), priority on time-sensitive Reactive Cases, and occasional cross-regional assignments.
+* *Standing 15+ (Honored / Elite):* The cell may *request* specific assignments or receive priority tasking on high-value targets. This is not cherry-picking easy work — it's being trusted with the cases that would destroy a less experienced team. The Covenant's most dangerous operations go to its most proven cells.

--- a/docs/chapters/16-travel.adoc
+++ b/docs/chapters/16-travel.adoc
@@ -88,14 +88,14 @@ Use route choices to create tradeoffs:
 |===
 | Vehicle | Speed | Capacity (Enc.) | Noise | Notes
 
-| *On Foot* | Slow | Personal carry only | Silent | Surveillance-proof but exhausting. Extended travel over multiple shifts risks exhaustion — the DA may require an Endure (AGI) roll (Difficulty 2) to avoid arriving Broken.
-| *Bicycle* | Slow-Medium | +4 Enc. (rack) | Silent | Urban movement; can enter places cars can't. Cannot outrun a vehicle chase.
+| *On Foot* | Slow | Personal carry only | Silent | Low profile; hard to track in crowds. Extended travel over multiple shifts risks exhaustion — the DA may require an Endure (AGI) roll (Difficulty 2) to avoid arriving Broken.
+| *Bicycle* | Slow-Medium | +4 Enc. (rack) | Silent | Urban movement; can cut through alleys, parks, and stairways that vehicles cannot follow. Outrunning a car on open road is impossible, but terrain advantage in dense urban areas is significant.
 | *Compact Car (e.g., Honda Civic)* | Medium | 20 Enc. | Low | Inconspicuous. +1 die on Sneak rolls to avoid surveillance.
 | *Full-Size Sedan (e.g., Crown Vic)* | Medium | 25 Enc. | Low | The standard Covenant field vehicle. Reliable. Boring. Perfect.
 | *Panel Van* | Medium | 50 Enc. | Medium | Can transport personnel and equipment. −1 die on Sneak rolls; noticed in residential areas.
-| *Pickup Truck* | Medium | 40 Enc. | Medium | Useful in rural terrain. Bed cargo is visible. Common enough to blend in.
+| *Pickup Truck* | Medium | 40 Enc. | Medium | Useful in rural terrain. Bed cargo is visible unless covered (bed cap or tarp). Common enough to blend in.
 | *Motorcycle* | Fast | 10 Enc. | Medium | Best for tailing, losing a tail, and city navigation. Terrible in bad weather (−2 dice in rain/snow).
-| *Helicopter (chartered)* | Very Fast | 30 Enc. | High | Expensive; requires a Contact. Arrival is conspicuous. Never use near civilian populations if covert.
+| *Helicopter (chartered)* | Very Fast | 30 Enc. | High | Expensive; requires a Contact. Arrival is conspicuous — rotor noise announces you from a distance. Never use near civilian populations if covert.
 | *Boat (motorized)* | Slow-Medium | 60 Enc. | Medium | Coastal and river access. Cannot be followed by road. Not available in every scenario.
 |===
 

--- a/docs/chapters/17-rival-factions.adoc
+++ b/docs/chapters/17-rival-factions.adoc
@@ -135,7 +135,7 @@ Use the Ember Accord when the problem is not only possession of the artifact but
 | STR | AGL | WIT | EMP | Skills
 | 3 | 2 | 2 | 4 | Manipulate 3, Lore 2, Fight 2
 |===
-_Accord zealots have no armor and rarely carry firearms. They fight desperately when cornered and are immune to Intimidate. A devoted leader (the Herald) has EMP 5, Lore 3, and causes a Fear Check (Rating 2) on a first encounter._
+_Accord zealots have no armor and rarely carry firearms. They fight desperately when cornered and are immune to Intimidate. A devoted leader (the Herald) has EMP 5, Lore 3, and causes a Corruption Burst (Rating 2) on a first encounter._
 
 ---
 
@@ -173,6 +173,18 @@ Use MJ-12 when the threat is surveillance, black-bag extraction, official deniab
 | 4 | 3 | 3 | 2 | Shoot 3, Fight 2, Investigate 2, Tech 1
 |===
 _MJ-12 field agents wear concealed ballistic vests (Armor 2) and operate in pairs. They have authority to detain, restrict access, and commandeer resources. They are not equipped for supernatural phenomena and gain Corruption normally from artifact exposure._
+
+****
+*How much does the government actually know?*
+
+The US government's awareness of occult artifacts is fragmented and deliberately compartmentalized. MJ-12 is not a unified policy — it is a black-budget program buried inside the Department of Defense, known to fewer than two dozen officials. Most of the federal government has no idea artifacts exist.
+
+MJ-12 knows artifacts are real and dangerous. They do not understand *why* artifacts exist, what the entities are, or what containment actually requires. Their approach is military: secure the site, extract the object, study it in a controlled facility, and weaponize anything useful. This approach has produced catastrophic failures — classified incidents at research sites that MJ-12 attributes to operator error rather than acknowledging the artifacts' inherent nature.
+
+The Covenant remains independent for three reasons: (1) it predates MJ-12 by centuries and has institutional knowledge that no government program can replicate; (2) the Covenant operates globally across jurisdictions that no single nation controls; and (3) every time a government has attempted to monopolize artifact containment, the results have been worse — the Covenant's archives contain multiple case studies of state-run containment programs that collapsed, leaked, or were corrupted by the artifacts themselves.
+
+MJ-12 and the Covenant are aware of each other. The relationship is hostile but restrained — MJ-12 considers the Covenant an unauthorized non-state actor operating on US soil, and the Covenant considers MJ-12 dangerously incompetent. Neither can afford open conflict. The Cold War provides cover for both: MJ-12 hides its operations behind national security classification, and the Covenant hides behind the assumption that secret societies are conspiracy theories.
+****
 
 ---
 

--- a/docs/chapters/18-notable-members.adoc
+++ b/docs/chapters/18-notable-members.adoc
@@ -25,6 +25,7 @@ What follows is a curated excerpt from those archives: notable members from acro
 | *Marco Polo* | 1254–1324 | Recovery | Used his famous travels as a smokescreen to extract dangerous Silk Road artifacts.
 | *Nicolas Flamel* | 1330–1418 | Keep | Guarded a highly unstable, reality-warping artifact masked as the "philosopher's stone."
 | *Marsilio Ficino* | 1433–1499 | Wayfinder | Translated the _Corpus Hermeticum_ to decipher ancient artifact triggers for field agents.
+| *Julie d'Aubigny* | 1673–1707 | Recovery | 17th-century swordfighter, opera singer, and adventurer whose public duels and theatrical career provided cover for artifact retrievals across France and the Low Countries. Her combat skill and talent for disguise made her one of the earliest Recovery agents to operate openly in hostile territory.
 | *Heinrich Cornelius Agrippa* | 1486–1535 | Keep | Authored the _Three Books of Occult Philosophy_ as a coded manual for Covenant catalogers.
 | *Paracelsus* | 1493–1541 | Wayfinder | Pioneered treatments for the physical symptoms of early-stage Corruption — the toll that direct artifact handling exacts on unshielded agents.
 | *John Dee* | 1527–1608 | Wayfinder | Used Enochian magic and Elizabeth I's court to intercept Spanish occult weaponry.
@@ -39,6 +40,7 @@ What follows is a curated excerpt from those archives: notable members from acro
 
 | *Athanasius Kircher* | 1602–1680 | Keep | Categorized cursed Egyptian artifacts and built the first deep-subterranean vaults beneath Rome.
 | *Emanuel Swedenborg* | 1688–1772 | Wayfinder | Mapped patterns of artifact-induced altered perception, developing techniques to navigate occult sensory disruption.
+| *William Blake* | 1757–1827 | Wayfinder | Poet, painter, and visionary mystic whose claimed visions of angels and demons were documented encounters with bound entities. His illuminated manuscripts encoded artifact locations and entity behavioral patterns in allegorical imagery that Wayfinder analysts still reference.
 | *Count of St. Germain* | 1712–1784 | Recovery | Used his alleged "immortality" as cover for a generational lineage of Recovery agents.
 | *Giovanni Battista Belzoni* | 1778–1823 | Recovery | Posed as an archaeologist to extract cursed Egyptian antiquities from collapsing tombs.
 | *Sir Richard Francis Burton* | 1821–1890 | Recovery | Master of disguise and linguistics who infiltrated forbidden cities to retrieve stolen relics.

--- a/docs/chapters/19-bestiary.adoc
+++ b/docs/chapters/19-bestiary.adoc
@@ -19,7 +19,7 @@ NAME
 
 Attributes: STR X | AGI X | WIT X | EMP X
 Armor Rating: X (type)
-Fear Rating: X (0 for humans unless marked)
+Burst Rating: X (0 for humans unless marked)
 
 Skills:
   Force X | Brawl X | Endure X
@@ -40,7 +40,7 @@ Motivation: One sentence describing what this adversary wants in this scene.
 * *Attributes* are used exactly as PC attributes — as both dice pool maximums and health pools. When Strength reaches 0, the adversary is Broken.
 * *Skills not listed* default to 0.
 * *Armor Rating* functions identically to PC armor — Gear dice rolled against incoming damage.
-* *Fear Rating* applies to supernatural entities and rare humans. 0 = no Fear check triggered. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+* *Burst Rating* applies to supernatural entities and rare humans. 0 = no Corruption Burst triggered. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing].
 * *Broken State* defines what happens when the adversary's Strength hits 0.
 * *Damage types* in special abilities should specify their type and target: Physical (STR or AGI), Mental (WIT or EMP), or Corruption. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 
@@ -66,7 +66,7 @@ Special: [One sentence if applicable, or "—"]
 ----
 Attributes: STR 3 | AGI 2 | WIT 2 | EMP 3
 Armor Rating: 0
-Fear Rating: 0
+Burst Rating: 0
 
 Skills:
   Force 1 | Brawl 2
@@ -96,7 +96,7 @@ Motivation: Protect the artifact/ritual/site. They believe you are desecrating s
 ----
 Attributes: STR 4 | AGI 3 | WIT 3 | EMP 4
 Armor Rating: 1 (concealed vest — improvised, not rated)
-Fear Rating: 0
+Burst Rating: 0
 
 Skills:
   Force 2 | Brawl 3 | Endure 2
@@ -131,7 +131,7 @@ They want to delay, contain, or eliminate you before word reaches the Covenant.
 ----
 Attributes: STR 5 | AGI 4 | WIT 3 | EMP 2
 Armor Rating: 4 (Tactical Kevlar — military spec)
-Fear Rating: 0
+Burst Rating: 0
 
 Skills:
   Force 3 | Brawl 3 | Endure 3
@@ -141,7 +141,7 @@ Skills:
 
 Special Abilities:
   Suppressive Discipline — MJ-12 agents do not panic under mundane violence.
-  Supernatural Fear checks are still required, but they roll with *+1 bonus die*
+  Supernatural Corruption Burst checks are still required, but they roll with *+1 bonus die*
   (training).
 
   Tactical Communication — If two or more MJ-12 agents are present, they act
@@ -169,7 +169,7 @@ operatives if exposed. No witnesses.
 ----
 Attributes: STR 3 | AGI 3 | WIT 4 | EMP 3
 Armor Rating: 2 (ritual garments — treated leather with artifact weaving)
-Fear Rating: 2 (the things they've done are visible in their eyes)
+Burst Rating: 2 (the things they've done are visible in their eyes)
 
 Skills:
   Brawl 2 | Endure 3
@@ -210,7 +210,7 @@ inconvenience that should have been avoided.
 ----
 Attributes: STR 4 | AGI 3 | WIT 1 | EMP 0
 Armor Rating: 2 (force of coherence — the entity's structural integrity)
-Fear Rating: 2 (objects move wrong; the air gets cold)
+Burst Rating: 2 (objects move wrong; the air gets cold)
 
 Skills:
   Force 3
@@ -252,7 +252,7 @@ strong emotional state.
 ----
 Attributes: STR 8 | AGI 3 | WIT 2 | EMP 0
 Armor Rating: 5 (crystallized occult energy — the artifact's self-defense)
-Fear Rating: 4 (wrongness of form; the geometry of it shouldn't work)
+Burst Rating: 4 (wrongness of form; the geometry of it shouldn't work)
 
 Skills:
   Force 5 | Brawl 4 | Endure 4
@@ -313,7 +313,7 @@ For quick reference when building encounters:
 ----
 Attributes: STR 3 | AGI 5 | WIT 4 | EMP 3
 Armor Rating: 1 (concealed ballistic vest)
-Fear Rating: 0
+Burst Rating: 0
 
 Skills:
   Brawl 2 | Endure 2
@@ -371,7 +371,7 @@ a client waiting. The agents are the only variable they didn't plan for.
 | *Empathy* | 5 (uses Empathy to manipulate; passively broadcasts)
 | *Skills* | Psychoanalyze 3 (passive pressure), Manipulate 2 (hallucination-induced)
 | *Armor Rating* | Immune to physical damage
-| *Fear Rating* | 3
+| *Burst Rating* | 3
 | *Corruption Cost* | +1 Corruption per minute spent within it (scene = +3 total)
 |===
 
@@ -420,7 +420,7 @@ means. It can be dispersed by:
 | *Empathy* | 0
 | *Skills* | Force 3, Brawl 2, Endure 3
 | *Armor Rating* | 1 (physical deadness reduces impact)
-| *Fear Rating* | 2
+| *Burst Rating* | 2
 | *Corruption Cost* | +1 Corruption on first sighting; +1 if recognized as someone known
 |===
 
@@ -462,7 +462,7 @@ removed.
 | *Empathy* | 5
 | *Skills* | Investigate 4, Sneak 5, Manipulate 3
 | *Armor Rating* | Immune to physical damage while intangible
-| *Fear Rating* | 2 (initially); 4 (once its nature is understood)
+| *Burst Rating* | 2 (initially); 4 (once its nature is understood)
 | *Corruption Cost* | +2 Corruption when it speaks directly to a character
 |===
 
@@ -512,7 +512,7 @@ Tech roll (Difficulty 3) to disrupt its signal network.
 | *Empathy* | 6 (weaponized grief)
 | *Skills* | Psychoanalyze 4, Manipulate 4, Brawl 3 (manifested physical form)
 | *Armor Rating* | 3 (partially intangible)
-| *Fear Rating* | 4 (maximum if the Wraith wears the face of a dead teammate)
+| *Burst Rating* | 4 (maximum if the Wraith wears the face of a dead teammate)
 | *Corruption Cost* | +2 Corruption on first contact; +1 each subsequent scene
 |===
 
@@ -523,9 +523,9 @@ Tech roll (Difficulty 3) to disrupt its signal network.
 ----
 Familiar Face — The Fracture Wraith appears as a dead Covenant agent.
 If any surviving character knew the deceased, seeing the Wraith triggers
-an immediate Fear Check (Fear Rating 4). If no character knew the
+an immediate Corruption Burst (Burst Rating 4). If no character knew the
 deceased, it appears as a figure whose face they can't quite place —
-Fear Rating 2.
+Burst Rating 2.
 
 Guilt Echo — Once per scene, the Wraith can attempt a Psychoanalyze roll
 (opposed by the target's Wits). On success: the target relives a specific
@@ -557,7 +557,7 @@ The following entries fill the gap between low-tier nuisances and lethal high-ti
 ----
 Attributes: STR 3 | AGI 3 | WIT 4 | EMP 2
 Armor Rating: 0
-Fear Rating: 2
+Burst Rating: 2
 
 Skills:
   Manipulate 3 | Lore 2 | Brawl 2 | Endure 3
@@ -603,7 +603,7 @@ process.
 ----
 Attributes: STR — (incorporeal) | AGI — (incorporeal) | WIT 5 | EMP 4
 Armor Rating: Immune to physical damage
-Fear Rating: 3
+Burst Rating: 3
 
 Skills: None (the Echo does not act with intention)
 
@@ -612,7 +612,7 @@ Movement: Zone-locked (occupies 1–2 zones defined at creation; does not move)
 Special Abilities:
   Immersion Field (Passive) — At the start of each round, all characters within
   the Echo's zone(s) resist the Echo's influence. This uses the same mechanic
-  as a Fear Check (Wits attribute only, no skill bonus), Difficulty 1.
+  as a Corruption Burst check (Wits attribute only, no skill bonus), Difficulty 1.
   Failure: the character experiences the historical trauma as if they were a
   participant — takes 1 Wits damage and 1 Empathy damage (mental, no armor).
   Success: the character observes the replay from a dissociated perspective and
@@ -628,7 +628,7 @@ Special Abilities:
   Escalation (Triggered) — If any character within the Echo's zone activates an
   artifact, uses a Division Talent, or pushes a roll, the Echo intensifies. For
   the remainder of the scene, Immersion Field damage increases to 2 Wits + 1
-  Empathy, and the Fear Rating increases to 4. The historical replay becomes
+  Empathy, and the Burst Rating increases to 4. The historical replay becomes
   more vivid and violent.
 
   Loop Reset (Passive) — At the end of each scene, the Echo restarts its cycle.
@@ -659,7 +659,7 @@ of three methods:
 ----
 Attributes: STR 3 | AGI 3 | WIT 4 | EMP 2
 Armor Rating: 1 (artifact-warded clothing — subtle, not tactical)
-Fear Rating: 0 (human, but deeply unsettling — see DA Guidance)
+Burst Rating: 0 (human, but deeply unsettling -- see DA Guidance)
 
 Skills:
   Lore 4 | Manipulate 3 | Investigate 3 | Deft Hands 3 | Sneak 2 | Tech 2
@@ -697,7 +697,7 @@ Special Abilities:
   agent carrying an artifact, they may offer accurate, detailed information
   about the artifact's properties, risks, and history. This information is
   always truthful and always unsettling. The agent receiving this information
-  must make a Fear Check (Wits only, standard Fear rules) — not because the
+  must make a Corruption Burst check (Wits only, standard Burst rules) -- not because the
   Collector is frightening, but because the depth and accuracy of their
   knowledge implies intimate experience with forces that should have destroyed
   them.
@@ -725,7 +725,7 @@ Collectors should not appear in every Case File. One Collector per campaign arc 
 
 === Corruption Threshold and Behavior
 
-The Corruption thresholds from xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing] apply to NPCs as well as agents. For simplicity, the DA tracks NPC corruption with a three-stage shorthand:
+The Corruption thresholds from xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing] apply to NPCs as well as agents. For simplicity, the DA tracks NPC corruption with a three-stage shorthand:
 
 [%header,cols="^1,2,4"]
 |===
@@ -733,7 +733,7 @@ The Corruption thresholds from xref:chapters/08-corruption-fear-healing.adoc#cha
 
 | *0* | 0–3 | Normal. No mechanical difference from a baseline NPC.
 | *1* | 4–7 | *Distorted.* The NPC is erratic — inconsistent, prone to misreading motives. −1 die on all social skill rolls targeting them. They believe they are functioning normally.
-| *2* | 8–10 | *Compromised.* The NPC's primary goal has been replaced by the logic of a corrupting artifact. They act with genuine conviction in service of something the artifact wants. Fear Rating 1 (their behavior is uncanny and wrong).
+| *2* | 8--10 | *Compromised.* The NPC's primary goal has been replaced by the logic of a corrupting artifact. They act with genuine conviction in service of something the artifact wants. Burst Rating 1 (their behavior is uncanny and wrong).
 | *3* | 11+ | *Broken.* The NPC meets the Fracture Wraith threshold or reaches catatonia. If not Catatonic, treat as equivalent to a Hollow (see above) — still moving, but no longer present.
 |===
 
@@ -801,7 +801,7 @@ Limit special abilities by tier:
 . At least one ability should have *a meaningful counter* that can be discovered with a successful Lore or Investigate roll.
 . Avoid purely defensive abilities — entities that can only be hurt in specific ways are frustrating if players can't find the method.
 
-=== Step 5 — Set Fear Rating
+=== Step 5 — Set Burst Rating
 
 [%header,cols="^1,3"]
 |===

--- a/docs/chapters/21-glossary.adoc
+++ b/docs/chapters/21-glossary.adoc
@@ -4,7 +4,7 @@
 
 This chapter is a quick-reference glossary of game-specific terms used throughout the Neon Relic core rules. Entries are alphabetical. Each definition includes a cross-reference to the chapter where the full rules appear — the glossary is a lookup aid, not a replacement for the canonical rules text.
 
-Not every game term appears here. The glossary covers the terms most likely to cause confusion or require mid-session lookup. For complete rules, consult the referenced chapter. For the full skill list, see xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills]. For the complete talent catalog, see xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+Not every game term appears here. The glossary covers the terms most likely to cause confusion or require mid-session lookup. For complete rules, consult the referenced chapter. For the full skill list, see xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills]. For the complete talent catalog, see xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 
 ---
 
@@ -15,7 +15,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 |===
 | *Aftermath* | The structured wrap-up phase that follows the resolution of a Case File. Characters earn Development Points (DP) during Aftermath based on outcomes, then spend them on Headquarters upgrades before the next Case File begins. See xref:chapters/12-headquarters.adoc#chapter-headquarters[Headquarters].
 | *Age Group* | Character creation choice determining starting Attribute and Skill point pools. Three tiers: Young (14 attribute / 10 skill), Experienced (13 / 12), Senior (12 / 14). See xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
-| *Anchor* | A physical object linked to a humanizing memory. Once per session, a character may interact with their Anchor to heal 1d4 Corruption. See xref:chapters/08-corruption-fear-healing.adoc#_anchors[Anchors].
+| *Anchor* | A personal source of solace — a practice, habit, or connection — that grounds the agent against Corruption. Once per session, a character may engage with their Anchor to heal 1d4 Corruption. See xref:chapters/08-corruption-fear-healing.adoc#_anchors[Anchors].
 | *Arc* | A sequence of 3–5 Case Files centered on a shared antagonist, artifact thread, or escalating crisis. Arcs provide long-term narrative structure without prescribing outcomes. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 | *Armor Rating* | The number of Gear dice rolled to absorb incoming damage. Each 6 rolled cancels one point of damage. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 | *Artifact Die* | A step-down usage die tracking an artifact's remaining stability. Starts at d20 and steps down (d20→d12→d10→d8→d6→d4→Fractured) each time a 1 is rolled on activation. When the die steps past d4, the artifact fractures. See xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts].
@@ -28,7 +28,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
-| *Background Talent* | A General Talent tagged *Background* representing the agent's pre-Covenant professional expertise. Chosen at character creation. Provides a bonus die (not a rating increase) when the agent acts within their background domain. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+| *Background Talent* | A General Talent tagged *Background* representing the agent's pre-Covenant professional expertise. Chosen at character creation. Provides a bonus die (not a rating increase) when the agent acts within their background domain. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 | *Broken* | State when any Attribute reaches 0. The character is incapacitated and rolls on the appropriate Critical Injury table (Physical or Mental). See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 |===
 
@@ -43,7 +43,8 @@ Not every game term appears here. The glossary covers the terms most likely to c
 | *Containment Profile* | An artifact's full physical and procedural containment record: the combination of measures that suppress it without dispersing it. Used by The Keep during long-term custody. See xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts].
 | *Containment Ritual* | A Lore-led field procedure used to suppress, shield, or disperse an artifact or manifestation. Three types: *Quiescence* (suppress active effects, Base Difficulty 2, 10 min), *Shielding* (seal against passive emissions, Base Difficulty 2, full scene), and *Banishment* (disperse a manifestation or collapse a ritual site, Base Difficulty 3, full scene, Lore 3+ required). See xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts].
 | *Containment Truth* | A formal statement about an artifact's behavior that enables safe resolution of a case. Each Containment Truth has three components: *Trigger Condition* (what causes the artifact to activate or escalate), *Appetite* (what the artifact seeks when active), and *Quiescence Condition* (what must be done to return it to dormancy). Case files typically include three to five Containment Truths. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files] and xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts].
-| *Corruption* | Cumulative psychological and occult damage track. Gained from pushing rolls, Division Talent activation, Fear Checks (rolling 1s), artifact activation, supernatural exposure, and rolling on the Mental Critical Injury table. *Maximum Corruption Threshold* = 10 + Empathy score; exceeding it causes permanent catatonia and character retirement. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+| *Corruption* | Cumulative psychological and occult damage track. Gained from pushing rolls, Division Talent activation, Corruption Bursts (rolling 1s), artifact activation, supernatural exposure, and rolling on the Mental Critical Injury table. *Maximum Corruption Threshold* = 10 + Empathy score; exceeding it causes permanent catatonia and character retirement. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing].
+| *Corruption Burst* | A special binary Wits roll triggered by direct supernatural confrontation. One or more 6s = success. Any 1s = +1 Corruption. No 6s = failure (+Burst Rating Corruption + Panic Table roll). Cannot be pushed or assisted. See xref:chapters/08-corruption-fear-healing.adoc#corruption-burst-procedure[Corruption Burst].
 | *Corruption Cascade* | The penalty for carrying three or more artifacts simultaneously. All carried artifacts leak their Corruption cost at end of scene, even if none were activated. See xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts].
 | *Covenant Request Packet* | A field request sent to the Covenant for delayed support such as archive pulls, identity checks, freight screening, or comparative case data. Only one packet may be sent per shift, and responses take at least 2 shifts. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 | *Cover* | Terrain protection in combat. Soft cover (low walls, furniture) grants +2 Armor Rating. Hard cover (concrete walls, vehicles) grants +4 Armor Rating. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
@@ -57,12 +58,11 @@ Not every game term appears here. The glossary covers the terms most likely to c
 |===
 | *D66* | A roll of two six-sided dice read as a two-digit number (first die = tens, second = units). Used for Critical Injury tables. Range: 11–66.
 | *Damage Type* | One of three categories: *Physical* (targets STR or AGI), *Mental* (targets WIT or EMP), or *Corruption* (added directly to the Corruption track). See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
-| *Dark Secret* | A specific hidden fact from the character's past — an event, decision, or relationship someone wants buried. Serves as a roleplay device and XP hook ("Did your Dark Secret complicate the mission?" = +1 XP). See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement].
 | *Death Check* | A single d6 roll required when a Critical Injury is marked †. On 1–2: the character dies (or is permanently retired for mental death). On 3–6: survival, but the Critical Injury still applies. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 | *Debrief* | The structured end-of-case-file phase where Experience Points are awarded. The DA asks five debrief questions; each "yes" answer grants +1 XP. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement].
 | *Department* | Specialization within a Division. Wayfinder agents choose Wings, Keep agents choose Departments, and Recovery agents choose Operational Paradigms instead. Stack is a *Keep department*, not a separate Division. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 | *Development Points (Dev Points / DP)* | The shared resource the cell earns during Aftermath and spends on Headquarters facilities, personnel, and infrastructure upgrades. See xref:chapters/12-headquarters.adoc#chapter-headquarters[Headquarters].
-| *Difficulty* | The number of successes (6s) required to pass a standard skill roll. Default Difficulty is 1 if a rule does not state otherwise. Opposed rolls compare totals instead of using a fixed Difficulty, and a few special rolls such as Fear checks use their own binary rules. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
+| *Difficulty* | The number of successes (6s) required to pass a standard skill roll. Default Difficulty is 1 if a rule does not state otherwise. Opposed rolls compare totals instead of using a fixed Difficulty, and a few special rolls such as Corruption Burst checks use their own binary rules. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 | *Director of Agents (DA)* | The table's facilitator role. The DA presents scenes, adjudicates uncertainty, tracks the Operations Board (organization rows and shift row), and portrays the world and opposition. See xref:chapters/14-da-guidance.adoc#chapter-da-guidance[Director of Agents Guidance].
 | *Disposition* | An NPC's current openness to engagement in Social Conflict, tracked from 1 (Closed) to 5 (Open). At Disposition 3 or higher, direct low-risk questions are answered without a roll; social rolls are reserved for sensitive disclosures or requests against self-interest. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict].
 | *Division* | Character class within the Verdant Covenant. The three playable Divisions are Wayfinder (research/intelligence), Recovery (field retrieval), and The Keep (vault security, custody, and logistics). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
@@ -76,7 +76,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
-| *Experience Points (XP)* | The game's only advancement currency. XP are awarded at the end of each Case File through debrief questions and spent to raise skills, buy new talents, or increase Clearance Level. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+| *Experience Points (XP)* | The game's only advancement currency. XP are awarded at the end of each Case File through debrief questions and spent to raise skills, buy new talents, or increase Clearance Level. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 |===
 
 [#glossary-f]
@@ -85,8 +85,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
 | *Fast Action* | One of three action types in combat. Represents a quick or secondary effort: moving one zone, drawing a weapon, taking cover, or using a small item. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
-| *Fear Check* | A special binary Wits roll triggered by supernatural horror. One or more 6s = success. Any 1s = +1 Corruption. No 6s = failure (+1 Corruption + Panic Table roll). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
-| *Fear Rating* | Narrative classification (1–5) of how terrifying a creature or event is. Used by the DA to determine when to call for a Fear check. Only events with a Fear Rating trigger Fear checks — mundane dangers do not. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+| *Burst Rating* | Supernatural intensity classification (1–5) of a creature or event. Determines when the DA calls for a Corruption Burst and how much Corruption a failed Burst inflicts. Only events with a Burst Rating trigger Corruption Bursts — mundane dangers do not. See xref:chapters/08-corruption-fear-healing.adoc#burst-ratings[Burst Ratings].
 | *Fracture* | The catastrophic failure state of an artifact when its Artifact Die steps past d4. The artifact's metaphysical structure collapses and its Fracture Condition triggers immediately. See xref:chapters/11-artifacts.adoc#chapter-artifacts[Artifacts].
 | *Free Action* | An action in combat that requires negligible effort: speaking a short sentence, dropping an item, or glancing at surroundings. Unlimited per turn. See xref:chapters/05-combat.adoc#chapter-combat[Combat].
 |===
@@ -97,7 +96,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
 | *Gear Dice* | Black dice in the pool contributed by equipment. Each 1 rolled on a Gear die causes the item to degrade one step. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
-| *General Talent* | A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. General Talents are chosen at character creation in place of a Division Talent or purchased later for 6 XP. The canonical list lives in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement, Talents, and Dark Secrets].
+| *General Talent* | A talent available to any character regardless of Division, providing a mechanical exception or situational bonus. General Talents are chosen at character creation in place of a Division Talent or purchased later for 6 XP. The canonical list lives in xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].
 | *Group Roll* | A roll where all team members roll the same skill simultaneously. The team succeeds if a specified number of members succeed individually. Used in travel, stealth, and investigation scenes. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 |===
 
@@ -132,7 +131,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
-| *Maximum Corruption Threshold* | The point at which a character's mind permanently fractures: 10 + Empathy score (base). Modified by Redundant Safeties talent (+2) and Fracture Point injury (−2). Exceeding this value retires the character. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+| *Maximum Corruption Threshold* | The point at which a character's mind permanently fractures: 10 + Empathy score (base). Modified by Redundant Safeties talent (+2) and Fracture Point injury (−2). Exceeding this value retires the character. See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing].
 |===
 
 [#glossary-n]
@@ -160,7 +159,7 @@ Not every game term appears here. The glossary covers the terms most likely to c
 
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
-| *Panic Table* | A d6 table rolled on Fear check failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+| *Panic Table* | A d6 table rolled on Corruption Burst failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption and Healing].
 | *Push* | Re-roll all non-6 dice after a roll fails to meet its Difficulty, or after a success when you want more successes. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 | *Psychoanalyze* | A skill used to read psychological states, detect deception, stabilize distressed people during social scenes, and treat mental and emotional Critical Injuries. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict] and xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 |===

--- a/docs/chapters/appendix-combat.adoc
+++ b/docs/chapters/appendix-combat.adoc
@@ -1,0 +1,197 @@
+[#appendix-combat]
+= Appendix: Advanced Combat Rules
+
+This appendix collects situational combat rules that most sessions will not use. The core combat loop — zones, actions, initiative, conditions, and Broken — is in xref:chapters/05-combat.adoc#chapter-combat[Ch 5 — Combat]. The rules here cover ammunition tracking, full automatic fire, chases, vehicle combat, and large-group (mob) combat.
+
+---
+
+[[ammunition-tracking]]
+== Ammunition Tracking
+
+Ammunition is tracked using a *Resource Die*. When you acquire a weapon or reload, set its ammo die based on the weapon type and current magazine state:
+
+[%header,cols="2,1,2"]
+|===
+| Ammo State | Die | Notes
+
+| *Pistol — full magazine* | d10 | 9mm, .38, .45; standard load
+| *Shotgun — full load* | d8 | Pump or semi-auto shotgun
+| *Rifle — full magazine* | d8 | Assault rifle, battle rifle, .308
+| *Half loaded (any)* | d6 | Partially used magazine
+| *Low / scrounged (any)* | d4 | Found ammo, emergency reload
+| *Drum / extended mag* | d12 | Special acquisition (CL 4)
+|===
+
+> *Two-track ammo system:* This table governs *in-combat per-shot tracking* — roll when you push a Firearms roll, fire full auto, or the DA calls for it. Between scenes, use the *Supply-level Resource Dice* in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment] to track how much ammo the team has on hand. When you reload in the field, roll the supply die; then reset the weapon's combat ammo die to its 'full' value from this table.
+
+*When do you roll the ammo die?*
+
+* After *every turn in which you fire* (standard fire — the die represents the resource pressure of sustained combat).
+* After *pushing a Firearms roll* — roll an additional time (you burned through extra rounds).
+* After a *full auto burst* — roll *twice* (see Full Auto below).
+* At the DA's discretion when dramatically appropriate (ambush, very long firefight).
+
+*Rolling the ammo die:*
+
+* Roll the current die. On a *1 or 2*, step the die down one size (d8→d6→d4→empty).
+* On *empty* (die was d4 and rolled 1–2): weapon is dry. Reload costs a Slow Action.
+
+=== Full Auto
+
+Weapons capable of fully automatic fire (noted in the Equipment tables) may fire a *full auto burst* on a Slow Action instead of a standard shot.
+
+* *Effect:* Make *two separate attack rolls* against the same target (or split between two targets in the same zone). Resolve each roll independently — each can hit, miss, or generate stunt points.
+* *Ammo:* Roll the ammo die *twice* after a full auto burst (once per attack).
+* *Penalty:* After firing full auto, the firing character suffers −1 die on all Firearms rolls until the start of their next turn (recoil and muzzle rise).
+* *When in doubt:* If the Equipment tables do not specify a weapon as full auto, it fires semi-auto only.
+
+---
+
+[[chase-and-pursuit]]
+== Chase and Pursuit
+
+When one side is fleeing and the other is pursuing, use the following chase rules.
+
+=== Chase Structure
+
+A chase is divided into *chase rounds*. Each round, both the fleeing and pursuing party roll their relevant attribute + skill:
+
+* *On foot:* Agility + Sneak (for stealth flight) or Agility + Endure (for pure sprint)
+* *By vehicle:* Wits + Tech (see <<vehicle-chase-rules>> for full vehicle chase procedure, speed modifiers, and maneuvers)
+
+> **DA discretion on skill choice:** These are default options. The DA may call for other skills when the context demands it — a chase through a crowded market could use Manipulate (EMP) to slip through a crowd; a chase through a building's maintenance passages could use Investigate (WIT). The DA should always tell the players which skill they're calling before the roll.
+
+=== Chase Outcome Per Round
+
+* Compare successes. The side with more successes *gains distance* (fleeing) or *closes distance* (pursuing).
+* Track relative distance on a 5-step track: *Contact → Following → Closing → Widening → Escaped*.
+* Start at Contact. Fleeing party wins a round → move one step toward Escaped. Pursuing party wins → move one step toward Contact.
+
+=== Escape and Recapture
+
+* The fleeing party *escapes* when they reach the Escaped position.
+* During a chase, characters may still attack (at whatever range the current position represents) but do so at *−1 die* (distraction of movement).
+* If the pursuing party reaches Contact: normal combat resumes. Draw initiative cards immediately; the pursuit party does not get a free round unless they successfully set up an ambush (see Surprise and Ambush).
+* *Hiding attempt:* If the fleeing party is at Widening, they may attempt to break the chase entirely — succeed on a Sneak roll (Difficulty 2) to vanish into the environment. This attempt may be made *once per chase*; if it fails, the hiding window has passed and the fleeing party must reach Escaped normally.
+
+---
+
+[[combat-around-vehicles]]
+== Combat Around Vehicles
+
+Not every vehicle encounter is a chase. When combat occurs at or near stationary vehicles — roadblock shootouts, parking lot ambushes, or attacks on a parked convoy — use standard combat rules with the following guidance:
+
+* *Vehicles as cover:* A vehicle provides cover equal to its Armor Rating. Agents behind a vehicle add the vehicle's Armor Rating to their defense as if it were personal armor (Gear Dice, 6s absorb damage). Unlike personal armor, vehicle cover does not degrade from 1s — the vehicle absorbs Wear instead (1 Wear per combat scene in which it provides cover).
+* *Attacking vehicles:* Targeting a vehicle (to disable it, breach it, or destroy it) uses Force (melee) or Firearms (ranged) at Difficulty 1 — no special maneuver is needed, just a successful hit. Each point of damage that exceeds the vehicle's Armor Rating reduces the vehicle by 1 Wear. At 5 Wear, the vehicle is disabled. Typical vehicle Armor Ratings are listed in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment].
+* *Targeting occupants:* Attacking someone inside a vehicle requires a called shot (1 stunt point) or the vehicle's windows/doors to be open. Closed vehicles provide full Armor Rating to occupants. Open vehicles (windows down, convertibles) provide half Armor Rating (round down).
+
+For moving vehicle encounters, use the <<chase-and-pursuit>> rules above. If a chase transitions into a stationary firefight (e.g., vehicles crash and combatants exit), switch to standard combat using the guidance in this section.
+
+> **Wear** is the vehicle damage track. It runs from 0 (undamaged) to 5 (disabled). At Wear 5, the vehicle cannot move, its systems are failing, and it may be on fire — DA determines consequences. Repairing Wear requires tools, time, and a successful Tech (WIT) roll. Full vehicle Wear and repair rules are in <<vehicle-damage>>.
+
+---
+
+[[vehicle-chase-rules]]
+== Vehicle Conflict — Actions and Chase Rules
+
+Vehicle conflict follows the same chase structure as foot chases (<<chase-and-pursuit>>), with vehicle-specific modifications. Vehicle stat blocks and the 1980s vehicle roster are in xref:chapters/10-equipment.adoc#chapter-equipment[Equipment].
+
+=== Contact Track
+
+Vehicle conflict uses a *Contact Track* — a 5-step range distinct from the foot-chase position track:
+
+[%header,cols="^1,3"]
+|===
+| Position | State
+
+| 1 | *Rammed / Contact* — vehicles are adjacent; ramming and boarding are possible.
+| 2 | *Following* — pursuing vehicle is directly behind; gunfire from rear positions is possible.
+| 3 | *Closing* — pursuit is active; the gap is narrowing or holding.
+| 4 | *Widening* — the pursued vehicle has gained distance; gunfire at Long range only.
+| 5 | *Escaped* — the pursuer has lost visual contact. Chase ends.
+|===
+
+The *pursued vehicle* wins by moving to position 5.
+The *pursuing vehicle* wins by moving to or holding position 1–2.
+
+=== Chase Roll
+
+Each round of a chase, both drivers make a roll:
+
+* *Tech (WIT):* The primary chase skill. Represents reading traffic, anticipating routes, and making calculated maneuvers with vehicles under pressure. Use this for all standard chase rolls.
+* *Tech (AGI):* Used when attempting sudden unpredictable movement — cutting through a building site, reversing against traffic, going off-road. Higher risk, higher reward. The DA may call for AGI + Tech instead of WIT + Tech when a maneuver is more reflexive than tactical.
+
+Both sides roll simultaneously. The side with more successes moves the Contact Track one position in their favor. Ties: no position change.
+
+*Speed modifiers:*
+
+* Each speed tier above the opponent's: +1 die on the chase roll.
+* Each speed tier below the opponent's: −1 die on the chase roll.
+* Handling bonus/penalty applies directly to the roll.
+
+*Pushing a chase roll:* +1 Corruption as normal. The vehicle also takes 1 Wear immediately (the driver is wringing everything out of it).
+
+=== Vehicle Maneuvers
+
+Declare before rolling. No cost unless noted.
+
+[%header,cols="1,2,3"]
+|===
+| Maneuver | Skill | Effect
+
+| *Ram* | Force (STR) | Only available at Contact. Roll Force (STR) opposed by opponent's Tech (WIT). On success: both vehicles take 1–3 damage (equal to Force successes); Contact Track does not change; occupants of both vehicles take 1 Agility damage (thrown around). Cannot ram a vehicle more than two speed tiers faster.
+| *PIT Maneuver* | Tech (WIT) Difficulty 3 | Available at Contact only. On success: target vehicle spins — they lose their next action and the pursuer moves to Contact. On failure: the maneuvering driver's vehicle takes 1 Wear.
+| *Gunfire from Vehicle* | Firearms (standard roll) | Available at Following or closer. −1 die on all shooting rolls from a moving vehicle unless the shooter has the *Stable Platform* talent. A passenger shooting from a moving car is at −1 die; a driver shooting is at −2 dice.
+| *Off-Road Break* | Tech (AGI) Difficulty 2 | Drive off the paved route. On success: move one position on the Contact Track toward Escaped. On failure: vehicle takes 1 Wear and no position change. If in a vehicle with off-road penalty (Motorcycle in rain, Van, Helicopter equivalent): add +1 Difficulty.
+| *Blending In* | Sneak (WIT) Difficulty 2 | Abandon the direct chase and disappear into traffic or terrain. On success: move directly to Escaped (skip the track). On failure: no change and opponent moves one step toward Contact.
+|===
+
+---
+
+[[vehicle-damage]]
+== Vehicle Damage
+
+When a vehicle takes damage (from ramming, gunfire, or environmental hazard):
+
+. Roll damage as normal. Subtract the vehicle's AR.
+. Remaining damage is applied as *Wear* (not as Strength damage to occupants, unless the damage is extraordinary).
+. At 5 Wear: vehicle stops. Characters inside may take 1 Agility damage from the sudden stop (Endure Difficulty 1 to avoid).
+. *Structural damage:* At DA discretion, a catastrophic hit (4+ damage after AR) may cause a specific system failure: blown tire (−2 die Handling), cracked windscreen (blindness penalties for driver), fuel leak (vehicle stops at end of scene unless repaired).
+
+*Repairing Wear:*
+
+* Tech roll (Difficulty 2) + 30 minutes + access to tools: clear 1 Wear.
+* Full garage repairs (overnight, proper tools): restore to starting Reliability.
+* Field repairs without tools: Tech Difficulty 4, clears 1 Wear, cannot reduce below 3.
+
+=== Vehicle Breakdown
+
+When Reliability reaches 5 Wear, the vehicle stops. Roll d6:
+
+[%header,cols="^1,4"]
+|===
+| Roll | Breakdown Type
+
+| 1–2 | *Total Failure.* Engine seized. Not repairable in the field. Needs a tow and a full day of garage work (restore to 2 Wear, 4 hours minimum).
+| 3–4 | *Serious Fault.* Driveable at Slow speed only. Tech (Difficulty 3) to clear in field; otherwise full garage repair.
+| 5–6 | *Inconvenient Failure.* Battery, tire, or small component. Tech (Difficulty 1) to address in 15 minutes. 1 Wear remains after fix.
+|===
+
+A breakdown during an active chase is resolved immediately: the broken-down vehicle is treated as *Contact* on the next round (the pursuer closes automatically).
+
+---
+
+[[group-combat]]
+== Group Combat (Multiple NPCs)
+
+When 3 or more combatants on the NPC side share a common purpose and act together, they may be treated as a *mob*.
+
+=== Mob Rules
+
+* A mob draws *one Initiative card* and acts as a single entity on that card.
+* A mob has a shared Strength pool equal to *3 per member* (e.g., a 4-person mob has Strength 12). Maximum mob Strength is 15 regardless of size.
+* A mob attacks as one unit: roll dice pool equal to the *best individual's dice pool* plus bonus dice equal to the number of additional members (beyond the first), *maximum +3 bonus dice total*.
+* *Damage to a mob:* Any attack that deals Strength damage reduces the mob's shared pool. When the mob Strength pool reaches 0, the mob is broken — all members are Broken or fleeing. The DA may narrate intermediate casualties at thresholds (e.g., one member falls at Strength 6, another at Strength 3).
+* *Splitting a mob:* Area effects (full auto burst, explosive, fire) or AoE-capable stunts can split a mob into two smaller groups. The DA distributes remaining Strength between them.
+
+> Mobs represent low-tier hostiles (cultist grunts, security guards, Compact foot soldiers). Named or significant NPCs always act individually with their own initiative and stat blocks.

--- a/docs/neon-relic.adoc
+++ b/docs/neon-relic.adoc
@@ -46,6 +46,8 @@ image::vegas-vic.png[Vegas Vic — The Pioneer Club,align=center,pdfwidth=60%]
 
 include::chapters/01-introduction.adoc[leveloffset=+1]
 
+include::chapters/01b-opening-fiction.adoc[leveloffset=+1]
+
 // ─────────────────────────────────────────────────────────────────────────────
 //  PART II — CHARACTER CREATION
 // ─────────────────────────────────────────────────────────────────────────────
@@ -192,8 +194,12 @@ image::svg/placeholder-section.svg[Section image placeholder,align=center,pdfwid
 include::chapters/21-glossary.adoc[leveloffset=+1]
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  APPENDIX — YZE FREE TABLETOP LICENSE
+//  APPENDICES
 // ─────────────────────────────────────────────────────────────────────────────
+
+<<<
+
+include::chapters/appendix-combat.adoc[leveloffset=+1]
 
 <<<
 


### PR DESCRIPTION
Closes #781 #782 #783 #785 #788 #796 #799 #802 #767 #748 #750 #751 #752 #744 #745 #746 #747 #749

## Summary

Batch resolution of 18 design issues covering mechanics overhauls, lore additions, and structural improvements.

### Major Reworks
- **#744 Remove Dark Secrets** — Removed the Dark Secret mechanic entirely from Ch2, Ch4, Ch7, Ch9, Ch13, Ch15, Ch21
- **#745 Rework Anchors** — Replaced physical-object Anchors with abstract solace categories (18 types), rewrote Ch8 Anchor section and Ch2 Step 9
- **#746 Replace Fear with Corruption Burst** — Complete replacement of Fear Check/Fear Rating with Corruption Burst/Burst Rating across all chapters (Ch1-Ch8, Ch11-Ch12, Ch15, Ch17, Ch19, Ch21)
- **#747 Rework HQ to city-based** — Converted single-safehouse model to city network: distributed capabilities, vault storage rules, updated Threat Meter/Compromise events
- **#749 Clarify org lore** — Added global structure (500-700 members, 6 regional hubs, ~100 cells), inter-division dynamics, assignment pipeline

### New Content
- **#750** Opening fiction (Agent Vasquez field report)
- **#752** Combat appendix (ammo, full auto, chase/pursuit, vehicle conflict, mob rules)
- **#748** Org chart diagram in Ch9
- **#751** How Play Works section in Ch1

### Fixes and Polish
- **#781** Historical members added (Ch18)
- **#782** Government awareness sidebar (Ch17)
- **#783** Vehicle table fixes (Ch16)
- **#785** Mirror/Clock artifact fix (Ch15)
- **#788** Clue web example diagram (Ch15)
- **#796** Key Attributes removed (Ch9/Ch2)
- **#799** Ghost Entry talent updated (Ch9)
- **#802** Crafting defaults simplified (Ch10)
- **#767** Death in combat clarification (Ch5)