### PR TITLE
Simplify stunts to general list — remove skill-specific stunts (#812)

### DIFF
--- a/docs/chapters/03-core-resolution.adoc
+++ b/docs/chapters/03-core-resolution.adoc
@@ -38,6 +38,13 @@ Each *6* rolled counts as *one success*.
 
 Successes beyond what was needed are *extra successes*. If the roll supports stunts, each extra success becomes *1 Stunt Point*.
 
+.Stunt Points Formula
+====
+_stuntPoints = max(0, successes − difficulty)_
+====
+
+The formula is applied *after* determining whether the roll passes: subtract the Difficulty from the number of 6s rolled. If the result is positive, those are your Stunt Points. If the roll fails (successes < Difficulty), stunt points are zero regardless of how many 6s were rolled.
+
 > **Stunt Points must be spent immediately.** They are not saved between rolls or carried into subsequent actions. If you do not spend a Stunt Point at the moment it is generated, it is lost. Decide how to spend extra successes before the next roll at the table.
 
 [cols="1,4", options="header"]

--- a/docs/chapters/04-attributes-skills.adoc
+++ b/docs/chapters/04-attributes-skills.adoc
@@ -60,7 +60,7 @@ The thirteen core skills are mapped to these four attributes, tailored to suppor
 
 ---
 
-== Skill Stunts
+== Stunts
 
 When you roll more 6s than the *minimum needed to succeed*, each extra 6 is a *Stunt Point*. You may spend Stunt Points to achieve effects beyond simple success.
 
@@ -78,9 +78,9 @@ When you roll more 6s than the *minimum needed to succeed*, each extra 6 is a *S
 
 > *Cross-reference:* Combat stunts — spending stunt points during an attack roll — are defined in the Combat chapter (xref:chapters/05-combat.adoc#chapter-combat[Combat]). The stunt economy is the same.
 
-=== Generic Stunts (Available on Any Skill)
+=== Stunts
 
-The following stunts may be purchased on *any* successful skill roll, regardless of which skill is being used. They represent clever execution rather than specialized technique.
+The following stunts may be purchased on *any* successful skill roll, regardless of which skill is being used.
 
 [cols="^1,2,4", options="header"]
 |===
@@ -93,160 +93,6 @@ The following stunts may be purchased on *any* successful skill roll, regardless
 | 2 | *Extended Effect* | The outcome of your action lasts an additional scene or at least one hour longer than it otherwise would.
 | 2 | *Additional Target* | Your action's results apply to one additional target in the same zone (the DA determines relevance).
 |===
-
----
-
-=== Skill-Specific Stunts
-
-The following stunts are available *only* when rolling the listed skill. They represent specialized applications of trained technique.
-
-=== Strength Skills
-
-==== Force
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Controlled Break* | You force open the door/lock/container without damaging the contents or triggering adjacent mechanisms. Finesse in violence.
-| 1 | *Intimidating Display* | Your feat of strength is visibly dramatic. One NPC present must make a *Corruption Burst* (Burst Rating 1) or immediately comply with your next simple demand. See xref:chapters/08-corruption-fear-healing.adoc#corruption-burst-procedure[Corruption Burst].
-| 2 | *Clear the Room* | A shove, flip, or sweep clears all loose objects from the zone simultaneously (useful for destroying a cultist's ritual setup, or just making a scene).
-|===
-
-==== Brawl
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Stay Down* | Target cannot stand up until the start of your next turn (they must spend a Slow Action to rise but simply cannot).
-| 1 | *Weapon Strike* | You've slapped or struck their weapon arm. Target suffers −1 die on all attack rolls until the end of the round.
-| 2 | *Neck Crank* | Target is immediately Grappled (see xref:chapters/05-combat.adoc#chapter-combat[Combat]) without requiring a separate maneuver roll. Costs 2 Stunt Points — you spend both at once to achieve a control hold in the same action that caused the hit.
-|===
-
-==== Endure
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Grind Through* | You remain focused and are able to push through the physical task at hand. You may ignore one penalty on your next roll. Only one stunt point may be spent this way per success.
-| 1 | *Inspire* | Your visible physical resilience gives allies heart. One ally in the scene recovers 1 point of Agility.
-| 2 | *Unfazed* | You succeed and take no Agility damage from whatever environmental or physical threat triggered the roll (extreme cold, sleep deprivation, toxic air).
-|===
-
----
-
-=== Agility Skills
-
-==== Sneak
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Shadow Step* | You can take one additional move action as part of the same turn/scene phase without breaking your stealth. You haven't just crept in — you've repositioned perfectly.
-| 1 | *Identify Exit* | As you infiltrate, you map the fastest withdrawal route. You have +2 dice on any Sneak roll to leave this location later this scene.
-| 2 | *Ghost Pass* | Your passage through *this location* leaves zero physical trace (no footprints, disturbed dust, or thermal record). You cannot be tracked from this location. This applies only to your entry and movement during this scene — it does not retroactively erase evidence from earlier in the session, and it does not cover actions you take once inside (items moved, locks broken, witnesses seen).
-|===
-
-==== Deft Hands
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Undetected* | The target of your pick-pocket, lift, or plant does not notice the action even after the immediate scene ends. They will assume the item was misplaced, not taken.
-| 1 | *Speed Lock* | You open a lock in seconds. No time resource is consumed; the DA cannot use the time you spent as a complication.
-| 2 | *Perfect Plant* | You plant an item on a target in a way that will implicate them credibly. Subsequent investigation will find the planted item and treat it as the target's possession.
-|===
-
-==== Firearms
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Aimed Shot* | The shot hits exactly the intended location (specific limb, lock, cable, tire). DA treats the result as precision even at range.
-| 1 | *Suppression* | Target is pinned behind cover until start of your next turn. They cannot move zones or fire back without losing their cover bonus.
-| 2 | *Warning Shot* | You visibly miss by design, close enough to be terrifying. The target must make a *Corruption Burst* (Burst Rating 2) or drop to the ground and remain there for 1 round. No ammo die roll required for this shot. See xref:chapters/08-corruption-fear-healing.adoc#corruption-burst-procedure[Corruption Burst].
-|===
-
----
-
-=== Wits Skills
-
-==== Investigate
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Pattern Lock* | You not only find the evidence — you identify why it matters. The DA must tell you one piece of context about the object's history or origin.
-| 1 | *Clock It* | You determine precisely when an event occurred (within the hour, or narrowed to a 30-minute window). Time is often as revealing as the event.
-| 2 | *Hidden Compartment* | You find something the scene intended to conceal — a room the blueprints don't show, a file folder in a false wall, a trapdoor. DA must reveal one hidden element they had established for the case, but not yet disclosed. If there are no more hidden elements in the case, the stunt points are forfeit.
-|===
-
-==== Tech
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Trace* | Successfully accessing a system also identifies who else accessed it recently — one account or one physical terminal is revealed.
-| 1 | *Improvised Repair* | The item you're repairing also gets a temporary improvement: a degraded weapon gets +1 Gear die this session; a damaged radio broadcasts on a sealed channel.
-| 2 | *Ghost Session* | Your access to *this digital system* leaves no log entry. No one can prove you were connected. This applies to digital access only (mainframe, terminal, BBS, phone system) — it does not cover physical surveillance cameras, witnesses, or analog records of your presence.
-|===
-
-==== Lore
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Deep Context* | Your knowledge is not just what this thing is — you know what it was used for. DA provides one historical or ritual context detail beyond what would normally be available.
-| 1 | *Weakness Identified* | Your lore grants you tactical information: an entity type's vulnerability, an artifact's known failure condition, a ritual's interruption point. +1 die on the next relevant roll.
-| 2 | *Primary Source* | You recall a specific source — a text, a case file, a person — that would contain detailed operational information about this entity or artifact. The DA must confirm the source exists and tell you how to find it. If the DA has not pre-established such a source, they invent one that is consistent with the setting and the case — it now exists and can be found.
-|===
-
----
-
-=== Empathy Skills
-
-==== Manipulate
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Bought Silence* | The target doesn't just comply — they will not mention this conversation to anyone for at least 24 hours. The DA may extend this window if the narrative warrants it (extreme fear, deep loyalty, significant leverage). The silence expires if the target is directly threatened or compelled by a more powerful authority.
-| 1 | *Read the Room* | Beyond this individual, you gauge how the wider group or faction feels about the situation. The DA tells you one faction-level attitude or intention.
-| 2 | *Turned Asset* | On an already-successful Manipulate, the target now actively wants to help you beyond the scope of your request. They will volunteer additional information or assistance once this session.
-|===
-
-==== Command
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Rally* | One Broken ally in the scene immediately acts on their next turn as if they had recovered — they can take their full action once before the impairment resumes.
-| 1 | *Coordinated Action* | Your directive enables two allies to act at the same initiative card slot this round. Both take their normal actions — neither loses their action to assist the other. This does not grant extra actions; it simply synchronizes timing so both effects land simultaneously (useful for simultaneous entries, simultaneous attacks, or flanking maneuvers).
-| 2 | *Hold the Line* | All allies who can hear you gain +1 die on their next roll this round. The effect of strong leadership under pressure.
-|===
-
-==== Psychoanalyze
-
-[cols="^1,2,4", options="header"]
-|===
-| Cost | Stunt | Effect
-
-| 1 | *Pressure Point* | You've identified something this person fears or desperately needs. The DA must reveal one personal vulnerability, driving motivation, or exploitable need.
-| 1 | *Decompress* | The person you're treating recovers 1 additional Wits or Empathy point beyond the normal healing (max to their normal maximum).
-| 2 | *Full Read* | You have comprehensively understood this person's psychological state. For the rest of *this scene*, all Psychoanalyze rolls against them gain +2 bonus dice and are treated as Difficulty 1 — you know their cues, their resistances, and their breaking points. This benefit applies to this scene only. If the same NPC appears in a future scene under different emotional circumstances, they are not pre-read.
-|===
-
----
 
 == General Talents
 

--- a/docs/chapters/06-social-conflict.adoc
+++ b/docs/chapters/06-social-conflict.adoc
@@ -136,7 +136,7 @@ Used to read, understand, or heal. In social conflict, Psychoanalyze has two mod
 ** The effective Difficulty of the follow-up roll is reduced by 1 (minimum Difficulty 1)
 * These benefits expire if not used in the same scene, or if the NPC's Disposition *drops* before the follow-up roll. A Disposition increase (from evidence shown, a service performed, etc.) does not invalidate Reading benefits — the agent's insight remains relevant as the NPC warms up.
 
-> *Stunt interaction:* Extra successes on a Reading roll become stunt points as normal (see <<stunts-in-social-conflict,Stunts in Social Conflict>> below). Spending the *Pressure Point* stunt on a Reading roll causes the DA to reveal an additional detail beyond the standard Reading reveal. Spending *Full Read* (2 SP) grants its scene-long benefits (+2 dice, Difficulty 1) in place of the standard single-use benefits — Full Read is strictly superior and replaces them.
+> *Stunt interaction:* Extra successes on a Reading roll become stunt points as normal (see <<stunts-in-social-conflict,Stunts in Social Conflict>> below). General stunts may be spent on social rolls — for example, spending *Precise* on a Reading roll causes the DA to reveal an additional detail beyond the standard Reading reveal. Spending *Extended Effect* (2 SP) extends the Reading's benefits into the following scene.
 
 > *Example:* An agent faces a Hostile NPC (Disposition 2, Difficulty 3 for social rolls). The agent first uses Psychoanalyze (Reading) to understand the NPC. On success, the follow-up Manipulate roll is made at Difficulty 2 (reduced from 3) with +1 bonus die. This means a roll generating 3+ successes now produces stunt points, compared to needing 4+ successes without the Psychoanalyze step.
 
@@ -217,11 +217,11 @@ Note: Petra passed the social focal point to Marcus — this is a tag-team appro
 
 Manipulate roll: Empathy 4 + Manipulate 3 = 7 dice. Difficulty 1 (Disposition 4, sensitive ask). Rolls: 6, 6, 5, 4, 2, 2, 1 — two successes. Two successes at Difficulty 1 = 1 extra success = 1 stunt point.
 
-Marcus spends the stunt point on *Bought Silence* (see xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills] for Manipulate stunts): Elias won't mention this conversation to anyone for at least 24 hours — enough time for the agents to move on Talvez before Elias has a chance to warn him.
+Marcus spends the stunt point on *Quieter* (see xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills] for the general stunt list): Elias won't mention this conversation to anyone for at least 24 hours — enough time for the agents to move on Talvez before Elias has a chance to warn him. The DA rules this is a valid application of Quieter — the social action leaves no detectable trace for others to follow.
 
 *Success:* Elias gives the name: a fence named Talvez, operating out of a pawn shop on the East Side. He works for several clients. Elias doesn't know who.
 
-*Outcome:* The scene demonstrates the full loop. Read first to find the leverage. Stabilize to move the NPC into conversation. Ask direct questions for free once Disposition is high enough. Roll only when the agents want disclosure that still carries risk for the target. Spend stunt points on skill-specific effects to shape what success means.
+*Outcome:* The scene demonstrates the full loop. Read first to find the leverage. Stabilize to move the NPC into conversation. Ask direct questions for free once Disposition is high enough. Roll only when the agents want disclosure that still carries risk for the target. Spend stunt points on general stunt effects to shape what success means.
 
 ---
 
@@ -246,11 +246,7 @@ All social rolls may be pushed per the standard push rules (see xref:chapters/03
 [[stunts-in-social-conflict]]
 == Stunts in Social Conflict
 
-Extra successes on social rolls become stunt points, as normal (see xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution]). These may be spent on the relevant skill's stunt list in xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills]:
-
-* *Manipulate stunts* (Bought Silence, Read the Room, Turned Asset) apply *in addition to* the automatic Disposition +1 shift from success.
-* *Command stunts* (Rally, Coordinated Action, Hold the Line) apply *in addition to* the NPC's compliance.
-* *Psychoanalyze stunts* (Pressure Point, Decompress, Full Read) apply *in addition to* Reading or Stabilizing effects.
+Extra successes on social rolls become stunt points, as normal (see xref:chapters/03-core-resolution.adoc#chapter-core-resolution[Core Resolution]). These may be spent on the general stunt list in xref:chapters/04-attributes-skills.adoc#chapter-attributes-skills[Attributes & Skills]. Any stunt from the general list may be purchased on a social roll — the effect is narrated in social context (e.g., *Quieter* means the target doesn't realize they were manipulated; *Additional Target* applies the social effect to a second NPC in the scene).
 
 Stunt effects and Disposition effects are cumulative — they are separate outcomes of the same roll. Stunt points must be spent immediately (within the same action) or they are lost.
 

--- a/docs/design/operations-board-webapp-architecture.md
+++ b/docs/design/operations-board-webapp-architecture.md
@@ -799,7 +799,7 @@ Board (always visible, z-index: 1)
 
 3. **Post-Roll Options:**
    - **Push:** Button shows "PUSH (+1 Corruption)". Confirms with Corruption cost. Re-rolls only non-6, non-gear dice. New dice animate in. Combined successes shown.
-   - **Spend Stunts:** If stunt points > 0, dropdown shows available stunts filtered by the skill used. Generic stunts always available. Skill-specific stunts shown when that skill is used. Costs 1–2 SP each. Selecting a stunt deducts from SP pool and logs the effect.
+   - **Spend Stunts:** If stunt points > 0, dropdown shows available general stunts. All stunts are available on any skill roll. Costs 1–2 SP each. Selecting a stunt deducts from SP pool and logs the effect.
    - **Accept Result:** "Done" button closes modal, logs the roll result to session log.
 
 4. **Edge Cases:**
@@ -1470,7 +1470,7 @@ Layout: 2×2 grid per letter page, cut lines indicated by crop marks.
   - Push mechanic with auto-Corruption increment
   - Gear degradation auto-detection
   - Artifact die integration
-  - Stunt spending menu (filtered by skill)
+  - Stunt spending menu (general stunts available on any skill)
 - Dice Roller modal UI
 - Quick Roll toolbar dropdown (pre-configured per agent)
 - Special rolls: d66 critical injury, d6 panic, Corruption burst (BR 1–5)

--- a/docs/design/operations-board-webapp-research.md
+++ b/docs/design/operations-board-webapp-research.md
@@ -104,7 +104,7 @@ Every mechanic the DA needs at their fingertips during play, organized by rules 
 | **Success Counting** | Each 6 = 1 success. Difficulty 1–5+. Extra 6s = Stunt Points | Auto-count successes, highlight extra successes, show available stunts |
 | **Push Mechanic** | Re-roll non-6 dice. Cost: +1 Corruption. Gear dice are locked (never re-rolled). Gear 1s = degradation | Push button that auto-increments Corruption, locks gear dice, re-rolls attribute+skill |
 | **Gear Degradation** | Gear die showing 1 on initial roll = Gear Bonus −1. At 0 = Broken | Visual gear condition tracker; auto-apply degradation on 1s |
-| **Stunt Points** | Must be spent immediately. Generic stunts (Faster, Quieter, Precise, Aid) + skill-specific stunts | Pop-up stunt menu showing available stunts by skill; deduct from total |
+| **Stunt Points** | Must be spent immediately. General stunts (Faster, Quieter, Precise, Aid, Extended Effect, Additional Target) | Pop-up stunt menu showing available general stunts; deduct from total |
 
 ### 2.2 Attributes & Skills (Chapter 4)
 
@@ -112,7 +112,7 @@ Every mechanic the DA needs at their fingertips during play, organized by rules 
 |----------|---------------|------------------------|
 | **4 Attributes** | Strength, Agility, Wits, Empathy (2–5 each). Serve as both dice pools AND health pools | Live attribute displays with damage overlays |
 | **13 Skills** | Force, Brawl, Endure, Sneak, Deft Hands, Firearms, Investigate, Tech, Lore, Heal, Manipulate, Command, Psychoanalyze (0–5) | Quick-reference skill table with descriptions |
-| **Skill Stunts** | 3 stunts per skill plus 5 generic stunts, each with cost (1–2 SP) | Contextual stunt suggestions after every roll |
+| **General Stunts** | 6 general stunts available on any skill, each with cost (1–2 SP) | Contextual stunt suggestions after every roll |
 | **Division Key Skill** | One skill per division capped at 4 at creation, 5 during play | Highlight agent-specific key skills |
 | **Attribute as Health** | Damage reduces attributes directly. STR=0 or AGI=0 → Physical Broken. WIT=0 or EMP=0 → Mental Broken | Damage trackers on each attribute; auto-detect Broken state |
 

--- a/docs/web-app-char-gen/data.js
+++ b/docs/web-app-char-gen/data.js
@@ -525,49 +525,16 @@ const NR_DATA = {
     { roll: 6, response: "Fugue", effect: "DA takes character sheet. DA narrates character for rest of scene. Player regains control next scene." }
   ],
 
-  // ─── SKILL STUNTS (abbreviated) ──────────────────────────
-  stunts: {
-    force: [
-      { cost: 1, name: "Controlled Break", effect: "Force open without damaging contents or triggering adjacent mechanisms." },
-      { cost: 1, name: "Intimidating Display", effect: "One NPC must make a Corruption Burst (BR 1) or comply with your next simple demand." },
-      { cost: 2, name: "Clear the Room", effect: "A shove, flip, or sweep clears all loose objects from the zone simultaneously." }
-    ],
-    brawl: [
-      { cost: 1, name: "Stay Down", effect: "Target cannot stand up until start of your next turn." },
-      { cost: 1, name: "Weapon Strike", effect: "Target suffers −1 die on all attack rolls until end of round." },
-      { cost: 2, name: "Neck Crank", effect: "Target is immediately Grappled without requiring a separate maneuver roll." }
-    ],
-    endure: [
-      { cost: 1, name: "Grind Through", effect: "Ignore one penalty on your next roll." },
-      { cost: 1, name: "Inspire", effect: "One ally in the scene recovers 1 point of Agility." },
-      { cost: 2, name: "Unfazed", effect: "Take no Agility damage from whatever triggered the roll." }
-    ],
-    sneak: [
-      { cost: 1, name: "Shadow Step", effect: "Take one additional move action without breaking stealth." },
-      { cost: 1, name: "Identify Exit", effect: "+2 dice on any Sneak roll to leave this location later this scene." },
-      { cost: 2, name: "Ghost Pass", effect: "Passage through this location leaves zero physical trace." }
-    ],
-    deftHands: [
-      { cost: 1, name: "Undetected", effect: "Target of pick-pocket/lift/plant does not notice even after the scene ends." },
-      { cost: 1, name: "Speed Lock", effect: "Open a lock in seconds. No time resource consumed." },
-      { cost: 2, name: "Perfect Plant", effect: "Plant an item on a target so that subsequent investigation treats it as their possession." }
-    ],
-    firearms: [
-      { cost: 1, name: "Aimed Shot", effect: "Shot hits exactly the intended location (specific limb, lock, cable, tire)." },
-      { cost: 1, name: "Suppression", effect: "Target pinned behind cover until start of your next turn." },
-      { cost: 2, name: "Warning Shot", effect: "Target must make Corruption Burst (BR 2) or drop and remain down for 1 round." }
-    ],
-    investigate: [
-      { cost: 1, name: "Pattern Lock", effect: "DA must tell you one piece of context about the object's history or origin." },
-      { cost: 1, name: "Clock It", effect: "Determine precisely when an event occurred (within 30-minute window)." },
-      { cost: 2, name: "Hidden Compartment", effect: "Find something the scene intended to conceal — DA must reveal one hidden element." }
-    ],
-    tech: [
-      { cost: 1, name: "Trace", effect: "Identify who else accessed the system recently — one account or terminal revealed." },
-      { cost: 1, name: "Improvised Repair", effect: "Item also gets a temporary improvement (+1 Gear die this session, etc.)." },
-      { cost: 2, name: "Ghost Session", effect: "Access to this digital system leaves no log entry. No one can prove you were connected." }
-    ]
-  },
+  // ─── GENERAL STUNTS ──────────────────────────────────────
+  // Available on any successful skill roll. Costs are in Stunt Points.
+  stunts: [
+    { cost: 1, name: "Faster", effect: "Accomplish the action in half the expected time." },
+    { cost: 1, name: "Quieter", effect: "Accomplish the action without leaving a detectable trace." },
+    { cost: 1, name: "Precise", effect: "Your result is exactly as intended — no collateral effects, no ambiguity." },
+    { cost: 1, name: "Aid", effect: "Your success automatically assists an ally's next related roll this scene (+1 die)." },
+    { cost: 2, name: "Extended Effect", effect: "The outcome lasts an additional scene or at least one hour longer." },
+    { cost: 2, name: "Additional Target", effect: "Your action's results apply to one additional target in the same zone." }
+  ],
 
   // ─── CLEARANCE LEVELS ────────────────────────────────────
   clearanceLevels: [


### PR DESCRIPTION
## Changes

This PR simplifies the stunt system by removing all skill-specific stunts and consolidating to a unified general stunt list.

### foundry-neon-relic-system (code)
- Delete SKILL_STUNTS constant (12 skills x 3 stunts = 36 entries)
- Remove skill parameter from NRStuntPicker constructor and open()
- Wire NRStuntPicker into roll-dialog.mjs with stuntPoints = max(0, successes - difficulty)
- Add stuntPoints to roll-handler chat template context
- Remove skill-specific stunt blocks from stunt-picker.hbs template
- Add stunt points display to roll-chatcard.hbs
- Delete 36 skill-specific i18n keys from en.yaml
- Add _stunt-picker.scss with full stunt picker styling
- Delete skill-specific stunts table from rules-reference.yaml

### neon-relic (rulebook/docs)
- Delete Skill-Specific Stunts section from Ch 4 (13 skills x 3 stunts)
- Rename Generic Stunts to Stunts in Ch 4
- Add explicit stuntPoints formula to Ch 3
- Update Ch 6 social conflict examples
- Replace skill-keyed stunts object with unified array in web app data.js
- Update design docs

### Bugs Fixed
1. NRStuntPicker was dead code - now wired into roll flow
2. Skill key mismatch (stealth/sneak, investigation/investigate, medicine/heal) - eliminated by removing skill keys
3. Stunt points formula never calculated - now computed explicitly

## Issue
Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)