### PR TITLE
fix(#793,#778): PDF table column widths and text box formatting

### DIFF
--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -115,14 +115,18 @@ If the winning roll supports stunts, each success beyond the opposing total is a
 
 === Tie-Breaking
 
-> **Design Decision:** In Neon Relic, ties are resolved *in favor of the player character*. If a PC is involved in an opposed roll, a tie is a player win — regardless of who initiated the action. +
-> +
-> **Rationale:** The active-party rule punishes players whenever a hostile NPC takes the initiative. Corruption costs and the asymmetric difficulty of the Corruption track already provide consistent pressure. Giving NPCs tie wins would compound that pressure without interesting dramatic benefit. This aligns with _Alien RPG_ and the general YZE design principle of player-favorable resolution. +
-> +
-> **Edge cases:** +
-> * _PC vs. NPC:_ The PC wins, regardless of who initiated. +
-> * _NPC vs. NPC:_ Equal nonzero successes = no change; both zero = no change (see below). +
-> * _PC vs. PC:_ The DA rules in context; no mechanical default applies.
+[quote]
+____
+**Design Decision:** In Neon Relic, ties are resolved *in favor of the player character*. If a PC is involved in an opposed roll, a tie is a player win — regardless of who initiated the action.
+
+**Rationale:** The active-party rule punishes players whenever a hostile NPC takes the initiative. Corruption costs and the asymmetric difficulty of the Corruption track already provide consistent pressure. Giving NPCs tie wins would compound that pressure without interesting dramatic benefit. This aligns with _Alien RPG_ and the general YZE design principle of player-favorable resolution.
+
+**Edge cases:**
+
+* _PC vs. NPC:_ The PC wins, regardless of who initiated.
+* _NPC vs. NPC:_ Equal nonzero successes = no change; both zero = no change (see below).
+* _PC vs. PC:_ The DA rules in context; no mechanical default applies.
+____
 
 If both sides roll zero successes, the outcome is *no change* — the situation remains unresolved, and the DA should advance the fiction in a direction that applies pressure (the confrontation escalates, time runs out, a third party notices, etc.). The acting character does *not* gain Corruption from a zero-zero tie.
 

--- a/docs/chapters/11-artifacts.adoc
+++ b/docs/chapters/11-artifacts.adoc
@@ -249,7 +249,7 @@ No free rides. No safe artifacts.
 
 Every artifact needs *six defined components* — five mandatory and one optional. Fill in each section before introducing the artifact to players.
 
-[%header,cols="1,3,4"]
+[%header,cols="2,3,4"]
 |===
 | Component | What It Defines | Design Prompt
 
@@ -292,7 +292,7 @@ of the effect. Use this framework to set the Corruption cost for a new artifact.
 The Artifact Die is assigned separately based on history and resilience — see
 <<using-an-artifact,Artifact Die Levels>>.
 
-[%header,cols="1,1,4"]
+[%header,cols="2,2,5"]
 |===
 | Tier | Corruption Cost | Effect Power Level
 


### PR DESCRIPTION
Closes #793
Closes #778

## Changes

### #793 — Table Column Widths
- **Artifact Template table** (Ch11): Widened first column from \cols="1,3,4"\ to \cols="2,3,4"\ — prevents truncation of 'Component' and 'Corruption Cost & Tier' labels
- **Corruption Budget System table** (Ch11): Widened first two columns from \cols="1,1,4"\ to \cols="2,2,5"\ — prevents wrapping of tier names like '2 — Threatening' and '3 — Catastrophic'

### #778 — Text Box Formatting
- **Tie-Breaking blockquote** (Ch03): Converted from Markdown-style blockquote (\> +\) to AsciiDoc native quote block (\[quote]/____\). The \> +\ line continuations were rendering as literal '+' characters in the PDF and preventing proper paragraph separation. The quote block now renders with clean multi-paragraph content and properly formatted bullet lists.

## Verification
PDF rebuilt and verified:
- Artifact Template table: 'Component' and 'Corruption Cost & Tier' labels display without truncation
- Corruption Budget table: Tier names display on single lines
- Tie-Breaking quote block: No literal '+' characters; proper paragraphs and bullet list rendering