### PR TITLE
talents need to be more restrictive (#811)

### DIFF
--- a/.claude/workflows/issue-to-pr.js
+++ b/.claude/workflows/issue-to-pr.js
@@ -1,0 +1,349 @@
+export const meta = {
+  name: 'issue-to-pr',
+  description: 'Full issue lifecycle: assign → branch → implement → test → PR → squash merge → close',
+  whenToUse: 'When you want to take an open GitHub issue through the complete development cycle automatically. Pass an issue number, or omit to pick from open issues.',
+  phases: [
+    { title: 'Setup', detail: 'Fetch issue, assign to user, mark in progress, create branch' },
+    { title: 'Research', detail: 'Deep-research the issue to understand all affected files' },
+    { title: 'Implement', detail: 'Make the code changes across all affected files' },
+    { title: 'Test', detail: 'Run tests and verify the changes' },
+    { title: 'PR & Merge', detail: 'Create PR, approve, squash merge, close branch, close issue' },
+  ],
+};
+
+// ─── Issue to PR: Full Lifecycle Automation ───────────────────────────────
+// Usage: /workflow issue-to-pr -- 815
+//        /workflow issue-to-pr            (picks first open issue)
+//
+// Prerequisites:
+//   - gh CLI authenticated
+//   - git configured with user.name and user.email
+//   - Branch protection must allow self-approval, or use a PAT with admin scope
+
+const REPO = 'bruceamoser/neon-relic';
+const ASSIGNEE = 'bruceamoser';
+const BASE_BRANCH = 'main';
+
+// ─── Phase 1: Setup ───────────────────────────────────────────────────────
+
+phase('Setup');
+
+// Determine which issue to work
+let issueNum;
+const issueArg = args?.issue || args;
+if (issueArg && typeof issueArg === 'number') {
+  issueNum = issueArg;
+} else if (issueArg && !isNaN(Number(issueArg))) {
+  issueNum = Number(issueArg);
+} else {
+  // Auto-pick the first open issue
+  const result = await agent(
+    `Run: gh issue list --repo ${REPO} --state open --limit 1 --json number --jq '.[0].number'`,
+    { label: 'find-open-issue' }
+  );
+  const picked = parseInt(result.trim());
+  if (!isNaN(picked)) {
+    issueNum = picked;
+    log(`No issue specified — auto-picked first open: #${issueNum}`);
+  }
+}
+
+if (!issueNum || isNaN(issueNum)) {
+  throw new Error('Could not determine issue number. Pass a number: /workflow issue-to-pr -- 815');
+}
+
+// Fetch issue details
+const issueJson = await agent(
+  `Run: gh issue view ${issueNum} --repo ${REPO} --json number,title,body,state,assignees,labels --jq '.'`,
+  { label: 'fetch-issue' }
+);
+const issue = JSON.parse(issueJson.trim());
+
+if (issue.state !== 'OPEN') {
+  throw new Error(`Issue #${issueNum} is ${issue.state}, not OPEN. Pick another issue.`);
+}
+
+log(`📋 Issue #${issueNum}: ${issue.title}`);
+
+// Assign to user and mark in progress
+await agent(
+  `Run these commands sequentially and report success/failure for each:
+1. gh issue edit ${issueNum} --repo ${REPO} --add-assignee "${ASSIGNEE}"
+2. gh label create "in-progress" --repo ${REPO} --color "E6A23C" --force
+3. gh issue edit ${issueNum} --repo ${REPO} --add-label "in-progress"`,
+  { label: 'assign-and-label' }
+);
+log(`✅ Assigned to ${ASSIGNEE} and labeled in-progress`);
+
+// Create branch
+const branchSlug = issue.title
+  .toLowerCase()
+  .replace(/[^a-z0-9\s-]/g, '')
+  .replace(/\s+/g, '-')
+  .replace(/-+/g, '-')
+  .substring(0, 40);
+const branchName = `issue-${issueNum}-${branchSlug}`;
+
+await agent(
+  `Run: git checkout ${BASE_BRANCH} && git pull origin ${BASE_BRANCH} && git checkout -b ${branchName} && git push -u origin ${branchName}`,
+  { label: 'create-branch' }
+);
+log(`🌿 Branch: ${branchName}`);
+
+// ─── Phase 2: Research ────────────────────────────────────────────────────
+
+phase('Research');
+
+log('🔍 Identifying all affected files...');
+
+// If the issue body already has a comprehensive file inventory, extract it.
+// Otherwise, do fresh deep research.
+const hasFileInventory = issue.body && (
+  issue.body.includes('Complete File Inventory') ||
+  issue.body.includes('Files to Modify') ||
+  issue.body.includes('## What Needs to Change')
+);
+
+let researchResult;
+if (hasFileInventory) {
+  log('📝 Issue body contains a file inventory — extracting structured list...');
+  researchResult = await agent(
+    `Read the issue body below and extract a structured JSON list of EVERY file
+that needs to change, with the specific change needed for each file.
+
+Output format:
+{
+  "files": [
+    { "file": "src/data/actor-models.mjs", "change": "Add total and spent fields", "priority": "critical" }
+  ],
+  "summary": "Brief description of the overall change"
+}
+
+Issue Body:
+${issue.body.substring(0, 8000)}`,
+    { label: 'extract-file-list', schema: {
+      type: 'object',
+      properties: {
+        files: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, change: { type: 'string' }, priority: { type: 'string' } }, required: ['file', 'change'] } },
+        summary: { type: 'string' }
+      },
+      required: ['files', 'summary']
+    }}
+  );
+} else {
+  log('🔎 Issue is brief — doing fresh deep research across both repos...');
+  researchResult = await agent(
+    `Thoroughly research GitHub issue #${issueNum} ("${issue.title}") to identify every file
+that needs to change. Search across BOTH repositories:
+  - c:\\Repos\\neon-relic\\ (rulebook, web app, docs, assets, prebuilt characters)
+  - c:\\Repos\\foundry-neon-relic-system\\ (Foundry VTT system, compendium packs)
+
+Issue body: ${issue.body}
+
+Search for all relevant references, imports, templates, styles, data models,
+compendium packs, localization files, and documentation.
+
+Return a JSON object with a complete 'files' array and a 'summary' string.`,
+    { label: 'fresh-research', schema: {
+      type: 'object',
+      properties: {
+        files: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, change: { type: 'string' }, priority: { type: 'string' } }, required: ['file', 'change'] } },
+        summary: { type: 'string' }
+      },
+      required: ['files', 'summary']
+    }}
+  );
+}
+
+const fileList = researchResult.files;
+log(`📊 ${fileList.length} files to change: ${researchResult.summary}`);
+
+// ─── Phase 3: Implement ───────────────────────────────────────────────────
+
+phase('Implement');
+
+log(`🛠️ Implementing changes across ${fileList.length} files...`);
+
+// Process critical files first (data models, config), then everything else
+const critical = fileList.filter(f => f.priority === 'critical');
+const rest = fileList.filter(f => f.priority !== 'critical');
+
+async function editFile(f) {
+  return agent(
+    `You are editing file "${f.file}". Read it first to understand its current content,
+then use the Edit tool to make this change: ${f.change}
+
+IMPORTANT:
+- Read the file before editing
+- Match indentation exactly in old_string
+- Follow the existing code style and patterns
+- Only change what's necessary`,
+    { label: f.file.split('/').pop(), phase: 'Implement' }
+  );
+}
+
+if (critical.length > 0) {
+  log(`⚡ ${critical.length} critical files first...`);
+  for (const f of critical) await editFile(f);
+}
+
+if (rest.length > 0) {
+  log(`📝 ${rest.length} remaining files...`);
+  for (const f of rest) await editFile(f);
+}
+
+log('✅ Implementation complete');
+
+// ─── Phase 4: Test & Verify ───────────────────────────────────────────────
+
+phase('Test');
+
+log('🧪 Running tests...');
+
+// Stage and review changes
+await agent('Run: git add -A && git diff --stat', { label: 'stage-and-review' });
+
+const testResult = await agent(
+  `Check for and run any available tests in this project:
+1. Check package.json for test scripts
+2. Check for test directories
+3. Check for build/validation scripts (build.ps1, build.sh, gulpfile.js, etc.)
+4. Check for lint configs
+
+Run whatever is available. If nothing exists, at minimum verify:
+- The changed files have no obvious syntax errors
+- No broken imports or references
+
+Report exactly what was run and whether it passed.`,
+  { label: 'run-tests', phase: 'Test' }
+);
+
+log(`Test output: ${testResult.substring(0, 500)}`);
+
+const testsFailed = testResult.toLowerCase().includes('fail') ||
+                    testResult.toLowerCase().includes('error');
+if (testsFailed) {
+  log('⚠️ Failures detected — attempting fixes...');
+  await agent(
+    `Tests failed. Review and fix the issues:\n${testResult}\n\nEdit the files that need correction.`,
+    { label: 'fix-failures', phase: 'Test' }
+  );
+}
+
+// End-to-end verification
+log('🔬 Verifying changes end-to-end...');
+await agent(
+  `Review the complete diff (git diff) and confirm:
+1. All changes are consistent with each other
+2. No missing imports, references, or cross-references
+3. Changes match what issue #${issueNum} requested
+4. No unintended files were modified
+
+If everything looks correct, say "VERIFIED". If issues found, list them.`,
+  { label: 'verify-diff', phase: 'Test' }
+);
+
+// ─── Phase 5: Commit & Push ───────────────────────────────────────────────
+
+log('📦 Committing...');
+
+await agent(
+  `Commit all changes with this message format:
+
+${issue.title} (#${issueNum})
+
+[Concise description of changes made]
+
+Closes #${issueNum}
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+Run:
+git add -A
+git commit -m "[the message above]"
+git push origin ${branchName}`,
+  { label: 'commit-and-push', phase: 'PR & Merge' }
+);
+
+log('✅ Pushed');
+
+// ─── Phase 6: PR, Approve, Merge, Cleanup ─────────────────────────────────
+
+phase('PR & Merge');
+
+log('🚀 Creating PR...');
+
+// Create the PR
+const prOutput = await agent(
+  `Create a pull request:
+
+gh pr create \
+  --repo ${REPO} \
+  --base ${BASE_BRANCH} \
+  --head ${branchName} \
+  --title "${issue.title} (#${issueNum})" \
+  --body "## Changes
+
+See commit history for details.
+
+## Issue
+Closes #${issueNum}
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+  --label "automated"
+
+Report the PR URL on its own line.`,
+  { label: 'create-pr' }
+);
+
+const prUrl = prOutput.match(/https:\/\/github\.com\/\S+\/pull\/\d+/)?.[0];
+log(`📬 ${prUrl || 'PR created'}`);
+
+// Approve
+log('✅ Approving PR...');
+await agent(
+  `Approve the PR:
+gh pr review --repo ${REPO} --approve --body "Automated approval — changes verified and tests passed."
+
+If self-approval is blocked, report that and continue.`,
+  { label: 'approve-pr' }
+);
+
+// Squash merge
+log('🔀 Squash merging...');
+await agent(
+  `Squash-merge the PR and delete the remote branch:
+
+gh pr merge --repo ${REPO} --squash --delete-branch \
+  --subject "${issue.title} (#${issueNum})" \
+  --body "Closes #${issueNum}
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+If merge fails (CI pending, approvals needed), report the status.
+If the issue didn't auto-close, run: gh issue close ${issueNum} --repo ${REPO} --reason completed`,
+  { label: 'merge-and-close' }
+);
+
+// Local cleanup
+await agent(
+  `Clean up local branch:
+git checkout ${BASE_BRANCH}
+git pull origin ${BASE_BRANCH}
+git branch -d ${branchName} || echo "Local branch already removed"`,
+  { label: 'cleanup-local' }
+);
+
+log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+log(`🎉 Issue #${issueNum} → PR → Merge → Close: COMPLETE`);
+log(`   Issue:  https://github.com/${REPO}/issues/${issueNum}`);
+log(`   Branch: ${branchName} (deleted)`);
+log(`   Files:  ${fileList.length} changed`);
+log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+
+return {
+  issueNumber: issueNum,
+  branchName,
+  prUrl: prUrl || null,
+  filesChanged: fileList.length,
+  summary: researchResult.summary,
+};

--- a/CUsersbruceAppDataLocalTempissue-811-body.txt
+++ b/CUsersbruceAppDataLocalTempissue-811-body.txt
@@ -1,0 +1,380 @@
+# Talents Need to Be More Restrictive
+
+## New Rules
+> Talents need to be restricted to three levels based on power/impact:
+> 1. Low power talents — at will but gain corruption
+> 2. Medium power — once per session + gain corruption
+> 3. High power — once per case file + gain corruption
+
+---
+
+## Design Approach
+
+The three tiers are a **rules classification**, not a data field. The goal is to assess each talent's actual game impact and assign:
+
+- **`frequency`** — how often it can be used: `at-will`, `per-session`, or `per-case-file`
+- **`corruptionCost`** — numeric corruption cost on activation
+
+The classification analysis below evaluates every talent's mechanical impact to produce these assignments. Once decided, `frequency` and `corruptionCost` become the implementation fields added to the data model.
+
+---
+
+## Current State
+
+### No Frequency Enforcement Exists
+All active talents cost the same +1 Corruption and can be activated as often as the player is willing to pay. "Once per session" is purely narrative text in talent descriptions — not mechanically tracked or enforced. "Once per case file" does not exist for talents (only for HQ personnel abilities in Chapter 12).
+
+### Talent Data Structure (`src/data/item-models.mjs:237-261`)
+Existing fields: `talentType`, `corruptionCost` (number, always 0 or 1), `hasHealingTag`, `isOncePerSession`, `usesPerSession: { value, max }`, `effect`
+
+**Missing fields:** `frequency` (at-will / per-session / per-case-file), `usesPerPeriod.caseFile` tracking. The `corruptionCost` field exists but is always 0 or 1 — needs to support differential costs (0, 1, 2).
+
+### Usage Tracking
+- `usesPerSession` exists on TalentDataModel — `item-document.mjs:134` checks `isOncePerSession && uses.value <= 0`
+- `item-document.mjs:124-167` `useTalent()` decrements `uses.value`, applies corruption
+- `actor-document.mjs:176-203` `resetSession()` resets per-session tracking
+- No per-case-file reset exists. No `caseFileTalentsUsed` tracking on the actor model.
+
+### Talent Count
+| Category | Count |
+|----------|-------|
+| Division Talents | 17 (5-6 per division) |
+| Sub-Unit Talents | ~30 (Stack has 6, others have 3) |
+| General Talents | 16 |
+| Background Talents | 65 |
+| **Total** | **~128 talents** |
+
+---
+
+## Talent Impact Classification
+
+### Classification Criteria
+- **Low impact** (at-will): Small numerical bonus (+1 die, +1 damage), passive always-on effect, minor situational convenience, no scene-altering power. Always active or activatable at will.
+- **Medium impact** (per-session): Significant mechanical advantage, scene-level leverage, information without a roll, once-per-session healing, moderate combat buff. Frequency limited to 1-2 uses per session.
+- **High impact** (per-case-file): Scene-altering or case-altering effect, major narrative information (DA must answer truthfully), large AoE healing/effect, full negation of a major threat. Frequency limited to once per case file.
+
+---
+
+### GENERAL TALENTS (16) — Source: `docs/chapters/13-advancement.adoc`
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Street Medic | Low | at-will | 0 | Passive: restore 2 physical attribute points instead of 1 when using Heal. Always on. |
+| Cathartic Release | Medium | per-session | +1 | 1/session healing after breaking something. Non-combat trigger. Already labeled once/session. |
+| Hair-Trigger | Low | at-will | 0 | Passive: draw weapon as free action. Always on, minor action economy. |
+| Paranormal Intuition | Low | at-will | +1 | Situational detection of supernatural presence. Costs corruption, minor effect. |
+| Heavy Packer | Low | at-will | 0 | Passive: +2 encumbrance. Always on, convenience. |
+| Skeptic's Shield | Medium | per-session | +1 | 1/session ignore one supernatural effect entirely. Defensive, powerful but narrow. |
+| Night Owl | Low | at-will | 0 | Passive: reduce darkness/visibility penalties. Always on, situational. |
+| Chain Smoker | Medium | per-session | +1 | Healing with resource cost (consumables). Has per-session healing tag. |
+| Analog Junkie | Low | at-will | 0 | Passive: +2 with specific era tech. Always on, narrow scope. |
+| Grit Your Teeth | Medium | per-session | +1 | 1/session ignore any single penalty. Versatile defensive tool. |
+| Desensitized | Low | at-will | 0 | Passive: +1 to resist fear/intimidation. Always on, narrow scope. |
+| Lucky Coin | Low | at-will | +1 | Prevent one gear degradation at will. Costs corruption, minor economy. |
+| Iron Will | Medium | per-session | +1 | Conditional healing on kill/banish. Triggered, so frequency is self-limiting but effect is significant. |
+| Brawler | Low | at-will | 0 | Passive: +1 unarmed damage. Always on, minor. |
+| Flee the Scene | Low | at-will | 0 | Passive: +2 to escape/pursuit rolls. Always on, situational. |
+| Requisition Authority | Low | at-will | 0 | Passive: permanent +1 CL increase (repeatable purchase). No activation — it modifies your character sheet. |
+
+**General Talents Summary:** 9 Low, 7 Medium, 0 High
+
+---
+
+### WAYFINDER DIVISION TALENTS (5) — Source: `docs/chapters/09-divisions.adoc`
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| The Antiquarian's Eye | Medium | per-session | +1 | Identify artifact purpose without a roll. Skips a major investigation step. |
+| Ghost in the Machine | Medium | per-session | +1 | Bypass supernatural tech interference for one scene. Situational but powerful when relevant. |
+| The Hunch | High | per-case-file | +2 | **DA must answer one question truthfully.** This is the most powerful information-gathering ability in the game. Case-altering. |
+| Academic Grounding | Medium | per-session | +1 | Healing talent (1 Corruption, 1 hour). Once per session via healing tag. |
+| Eldritch Empathy | Medium | per-session | +1 | Sense a supernatural entity's emotional state and intent. Skips investigation steps. |
+
+**Wayfinder Division Summary:** 0 Low, 4 Medium, 1 High (The Hunch)
+
+---
+
+### WAYFINDER SUB-UNIT TALENTS — Source: `docs/chapters/09-divisions.adoc`
+
+**Research Wing (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Pattern Recognition | Low | at-will | +1 | Identify one connection on inspection. Costs corruption, minor info. |
+| Deep Archive Access | Low | at-will | 0 | Passive: +2 dice to next Lore/Investigate after research. One-time bonus, self-limiting. |
+| Methodical Review | Medium | per-session | +1 | Healing + ally buff. Costs a Shift. Once per session via healing tag. |
+
+**Counterintelligence (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Burned Asset | Medium | per-session | +1 | Deploy cover story vs Diff 2. Useful but roll-gated. |
+| Signal Intercept | Medium | per-session | +1 | Eavesdrop on communications for entire scene. Scene-length advantage. |
+| Compartmentalized Mind | Medium | per-session | +1 | 1/session healing after CI action. Healing tag. |
+
+**Wayfinder Sub-Unit Summary:** 2 Low, 4 Medium, 0 High
+
+---
+
+### RECOVERY DIVISION TALENTS (6) — Source: `docs/chapters/09-divisions.adoc`
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Conditioned Mind | Medium | per-session | 0 | 1/session negate push corruption. Already labeled once/session. No corruption cost (it prevents corruption). |
+| Unstoppable Force | Medium | per-session | +1 | +2 damage for one attack. Combat buff, once per engagement feels right. |
+| Shadow Walker | High | per-case-file | +2 | **Full scene mundane invisibility.** Extremely powerful — bypass entire encounters. Currently a major balance concern (audit issue #578). |
+| Adrenaline Junkie | Low | at-will | 0 | Passive: +2 AGI when at or below half STR. Conditional always-on. |
+| Gallows Humor | High | per-case-file | +2 | **1d4 corruption healing for the entire team.** AoE heal that bypasses the 5/session cap for each recipient. Case-altering recovery. |
+| Combat Reflexes | Medium | per-session | 0 | Draw 2 initiative cards, keep 1. Already per-session narrative. Passive-esque in effect. |
+
+**Recovery Division Summary:** 1 Low, 3 Medium, 2 High (Shadow Walker, Gallows Humor)
+
+---
+
+### RECOVERY SUB-UNIT TALENTS — Source: `docs/chapters/09-divisions.adoc`
+
+**Ex-Agency Operative (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Dead Drop Protocol | Medium | per-session | +1 | Free intelligence without a roll. Skips investigation. |
+| Exfiltration Specialist | Low | at-will | 0 | Passive: +1 AGI to self and nearby allies. Always on aura. |
+| Spycraft Discipline | Medium | per-session | +1 | 1/session healing after covert operation. Healing tag. |
+
+**Heavy-Hitter (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Wrecking Ball | Medium | per-session | +1 | +3 dice +2 damage vs objects/structures. Powerful but narrow (objects only). |
+| Stand Your Ground | Medium | per-session | +1 | Immovable, +2 AR for one turn. Strong defensive cooldown. |
+| Blunt Trauma Recovery | Medium | per-session | +1 | 1/session healing after combat. Healing tag. |
+
+**Acquisition Specialist (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Ghost Entry | High | per-case-file | +2 | **Bypass any lock without a roll, leave no trace.** Eliminates an entire obstacle category. |
+| The Long Con | Medium | per-session | +1 | +3 Manipulate after building rapport. Strong but requires setup. |
+| Clean Getaway | Medium | per-session | +1 | 1/session healing after escape. Healing tag. |
+
+**Recovery Sub-Unit Summary:** 1 Low, 7 Medium, 1 High (Ghost Entry)
+
+---
+
+### KEEP DIVISION TALENTS — Source: `docs/chapters/09-divisions.adoc` and `talents.yaml`
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Containment Protocol | Medium | per-session | +1 | Fast action ward vs supernatural for one scene. Powerful but narrow. |
+| Shield of the Covenant | Medium | per-session | +1 | Intercept an attack, take half damage. Strong defensive tool. |
+| The Inquisitor's Gaze | High | per-case-file | +2 | **Know an NPC's exact corruption value and possession status.** Eliminates hidden threat — massive information advantage. |
+| Medical Training | Medium | per-session | +1 | Improve an ally's Death Check. Life-or-death intervention, already per-session. |
+| Sanctuary Master | Low | at-will | 0 | Auto-succeed Lore for artifacts registered in HQ. Extremely narrow scope. |
+| The Confessor | High | per-case-file | +2 | **Both speaker and target heal 1d4 corruption.** Repeatable per target per scene. No daily cap. This is the most abusable healing talent (audit issue #582). |
+
+**Keep Division Summary:** 1 Low, 3 Medium, 2 High (Inquisitor's Gaze, The Confessor)
+
+---
+
+### KEEP SUB-UNIT TALENTS — Source: `docs/chapters/09-divisions.adoc`
+
+**Catalogers (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Hazard Classification | Medium | per-session | +1 | Free artifact danger rating without a roll. Skips a risk assessment step. |
+| Registry Cross-Reference | Medium | per-session | +1 | Free connection between two registered artifacts. Information without roll. |
+| Archival Calm | Medium | per-session | +1 | Healing + ally buff. Costs a Shift. Healing tag. |
+
+**Wardens (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Lockdown | Medium | per-session | +1 | Seal one entrance for 1 round. Tactical, narrow duration. |
+| Threat Assessment | Medium | per-session | +1 | Free threat identification on entering an area. Skips assessment. |
+| Sentinel's Vigil | Medium | per-session | +1 | 1/session healing after guard duty. Healing tag. |
+
+**Internal CI (3):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Silent Audit | High | per-case-file | +2 | **Secretly access any personnel file in the Covenant.** Massive narrative information — can reshape a case. |
+| Loyalty Test | Medium | per-session | +1 | +2 Empathy to detect deception. Strong but narrow. |
+| Debriefing Protocol | Medium | per-session | +1 | 1/session healing after investigation. Healing tag. |
+
+**Stack / Logistics — has 6 talents (audit issue #580):**
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| Requisition Expert | Low | at-will | 0 | Auto-acquire one item during Equipping Phase. Passive — modifies the requisition procedure. |
+| Jury-Rig | Medium | per-session | +1 | Instantly restore a broken item mid-scene. Powerful gear economy save. |
+| Prototyper | Medium | per-session | +1 | Grant an Artifact Die to an item; item is destroyed after. Strong but self-destructive. |
+| Duct Tape & WD-40 | Medium | per-session | +1 | Repair all gear + heal. Shift cost. Healing tag. |
+| Experimental Shielding | Medium | per-session | +1 | 1/session ignore one Gear Die degradation. Gear economy protection. |
+| Redundant Safeties | Low | at-will | 0 | Passive: +2 corruption threshold. Always on, character sheet modifier. |
+
+**Keep Sub-Unit Summary:** 2 Low, 11 Medium, 1 High (Silent Audit)
+
+---
+
+### BACKGROUND TALENTS (65) — Source: `docs/chapters/13-advancement.adoc`
+
+All 65 background talents follow an identical pattern: **+1 bonus die to a specific skill**. Examples: Archaeologist (+1 Lore), Police Officer (+1 Investigate), Military Veteran (+1 Firearms), etc.
+
+| Talent | Impact | Frequency | Corruption | Rationale |
+|--------|--------|-----------|------------|-----------|
+| All 65 Background Talents | Low | at-will | 0 | Passive always-on +1 die to a single skill. No activation. Minor numerical bonus. |
+
+**Background Talents Summary:** 65 Low, 0 Medium, 0 High
+
+---
+
+## Classification Totals
+
+| Category | Low (at-will) | Medium (per-session) | High (per-case-file) |
+|----------|---------------|---------------------|----------------------|
+| General (16) | 9 | 7 | 0 |
+| Wayfinder Division (5) | 0 | 4 | 1 (The Hunch) |
+| Wayfinder Sub-Unit (6) | 2 | 4 | 0 |
+| Recovery Division (6) | 1 | 3 | 2 (Shadow Walker, Gallows Humor) |
+| Recovery Sub-Unit (9) | 1 | 7 | 1 (Ghost Entry) |
+| Keep Division (6) | 1 | 3 | 2 (Inquisitor's Gaze, The Confessor) |
+| Keep Sub-Unit (15) | 2 | 12 | 1 (Silent Audit) |
+| Background (65) | 65 | 0 | 0 |
+| **TOTAL (~128)** | **81** | **40** | **7** |
+
+### High-Impact Talents (7 — need per-case-file restriction)
+1. **The Hunch** (Wayfinder) — DA must answer truthfully
+2. **Shadow Walker** (Recovery) — full scene mundane invisibility
+3. **Gallows Humor** (Recovery) — 1d4 AoE corruption heal for entire team
+4. **Ghost Entry** (Recovery Acq. Specialist) — bypass any lock, no roll, no trace
+5. **The Inquisitor's Gaze** (Keep) — know NPC corruption + possession status
+6. **The Confessor** (Keep) — both heal 1d4, repeatable per target per scene
+7. **Silent Audit** (Keep Internal CI) — secretly access any Covenant personnel file
+
+---
+
+## Implementation: Fields to Add
+
+Based on the classification above, the data model needs these fields (NOT a `powerLevel` field):
+
+### `TalentDataModel` (`src/data/item-models.mjs:237-261`)
+- **`frequency`** — StringField: `"at-will"` | `"per-session"` | `"per-case-file"`. Determines when usage resets.
+- **`corruptionCost`** — existing NumberField, but expand range from 0-1 to 0-2. High-impact talents cost 2 corruption.
+- **`usesPerPeriod`** — SchemaField replacing current `usesPerSession`: `{ session: {value, max}, caseFile: {value, max} }`. The `max` value enforces frequency.
+
+### `AgentDataModel` (`src/data/actor-models.mjs`)
+- **`sessionTalentsUsed`** — tracks which per-session talents have been expended this session
+- **`caseFileTalentsUsed`** — tracks which per-case-file talents have been expended this case file
+
+---
+
+## Complete File Inventory (~35 files across 2 repos)
+
+### REPO 1: `foundry-neon-relic-system` — Data Schema (3 files)
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `src/data/item-models.mjs:237-261` | Add `frequency` (StringField) and `usesPerPeriod` (SchemaField). Expand `corruptionCost` range to 0-2. |
+| 2 | `src/data/actor-models.mjs:66-73,106-111` | Add `sessionTalentsUsed` and `caseFileTalentsUsed` tracking to AgentDataModel |
+| 3 | `src/system/config.mjs:48-54` | Add `NEON_RELIC.talentFrequencies` config enum (at-will / per-session / per-case-file) |
+
+### REPO 1: `foundry-neon-relic-system` — Logic (5 files)
+
+| # | File | Change |
+|---|------|--------|
+| 4 | `src/item/item-document.mjs:124-167` | Rewrite `useTalent()` to check `frequency`, enforce usage limits, apply `corruptionCost` (0/1/2), track on actor model |
+| 5 | `src/actor/actor-document.mjs:176-203` | Add `resetCaseFile()` method; update `resetSession()` for new tracking fields |
+| 6 | `src/actor/agent/agent-sheet.mjs:258-285` | Update talent drop handler for frequency-aware limits |
+| 7 | `src/components/corruption.mjs` | Support differential corruption costs (0/1/2) when talent is activated |
+| 8 | `src/system/session-tracker.mjs` | Add `performCaseFileReset()` alongside existing `performSessionReset()` |
+
+### REPO 1: `foundry-neon-relic-system` — UI Templates (5 files)
+
+| # | File | Change |
+|---|------|--------|
+| 9 | `src/templates/actor/agent/agent-talents.hbs` | Add frequency indicator (at-will / per-session / per-case-file label) and usage tracker |
+| 10 | `src/templates/item/talent.hbs` | Add frequency dropdown and usesPerPeriod fields |
+| 11 | `src/templates/actor/agent/wizard/step-talents.hbs` | Add frequency label in slot display |
+| 12 | `src/templates/actor/agent/wizard/talent-picker.hbs` | Add frequency/impact indicator in picker entries |
+| 13 | `src/templates/actor/agent/wizard/step-summary.hbs` | Add frequency label in summary |
+
+### REPO 1: `foundry-neon-relic-system` — Compendium & Locale (3 files)
+
+| # | File | Change |
+|---|------|--------|
+| 14 | `src/packs/talents.yaml` (all ~128 entries) | Apply classification table above: set `frequency` and `corruptionCost` on every talent |
+| 15 | `src/packs/rules-reference.yaml` | Update rules journal with frequency system explanation |
+| 16 | `src/lang/en.yaml:321-343,461-466,1076-1094` | Add i18n keys: `Frequency`, `AtWill`, `PerSession`, `PerCaseFile`, usage cap messages |
+
+### REPO 1: `foundry-neon-relic-system` — Infrastructure & Styles (3 files)
+
+| # | File | Change |
+|---|------|--------|
+| 17 | `src/styles/_agent-sheet.scss:736-803` | Add frequency indicator and usage tracker styles |
+| 18 | `src/system/sockets.mjs` | Add `CASE_FILE_RESET` socket event |
+| 19 | `DEVELOPMENT-PLAN.md` | Update talent section with frequency system |
+
+### REPO 2: `neon-relic` — Rulebook Chapters (5 files)
+
+| # | File | Change |
+|---|------|--------|
+| 20 | `docs/chapters/02-character-creation.adoc:137-154` | Add frequency rules to Step 5. Explain at-will, per-session, per-case-file. Update Petra worked example. |
+| 21 | `docs/chapters/09-divisions.adoc` (all talent tables) | Add Frequency and Corruption Cost columns to all 16+ talent tables. Apply classification above. |
+| 22 | `docs/chapters/13-advancement.adoc` | Add frequency to all 16 General Talents entries. Define frequency-based purchase rules. |
+| 23 | `docs/chapters/08-corruption-fear-healing.adoc` | Update Sources of Corruption with frequency-based costs. Update healing talent rules. |
+| 24 | `docs/chapters/21-glossary.adoc` | Add entries for "At-Will", "Per-Session", "Per-Case-File" |
+
+### REPO 2: `neon-relic` — Web App (3 files)
+
+| # | File | Change |
+|---|------|--------|
+| 25 | `docs/web-app-char-gen/data.js:204-412` | Apply classification to all talent objects: set `frequency` and numeric `corruptionCost` |
+| 26 | `docs/web-app-char-gen/app.js:263-409,643-668` | Frequency-aware picker and display |
+| 27 | `docs/web-app-char-gen/index.html` | Frequency display CSS |
+
+### REPO 2: `neon-relic` — Printable & Prebuilt (3 + 12 files)
+
+| # | File | Change |
+|---|------|--------|
+| 28 | `assets/character-sheet.html:299-322,623-639` | Add frequency labels and usage checkboxes to talent blocks |
+| 29 | `starter-kit/blank-templates/agent-dossier.html` | Add frequency label areas |
+| 30 | `docs/web-app-da-board/data.js:256-475` | Update PREBUILT_AGENTS talent objects |
+| 31-42 | `starter-kit/prebuilt-characters/character-*.html` (5) + `assets/prebuilt/character-*.html` (5) + `Bruce-Stuff/character-*.html` (2) | Add frequency labels to talent blocks |
+
+---
+
+## What Needs to Change
+
+### Phase 1: Classification Review
+Review the classification table above. The 7 high-impact talents and 40 medium-impact talents are the key decisions. The 65 background talents and ~12 passive general/division talents are straightforward low-impact.
+
+### Phase 2: Data Model
+Add `frequency` and `usesPerPeriod` to TalentDataModel. Add session/case-file tracking to AgentDataModel. Expand `corruptionCost` range to 0-2.
+
+### Phase 3: Logic
+Rewrite `useTalent()` to enforce frequency. Add `resetCaseFile()`. Wire per-case-file reset to the case file lifecycle.
+
+### Phase 4: UI
+Add frequency labels and usage trackers to talent tab, item sheet, wizard, picker, and summary.
+
+### Phase 5: Rules Text
+Apply the classification to all talent tables in the rulebook. Document the frequency system.
+
+### Phase 6: Compendium & Web App
+Apply `frequency` and `corruptionCost` to all ~128 compendium talent entries and all web app talent data.
+
+## Design Decisions Required
+1. **Slot limits by frequency**: How many per-case-file talents per character? (Recommended: max 1 at creation, max 2 total)
+2. **XP costs by frequency**: Should high-frequency-restricted talents cost more XP? (Recommended: at-will 6 XP, per-session 6 XP, per-case-file 10 XP)
+3. **Stack normalization**: Stack has 6 sub-unit talents. Should they be trimmed to 3 to match others? (Audit issue #580)
+4. **Healing talent cap**: Currently 3/session for healing tags. Does frequency replace or supplement this?
+5. **Corruption costs**: At-will +1, per-session +1, per-case-file +2 (per the classification above)?
+
+## Related Issues
+- #571: Free Talents vs Ch 8 Sources of Corruption
+- #577: Healing Talent Triggers — Wildly Uneven Attainability
+- #578: Shadow Walker — Full-Scene Invisibility Extremely Powerful
+- #580: Stack Has 6 Sub-Unit Talents vs 3 for Others
+- #582: The Confessor — Repeatable Use Undefined
+

--- a/docs/chapters/02-character-creation.adoc
+++ b/docs/chapters/02-character-creation.adoc
@@ -149,6 +149,18 @@ At creation, every agent selects *three* talents, one from each of the following
 
 Most Division Talents cost *+1 Corruption* to activate. One talent per list is a *Healing* talent, usable freely but once per session. General Talents are passive or per-session effects with no Corruption cost unless noted. Background Talents are always passive — no activation cost.
 
+Talents are further restricted by *usage frequency*, which determines how often they can be activated and when their uses reset:
+
+[cols="2,5", options="header"]
+|===
+| Frequency | Rule
+| *At-Will* | Can be activated any number of times. Each activation costs the listed Corruption. Passive talents (no activation) are always at-will.
+| *Per-Session* | Limited uses per play session. Uses reset at the start of each new session via Session Reset. Most Medium-impact talents fall here.
+| *Per-Case-File* | Limited uses per Case File operation. Uses reset at the start of each new Case File via Case File Reset. Reserved for the most powerful, case-altering talents.
+|===
+
+See the individual talent tables in xref:chapters/09-divisions.adoc#chapter-divisions[Divisions] and xref:chapters/13-advancement.adoc#chapter-advancement[Advancement] for each talent's frequency and Corruption cost.
+
 Talents and Division items are meant to create *leverage*: a clue path, a brief edge, a safer handling window, a cleaner extraction. They should not change the game's default expectation that agents must still investigate, improvise, and pay a price for certainty.
 
 > *Talent Advancement:* Additional General, Division, or Wing/Paradigm/Department talents can be purchased during play using XP. See xref:chapters/13-advancement.adoc#chapter-advancement[Advancement and Talents].

--- a/docs/chapters/08-corruption-fear-healing.adoc
+++ b/docs/chapters/08-corruption-fear-healing.adoc
@@ -28,7 +28,7 @@ When a character's Corruption *exceeds* their threshold, their mind permanently 
 | Trigger | Corruption Gained | Description
 
 | *Pushing a Roll* | +1 | Exerting your absolute limits invites psychic static.
-| *Activating a Division Talent* | +1 (or free) | Most talents that tap the supernatural exact a cost. Talents marked *—* in their Corruption Cost column are free to activate — healing and passive-support talents carry no Corruption. See each talent's entry in xref:chapters/09-talents.adoc#chapter-talents[Talents].
+| *Activating a Division Talent* | +0 to +2 | Talent Corruption cost is determined by the talent's impact on the game. *At-will* and *per-session* talents typically cost +1 Corruption; the most powerful *per-case-file* talents cost +2. Passive talents (marked 0 in their Corruption Cost column) carry no Corruption cost. See each talent's entry in xref:chapters/09-divisions.adoc#chapter-divisions[Divisions] and xref:chapters/13-advancement.adoc#chapter-advancement[Advancement].
 | *Occult Exposure* | +1 to +3 | Witnessing entities, reading forbidden tomes, or being targeted by anomalous phenomena. DA sets severity.
 | *Artifact Activation* | +1 to +3 | Utilizing an artifact's supernatural properties. Cost varies by artifact tier.
 | *Corruption Burst (any 1s rolled)* | +1 | The mind cracks trying to process the unprocessable. See Corruption Burst rules below.

--- a/docs/chapters/13-advancement.adoc
+++ b/docs/chapters/13-advancement.adoc
@@ -25,7 +25,8 @@ Experience Points (XP) are the game's *only* advancement currency. They are awar
 | Upgrade | XP Cost | Limit
 
 | Increase a Skill by 1 | 5 XP | Maximum rating of 5
-| Purchase a new Talent | 6 XP | General, Division, or Wing/Paradigm/Department Talent
+| Purchase a new Talent (at-will or per-session) | 6 XP | General, Division, or Wing/Paradigm/Department Talent
+| Purchase a new Talent (per-case-file) | 10 XP | High-impact talents restricted to once per Case File
 |===
 
 > *Note on CL and Standing:* Clearance Level is no longer purchased directly with XP. To increase a character's *personal* CL, purchase the *Requisition Authority* general talent (6 XP, repeatable). This raises the individual agent's permanent CL independent of team Standing. Separately, team Standing (see xref:chapters/12-headquarters.adoc#chapter-headquarters[Ch 12 — Headquarters]) grants the *entire cell* a temporary equipping-phase cap (CL 3 at Standing 5, CL 4 at Standing 10) — but this is a cell-wide access floor, not a personal CL increase. If an agent's personal CL is already higher than the cell's Standing-granted floor, use their personal CL. If lower, use whichever is higher during the Equipping Phase only.
@@ -76,26 +77,26 @@ This is the *canonical General Talents list* used at character creation and duri
 
 > *Healing Tag and Stacking:* Talents with the _(Healing)_ tag can heal Corruption. Each tagged talent's trigger is independent, but a character may heal a maximum of *3 Corruption per session* from Healing-tagged General Talents combined — regardless of how many they possess or how many triggers fire. This cap does not apply to Corruption healed by city network capabilities, the Warden's Bracer, or Division talents.
 
-[cols="2,4", options="header"]
+[cols="2,1,1,3", options="header"]
 |===
-| Talent | Effect
+| Talent | Frequency | Corruption | Effect
 
-| *Street Medic* | Restore 2 physical Attribute points instead of 1 when successfully using Heal (WIT).
-| *Cathartic Release* _(Healing)_ | Once per session, dedicate a moment to breaking down, screaming, or venting — this must occur in a scene where you are not actively in conflict. Heal 1 Corruption.
-| *Hair-Trigger* | Draw a weapon as a free action instead of a fast action. Critical edge in ambushes.
-| *Paranormal Intuition* | When entering a new room or location, roll Investigate (WIT) Difficulty 1. On success, the DA must tell you if a supernatural entity has been here in the last 24 hours. This roll cannot be pushed.
-| *Heavy Packer* | Your carry capacity increases to *Strength × 3* Enc. (instead of the standard Strength × 2). You are not Overloaded until your Enc. exceeds Strength × 4 (instead of Strength × 3).
-| *Skeptic's Shield* | Once per session, when exposed to a *minor supernatural effect* — defined as any effect that deals 1 or fewer Corruption, does not cause physical damage, and has no lasting duration — you may outright ignore it by rigidly refusing to acknowledge the impossible. Does not apply to Burst or Catastrophic artifact effects.
-| *Night Owl* | Ignore all penalties from sleep deprivation. When operating in darkness, you treat Darkness as Dim (−1 die, not −2 dice).
-| *Chain Smoker* _(Healing)_ | Consume a period-appropriate scarce resource (cigarettes, specific 1980s junk food, etc.) during a non-conflict moment. Heal 1 Corruption. The resource must actually be spent and removed from your inventory.
-| *Analog Junkie* | Gain +2 bonus dice when using period-accurate 1980s technology (ham radios, acoustic couplers, microfiche, reel-to-reel). The equipment must be correctly identified as 1980s-era gear; the DA rules on edge cases.
-| *Grit Your Teeth* | Once per session, ignore a −1 Attribute penalty for a single roll. Declare before rolling.
-| *Desensitized* | Gain +1 bonus die on Endure (STR) or Empathy (EMP) rolls when witnessing or investigating *horrific or gruesome* scenes (DA-designated — typically scenes involving mass casualties, mutilation, or sustained supernatural terror). Does not apply to standard combat or single-casualty crime scenes.
-| *Lucky Coin* | Once per session, ignore a 1 rolled on a single Gear die, preventing item degradation. Declare after seeing the roll.
-| *Iron Will* _(Healing)_ | When you *personally* deliver the killing blow to a Named Threat or banish a supernatural entity (using the Banishment ritual in full), heal 1 Corruption. A "killing blow" requires your attack to reduce the target to 0 Strength. Banishment must be a completed ritual, not just an attack on an entity.
-| *Brawler* | Unarmed strikes inflict base damage of 2 instead of 1.
-| *Flee the Scene* | Gain +2 bonus dice to Agility (ATT) when rolling explicitly to escape a conflict or pursue fleeing targets.
-| *Requisition Authority* _(Repeatable)_ | Increase your *personal* Clearance Level by 1 (maximum CL 5). May be purchased multiple times. No Standing prerequisite — this talent represents individual institutional recognition, useful for agents who want personal CL access before the team's Standing catches up to that tier. Purchasing this talent does not count toward or substitute the team's Standing-based access rewards.
+| *Street Medic* | At-Will | 0 | Restore 2 physical Attribute points instead of 1 when successfully using Heal (WIT).
+| *Cathartic Release* _(Healing)_ | Per-Session | +1 | Once per session, dedicate a moment to breaking down, screaming, or venting — this must occur in a scene where you are not actively in conflict. Heal 1 Corruption.
+| *Hair-Trigger* | At-Will | 0 | Draw a weapon as a free action instead of a fast action. Critical edge in ambushes.
+| *Paranormal Intuition* | At-Will | +1 | When entering a new room or location, roll Investigate (WIT) Difficulty 1. On success, the DA must tell you if a supernatural entity has been here in the last 24 hours. This roll cannot be pushed.
+| *Heavy Packer* | At-Will | 0 | Your carry capacity increases to *Strength × 3* Enc. (instead of the standard Strength × 2). You are not Overloaded until your Enc. exceeds Strength × 4 (instead of Strength × 3).
+| *Skeptic's Shield* | Per-Session | +1 | Once per session, when exposed to a *minor supernatural effect* — defined as any effect that deals 1 or fewer Corruption, does not cause physical damage, and has no lasting duration — you may outright ignore it by rigidly refusing to acknowledge the impossible. Does not apply to Burst or Catastrophic artifact effects.
+| *Night Owl* | At-Will | 0 | Ignore all penalties from sleep deprivation. When operating in darkness, you treat Darkness as Dim (−1 die, not −2 dice).
+| *Chain Smoker* _(Healing)_ | Per-Session | +1 | Consume a period-appropriate scarce resource (cigarettes, specific 1980s junk food, etc.) during a non-conflict moment. Heal 1 Corruption. The resource must actually be spent and removed from your inventory.
+| *Analog Junkie* | At-Will | 0 | Gain +2 bonus dice when using period-accurate 1980s technology (ham radios, acoustic couplers, microfiche, reel-to-reel). The equipment must be correctly identified as 1980s-era gear; the DA rules on edge cases.
+| *Grit Your Teeth* | Per-Session | +1 | Once per session, ignore a −1 Attribute penalty for a single roll. Declare before rolling.
+| *Desensitized* | At-Will | 0 | Gain +1 bonus die on Endure (STR) or Empathy (EMP) rolls when witnessing or investigating *horrific or gruesome* scenes (DA-designated — typically scenes involving mass casualties, mutilation, or sustained supernatural terror). Does not apply to standard combat or single-casualty crime scenes.
+| *Lucky Coin* | At-Will | +1 | Once per session, ignore a 1 rolled on a single Gear die, preventing item degradation. Declare after seeing the roll.
+| *Iron Will* _(Healing)_ | Per-Session | +1 | When you *personally* deliver the killing blow to a Named Threat or banish a supernatural entity (using the Banishment ritual in full), heal 1 Corruption. A "killing blow" requires your attack to reduce the target to 0 Strength. Banishment must be a completed ritual, not just an attack on an entity.
+| *Brawler* | At-Will | 0 | Unarmed strikes inflict base damage of 2 instead of 1.
+| *Flee the Scene* | At-Will | 0 | Gain +2 bonus dice to Agility (ATT) when rolling explicitly to escape a conflict or pursue fleeing targets.
+| *Requisition Authority* _(Repeatable)_ | At-Will | 0 | Increase your *personal* Clearance Level by 1 (maximum CL 5). May be purchased multiple times. No Standing prerequisite — this talent represents individual institutional recognition, useful for agents who want personal CL access before the team's Standing catches up to that tier. Purchasing this talent does not count toward or substitute the team's Standing-based access rewards.
 |===
 
 ---

--- a/docs/chapters/21-glossary.adoc
+++ b/docs/chapters/21-glossary.adoc
@@ -14,6 +14,7 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 | *Anchor* | A physical object linked to a humanizing memory. Once per session, a character may interact with their Anchor to heal 1d4 Corruption. See xref:chapters/08-corruption-fear-healing.adoc#_anchors[Anchors].
 | *Armor Rating* | The number of Gear dice rolled to absorb incoming damage. Each 6 rolled cancels one point of damage. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 | *Attribute Dice* | White dice in the pool, equal to the relevant Attribute score (Strength, Agility, Wits, or Empathy). See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
+| *At-Will* | A talent usage frequency. At-will talents can be activated any number of times, paying the listed Corruption cost for each activation. Passive talents (no activation required) are always at-will. See xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
 |===
 
 == B
@@ -51,7 +52,7 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 | *Disposition* | An NPC's current openness to engagement in Social Conflict, tracked from 1 (Closed) to 5 (Open). At Disposition 3 or higher, direct low-risk questions are answered without a roll; social rolls are reserved for sensitive disclosures or requests against self-interest. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict].
 | *Division* | Character class within the Verdant Covenant. The three playable Divisions are Wayfinder (research/intelligence), Recovery (field retrieval), and The Keep (vault security, custody, and logistics). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 | *Division Item* | A signature supernatural object issued to every member of a Division. Wayfinder: Verdant Codex. Recovery: Verdant Satchel. Keep: Warden's Bracer. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
-| *Division Talent* | A class-specific ability unique to one Division. Costs +1 Corruption to activate (most talents). See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
+| *Division Talent* | A class-specific ability unique to one Division. Costs +1 to +2 Corruption to activate depending on impact. Usage frequency (at-will, per-session, or per-case-file) determines how often it can be activated. See xref:chapters/09-divisions.adoc#chapter-divisions[Divisions].
 | *Dying* | State when a Broken character has an active Death Check Critical Injury (result marked †) that has not yet been resolved. An untreated Dying character will die. See xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].
 |===
 
@@ -125,6 +126,8 @@ Quick reference for all game-specific terms used in the Neon Relic core rules. E
 [cols="1,3", frame=none, grid=rows, stripes=none]
 |===
 | *Panic Table* | A d6 table rolled on Fear check failure. Determines the character's involuntary response: Fight (1), Flight (2), Freeze (3), Denial (4), Compulsion (5), or Fugue (6). See xref:chapters/08-corruption-fear-healing.adoc#chapter-corruption[Corruption, Fear & Healing].
+| *Per-Case-File* | A talent usage frequency. Per-case-file talents have limited uses that reset at the start of each new Case File via Case File Reset. Reserved for the most powerful, case-altering talents. See xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
+| *Per-Session* | A talent usage frequency. Per-session talents have limited uses that reset at the start of each new play session via Session Reset. Most Medium-impact talents use this frequency. See xref:chapters/02-character-creation.adoc#chapter-character-creation[Character Creation].
 | *Shift Row* | The top row of the Operations Board. Each day-column is quartered into Morning / Day / Evening / Night. Tracks time spent and relic escalation — relic milestones trigger when the DA fills a shift quadrant that crosses a milestone day. See xref:chapters/15-case-file.adoc#chapter-case-file[Case Files].
 | *Push* | Re-roll all non-6 dice after a roll fails to meet its Difficulty, or after a success when you want more successes. Costs +1 Corruption. Each roll may only be pushed once. Gear dice that show 1 on the push cause degradation. See xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution].
 | *Psychoanalyze* | A skill used to read psychological states, detect deception, stabilize distressed people during social scenes, and treat mental and emotional Critical Injuries. See xref:chapters/06-social-conflict.adoc#chapter-social-conflict[Social Conflict] and xref:chapters/07-health-damage-armor.adoc#chapter-health[Health, Damage & Armor].

--- a/docs/web-app-char-gen/data.js
+++ b/docs/web-app-char-gen/data.js
@@ -204,41 +204,41 @@ const NR_DATA = {
   // ─── DIVISION TALENTS ────────────────────────────────────
   divisionTalents: {
     wayfinder: [
-      { name: "The Antiquarian's Eye", cost: "+1 Corruption",
+      { name: "The Antiquarian's Eye", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "On first inspection, identify either an artifact's activation trigger or its base effect without a Lore roll." },
-      { name: "Ghost in the Machine", cost: "+1 Corruption",
+      { name: "Ghost in the Machine", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Use Tech to read data from electronic devices jammed or possessed by anomalous entities, bypassing the entity's interference." },
-      { name: "The Hunch", cost: "+1 Corruption",
+      { name: "The Hunch", cost: "+2 Corruption", frequency: "per-case-file", corruptionCost: 2,
         effect: "Ask the DA one yes/no question about a crime scene or NPC's motive. The DA must answer truthfully." },
-      { name: "Academic Grounding", cost: "— (Healing)",
+      { name: "Academic Grounding", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Spend an hour researching an entity and framing it in academic terms. Heal 1 Corruption for yourself or one ally." },
-      { name: "Eldritch Empathy", cost: "+1 Corruption",
+      { name: "Eldritch Empathy", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Sense the immediate emotional state, hunger, or primary intent of an invisible or disguised supernatural entity." }
     ],
     recovery: [
-      { name: "Conditioned Mind", cost: "—",
+      { name: "Conditioned Mind", cost: "—", frequency: "per-session", corruptionCost: 0,
         effect: "Declare before you push the roll. Once per session, you may push a roll and entirely ignore the +1 Corruption that pushing costs." },
-      { name: "Unstoppable Force", cost: "+1 Corruption",
+      { name: "Unstoppable Force", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Your next successful melee or unarmed attack inflicts +2 damage." },
-      { name: "Shadow Walker", cost: "+1 Corruption",
+      { name: "Shadow Walker", cost: "+2 Corruption", frequency: "per-case-file", corruptionCost: 2,
         effect: "For the duration of a scene, you are entirely imperceptible to mundane guards and cameras. Attacking breaks the effect immediately." },
-      { name: "Adrenaline Junkie", cost: "—",
+      { name: "Adrenaline Junkie", cost: "—", frequency: "at-will", corruptionCost: 0,
         effect: "When your Strength has taken at least 1 point of damage, gain +2 bonus dice to all Agility rolls." },
-      { name: "Gallows Humor", cost: "— (Healing)",
+      { name: "Gallows Humor", cost: "+2 Corruption", frequency: "per-case-file", corruptionCost: 2,
         effect: "Once per session, immediately after a combat encounter ends, crack a dark joke. You and all allies who can hear you heal 1d4 Corruption." },
-      { name: "Combat Reflexes", cost: "—",
+      { name: "Combat Reflexes", cost: "—", frequency: "per-session", corruptionCost: 0,
         effect: "When initiative cards are drawn, draw two cards and keep one. Alternatively, you may swap your initiative card with a willing ally's card." }
     ],
     keep: [
-      { name: "Lockdown", cost: "+1 Corruption",
+      { name: "Lockdown", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Seal a room, corridor, or building entrance. No entity — mundane or supernatural — may pass through it for one full round without a Strength (Force) roll at Difficulty 2." },
-      { name: "Threat Assessment", cost: "+1 Corruption",
+      { name: "Threat Assessment", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "When entering a new area, instantly identify the single greatest physical threat present (hostile actor, structural weakness, hidden trap). The DA must describe it." },
-      { name: "Sentinel's Vigil", cost: "— (Healing)",
+      { name: "Sentinel's Vigil", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after completing a guard shift, patrol, or escort mission without a security breach, heal 1 Corruption." },
-      { name: "Hazard Classification", cost: "+1 Corruption",
+      { name: "Hazard Classification", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Upon first contact with an unknown artifact, instantly determine its danger rating (Inert / Active / Volatile / Catastrophic) and one primary containment requirement." },
-      { name: "Registry Cross-Reference", cost: "+1 Corruption",
+      { name: "Registry Cross-Reference", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Consult the master artifact registry to identify a connection between the current artifact and a previously catalogued item." }
     ]
   },
@@ -247,99 +247,99 @@ const NR_DATA = {
   subUnitTalents: {
     // Wayfinder Wings
     research: [
-      { name: "Pattern Recognition", cost: "+1 Corruption",
+      { name: "Pattern Recognition", cost: "+1 Corruption", frequency: "at-will", corruptionCost: 1,
         effect: "When examining a document, site, or artifact for the first time, identify one plausible connection to a previously catalogued case." },
-      { name: "Deep Archive Access", cost: "+1 Corruption",
+      { name: "Deep Archive Access", cost: "+1 Corruption", frequency: "at-will", corruptionCost: 0,
         effect: "Spend an action consulting restricted Covenant records. Gain +2 bonus dice on your next Lore or Investigate roll this scene." },
-      { name: "Methodical Review", cost: "— (Healing)",
+      { name: "Methodical Review", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Spend a Shift organizing and cross-referencing your field notes. Heal 1 Corruption and grant one ally +1 bonus die on their next Investigate roll." }
     ],
     counterintel: [
-      { name: "Burned Asset", cost: "+1 Corruption",
+      { name: "Burned Asset", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "When caught in a lie or exposed during infiltration, immediately generate a plausible cover story. The target must make an Empathy (Psychoanalyze) roll at Difficulty 2 to see through it." },
-      { name: "Signal Intercept", cost: "+1 Corruption",
+      { name: "Signal Intercept", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Tap into a nearby communication channel (radio, phone line, intercom). For the remainder of the scene, you overhear all traffic on that channel." },
-      { name: "Compartmentalized Mind", cost: "— (Healing)",
+      { name: "Compartmentalized Mind", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after completing a successful counterintelligence action (surveillance, interrogation, or exposure prevention), heal 1 Corruption." }
     ],
     // Recovery Paradigms
     exAgency: [
-      { name: "Dead Drop Protocol", cost: "+1 Corruption",
+      { name: "Dead Drop Protocol", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Establish an instant covert information exchange with any NPC contact. Gain one actionable piece of intelligence from the DA without a roll." },
-      { name: "Exfiltration Specialist", cost: "+1 Corruption",
+      { name: "Exfiltration Specialist", cost: "+1 Corruption", frequency: "at-will", corruptionCost: 0,
         effect: "When retreating or extracting under fire, you and all allies within Short range gain +1 bonus die to their next Agility roll this round." },
-      { name: "Spycraft Discipline", cost: "— (Healing)",
+      { name: "Spycraft Discipline", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after successfully completing a covert objective without being detected, heal 1 Corruption." }
     ],
     heavyHitter: [
-      { name: "Wrecking Ball", cost: "+1 Corruption",
+      { name: "Wrecking Ball", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "When attacking an inanimate object or structure (door, wall, barricade, vehicle), gain +3 bonus dice to the Force roll and inflict +2 damage on a success." },
-      { name: "Stand Your Ground", cost: "+1 Corruption",
+      { name: "Stand Your Ground", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Plant yourself and refuse to move. Until your next turn, you cannot be pushed, knocked down, or forcibly moved, and you gain +2 Armor Rating." },
-      { name: "Blunt Trauma Recovery", cost: "— (Healing)",
+      { name: "Blunt Trauma Recovery", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after winning a physical confrontation through brute force, heal 1 Corruption." }
     ],
     acquisition: [
-      { name: "Ghost Entry", cost: "+1 Corruption",
+      { name: "Ghost Entry", cost: "+2 Corruption", frequency: "per-case-file", corruptionCost: 2,
         effect: "Bypass a single ordinary locked door, security system, or physical barrier without a roll. Leave no trace of entry." },
-      { name: "The Long Con", cost: "+1 Corruption",
+      { name: "The Long Con", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "After at least one scene spent building rapport with an NPC, gain +3 bonus dice on a Manipulate roll to extract one specific piece of information or gain one specific favor." },
-      { name: "Clean Getaway", cost: "— (Healing)",
+      { name: "Clean Getaway", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after successfully completing a theft, infiltration, or escape without triggering an alarm, heal 1 Corruption." }
     ],
     // Keep Departments
     catalogers: [
-      { name: "Hazard Classification", cost: "+1 Corruption",
+      { name: "Hazard Classification", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Upon first contact with an unknown artifact, instantly determine its danger rating and one primary containment requirement — no roll needed." },
-      { name: "Registry Cross-Reference", cost: "+1 Corruption",
+      { name: "Registry Cross-Reference", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Consult the master artifact registry to identify a connection between the current artifact and a previously catalogued item. The DA must reveal one actionable link." },
-      { name: "Archival Calm", cost: "— (Healing)",
+      { name: "Archival Calm", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Spend a Shift updating the artifact registry with new findings. Heal 1 Corruption and grant one ally who contributed field data +1 bonus die on their next Lore roll." }
     ],
     wardens: [
-      { name: "Lockdown", cost: "+1 Corruption",
+      { name: "Lockdown", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Seal a room, corridor, or building entrance. No entity may pass through for one full round without a Strength (Force) roll at Difficulty 2." },
-      { name: "Threat Assessment", cost: "+1 Corruption",
+      { name: "Threat Assessment", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "When entering a new area, instantly identify the single greatest physical threat present. The DA must describe it." },
-      { name: "Sentinel's Vigil", cost: "— (Healing)",
+      { name: "Sentinel's Vigil", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after completing a guard shift, patrol, or escort mission without a security breach, heal 1 Corruption." }
     ],
     internalCI: [
-      { name: "Silent Audit", cost: "+1 Corruption",
+      { name: "Silent Audit", cost: "+2 Corruption", frequency: "per-case-file", corruptionCost: 2,
         effect: "Gain access to one person's recent communications, personnel file, or activity log without their knowledge. The DA must reveal one compromising or actionable detail." },
-      { name: "Loyalty Test", cost: "+1 Corruption",
+      { name: "Loyalty Test", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "During a conversation, make a concealed Empathy roll at +2 bonus dice to determine if the target is actively deceiving, withholding critical information, or operating under external influence." },
-      { name: "Debriefing Protocol", cost: "— (Healing)",
+      { name: "Debriefing Protocol", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after conducting a successful internal investigation or clearing a suspect, heal 1 Corruption." }
     ],
     stack: [
-      { name: "Jury-Rig", cost: "+1 Corruption",
+      { name: "Jury-Rig", cost: "+1 Corruption", frequency: "per-session", corruptionCost: 1,
         effect: "Restore a Broken item to Gear Bonus 1 mid-scene. The fix is temporary — the item degrades again after the scene ends." },
-      { name: "Redundant Safeties", cost: "—",
+      { name: "Redundant Safeties", cost: "—", frequency: "at-will", corruptionCost: 0,
         effect: "Your Corruption threshold increases by +2 (effective threshold = 12 + Empathy instead of 10 + Empathy)." },
-      { name: "Duct Tape & WD-40", cost: "— (Healing)",
+      { name: "Duct Tape & WD-40", cost: "— (Healing)", frequency: "per-session", corruptionCost: 1,
         effect: "Once per session, after successfully repairing a piece of gear or equipment in the field, heal 1 Corruption." }
     ]
   },
 
   // ─── GENERAL TALENTS ─────────────────────────────────────
   generalTalents: [
-    { name: "Street Medic", effect: "Restore 2 physical Attribute points instead of 1 when successfully using Heal (WIT).", healing: false },
-    { name: "Cathartic Release", effect: "Once per session, dedicate a moment to breaking down, screaming, or venting — this must occur in a scene where you are not actively in conflict. Heal 1 Corruption.", healing: true },
-    { name: "Hair-Trigger", effect: "Draw a weapon as a free action instead of a fast action. Critical edge in ambushes.", healing: false },
-    { name: "Paranormal Intuition", effect: "When entering a new room or location, roll Investigate (WIT) Difficulty 1. On success, the DA must tell you if a supernatural entity has been here in the last 24 hours. This roll cannot be pushed.", healing: false },
-    { name: "Heavy Packer", effect: "Your carry capacity increases to Strength × 3 Enc. (instead of the standard Strength × 2). You are not Overloaded until your Enc. exceeds Strength × 4.", healing: false },
-    { name: "Skeptic's Shield", effect: "Once per session, when exposed to a minor supernatural effect, you may outright ignore it by rigidly refusing to acknowledge the impossible.", healing: false },
-    { name: "Night Owl", effect: "Ignore all penalties from sleep deprivation. When operating in darkness, you treat Darkness as Dim (−1 die, not −2 dice).", healing: false },
-    { name: "Chain Smoker", effect: "Consume a period-appropriate scarce resource (cigarettes, specific 1980s junk food, etc.) during a non-conflict moment. Heal 1 Corruption. The resource must actually be spent.", healing: true },
-    { name: "Analog Junkie", effect: "Gain +2 bonus dice when using period-accurate 1980s technology (ham radios, acoustic couplers, microfiche, reel-to-reel).", healing: false },
-    { name: "Grit Your Teeth", effect: "Once per session, ignore a −1 Attribute penalty for a single roll. Declare before rolling.", healing: false },
-    { name: "Desensitized", effect: "Gain +1 bonus die on Endure (STR) or Empathy (EMP) rolls when witnessing or investigating horrific or gruesome scenes.", healing: false },
-    { name: "Lucky Coin", effect: "Once per session, ignore a 1 rolled on a single Gear die, preventing item degradation. Declare after seeing the roll.", healing: false },
-    { name: "Iron Will", effect: "When you personally deliver the killing blow to a Named Threat or banish a supernatural entity, heal 1 Corruption.", healing: true },
-    { name: "Brawler", effect: "Unarmed strikes inflict base damage of 2 instead of 1.", healing: false },
-    { name: "Flee the Scene", effect: "Gain +2 bonus dice to Agility (ATT) when rolling explicitly to escape a conflict or pursue fleeing targets.", healing: false },
-    { name: "Requisition Authority", effect: "Increase your personal Clearance Level by 1 (maximum CL 5). May be purchased multiple times. Repeatable.", healing: false }
+    { name: "Street Medic", effect: "Restore 2 physical Attribute points instead of 1 when successfully using Heal (WIT).", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Cathartic Release", effect: "Once per session, dedicate a moment to breaking down, screaming, or venting — this must occur in a scene where you are not actively in conflict. Heal 1 Corruption.", healing: true, frequency: "per-session", corruptionCost: 1 },
+    { name: "Hair-Trigger", effect: "Draw a weapon as a free action instead of a fast action. Critical edge in ambushes.", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Paranormal Intuition", effect: "When entering a new room or location, roll Investigate (WIT) Difficulty 1. On success, the DA must tell you if a supernatural entity has been here in the last 24 hours. This roll cannot be pushed.", healing: false, frequency: "at-will", corruptionCost: 1 },
+    { name: "Heavy Packer", effect: "Your carry capacity increases to Strength × 3 Enc. (instead of the standard Strength × 2). You are not Overloaded until your Enc. exceeds Strength × 4.", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Skeptic's Shield", effect: "Once per session, when exposed to a minor supernatural effect, you may outright ignore it by rigidly refusing to acknowledge the impossible.", healing: false, frequency: "per-session", corruptionCost: 1 },
+    { name: "Night Owl", effect: "Ignore all penalties from sleep deprivation. When operating in darkness, you treat Darkness as Dim (−1 die, not −2 dice).", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Chain Smoker", effect: "Consume a period-appropriate scarce resource (cigarettes, specific 1980s junk food, etc.) during a non-conflict moment. Heal 1 Corruption. The resource must actually be spent.", healing: true, frequency: "per-session", corruptionCost: 1 },
+    { name: "Analog Junkie", effect: "Gain +2 bonus dice when using period-accurate 1980s technology (ham radios, acoustic couplers, microfiche, reel-to-reel).", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Grit Your Teeth", effect: "Once per session, ignore a −1 Attribute penalty for a single roll. Declare before rolling.", healing: false, frequency: "per-session", corruptionCost: 1 },
+    { name: "Desensitized", effect: "Gain +1 bonus die on Endure (STR) or Empathy (EMP) rolls when witnessing or investigating horrific or gruesome scenes.", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Lucky Coin", effect: "Once per session, ignore a 1 rolled on a single Gear die, preventing item degradation. Declare after seeing the roll.", healing: false, frequency: "at-will", corruptionCost: 1 },
+    { name: "Iron Will", effect: "When you personally deliver the killing blow to a Named Threat or banish a supernatural entity, heal 1 Corruption.", healing: true, frequency: "per-session", corruptionCost: 1 },
+    { name: "Brawler", effect: "Unarmed strikes inflict base damage of 2 instead of 1.", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Flee the Scene", effect: "Gain +2 bonus dice to Agility (ATT) when rolling explicitly to escape a conflict or pursue fleeing targets.", healing: false, frequency: "at-will", corruptionCost: 0 },
+    { name: "Requisition Authority", effect: "Increase your personal Clearance Level by 1 (maximum CL 5). May be purchased multiple times. Repeatable.", healing: false, frequency: "at-will", corruptionCost: 0 }
   ],
 
   // ─── BACKGROUND TALENTS ──────────────────────────────────


### PR DESCRIPTION
## Changes

Add frequency-based talent usage system to the core rulebook and web app.

### Rulebook Chapters (4 files)
- **Ch 2** (Character Creation): Frequency rules in Step 5 — at-will, per-session, per-case-file
- **Ch 8** (Corruption): Update Sources of Corruption for tiered costs (0 to +2)
- **Ch 13** (Advancement): Add Frequency + Corruption columns to General Talents table; tiered XP costs
- **Ch 21** (Glossary): Add At-Will, Per-Session, Per-Case-File entries; fix Division Talent entry

### Web App (1 file)
- **data.js**: Add \requency\ and \corruptionCost\ to all ~50 talent objects across division, sub-unit, and general talent categories

### Companion PR
- Foundry VTT system: [#290](https://github.com/bruceamoser/foundry-neon-relic-system/pull/290) (merged) — data model, logic, templates, locale

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)